### PR TITLE
Adding support for multiple queues

### DIFF
--- a/sqswatcher/plugins/openlava.py
+++ b/sqswatcher/plugins/openlava.py
@@ -29,7 +29,7 @@ def __runOpenlavaCommand(command):
         log.error("Failed to run %s\n" % _command)
 
 
-def addHost(hostname, cluster_user, slots):
+def addHost(hostname, cluster_user, slots, queue=None):
     log.info('Adding %s with %s slots' % (hostname,slots))
 
     command = ('/opt/openlava/bin/lsaddhost -t linux -m IntelXeon -M "%s" %s' % (slots, hostname))
@@ -63,7 +63,7 @@ def addHost(hostname, cluster_user, slots):
     ssh.save_host_keys(hosts_key_file)
     ssh.close()
 
-def removeHost(hostname,cluster_user):
+def removeHost(hostname,cluster_user, queue=None):
     log.info('Removing %s', hostname)
 
     command = ('/opt/openlava/bin/lsrmhost %s' % hostname)

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -31,7 +31,7 @@ def __runSgeCommand(command):
     except sub.CalledProcessError:
         log.error("Failed to run %s\n" % _command)
 
-def addHost(hostname, cluster_user, slots):
+def addHost(hostname, cluster_user, slots, queue=None):
     log.info('Adding %s with %s slots' % (hostname,slots))
 
     # Adding host as administrative host
@@ -107,7 +107,7 @@ report_variables      NONE
     command = ('/opt/sge/bin/lx-amd64/qconf -aattr queue slots ["%s=%s"] all.q' % (hostname,slots))
     __runSgeCommand(command)
 
-def removeHost(hostname,cluster_user):
+def removeHost(hostname,cluster_user, queue=None):
     log.info('Removing %s', hostname)
 
     # Purge hostname from all.q

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -114,14 +114,17 @@ def __writeNodeList(node_list):
     os.chmod(_config, 0744)
 
 
-def addHost(hostname, cluster_user, slots):
+def addHost(hostname, cluster_user, slots, queue=None):
     log.info('Adding %s' % hostname)
 
     # Get the current node list
     node_list = __readNodeList()
 
     # Add new node
-    node_list['compute'].append(hostname)
+    if queue and queue in node_list.keys():
+        node_list[queue].append(hostname)
+    else:
+        node_list['compute'].append(hostname)
     __writeNodeList(node_list)
 
     # Restart slurmctl locally
@@ -136,14 +139,19 @@ def addHost(hostname, cluster_user, slots):
     __runCommand(command)
 
 
-def removeHost(hostname, cluster_user):
+def removeHost(hostname, cluster_user, queue=None):
     log.info('Removing %s', hostname)
 
     # Get the current node list
     node_list = __readNodeList()
 
     # Remove node
-    node_list['compute'].remove(hostname)
+    # node_list['compute'].remove(hostname)
+    for k,v in node_list.iteritems():
+        try:
+            v.remove(hostname)
+        except ValueError:
+            pass
     __writeNodeList(node_list)
 
     # Restart slurmctl

--- a/sqswatcher/plugins/test.py
+++ b/sqswatcher/plugins/test.py
@@ -17,14 +17,14 @@ log = logging.getLogger(__name__)
 
 hostfile_path = 'sqswatcher.hosts'
 
-def addHost(hostname,cluster_user):
+def addHost(hostname,cluster_user, queue=None):
     if hostname != None:
         log.info('Adding', hostname)
         hostfile = open(hostfile_path, 'a')
         print >> hostfile, hostname
         hostfile.close()
 
-def removeHost(hostname,cluster_user):
+def removeHost(hostname,cluster_user, queue=None):
     if hostname != None:
         log.info('Removing', hostname)
         hostfile = open(hostfile_path, 'r')

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -28,7 +28,7 @@ def __runCommand(command):
     except sub.CalledProcessError:
         log.error("Failed to run %s\n" % _command)
 
-def addHost(hostname,cluster_user,slots):
+def addHost(hostname,cluster_user,slots, queue=None):
     log.info('Adding %s', hostname)
 
     command = ("/opt/torque/bin/qmgr -c 'create node %s np=%s'" % (hostname, slots))
@@ -67,7 +67,7 @@ def addHost(hostname,cluster_user,slots):
     command = ('/etc/init.d/pbs_server restart')
     __runCommand(command)
 
-def removeHost(hostname, cluster_user):
+def removeHost(hostname, cluster_user, queue=None):
     log.info('Removing %s', hostname)
 
     command = ('/opt/torque/bin/pbsnodes -o %s' % hostname)

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -143,12 +143,14 @@ def pollQueue(scheduler, q, t):
                                     log.warning("Unable to find running instance %s." % instanceId)
                                 else:
                                     log.info("Adding Hostname: %s" % hostname)
+                                    queue_name = hostname[0].instances[0].tags.get('queue',None)
                                     hostname = hostname[0].instances[0].private_dns_name.split('.')[:1][0]
-                                    s.addHost(hostname=hostname,cluster_user=cluster_user,slots=slots)
+                                    s.addHost(hostname=hostname,cluster_user=cluster_user,slots=slots, queue=queue_name)
 
                                     t.put_item(data={
                                         'instanceId': instanceId,
-                                        'hostname': hostname
+                                        'hostname': hostname,
+                                        'queue': queue_name
                                     })
 
                                 q.delete_message(result)
@@ -180,9 +182,10 @@ def pollQueue(scheduler, q, t):
                         try:
                             item = t.get_item(consistent=True, instanceId=instanceId)
                             hostname = item['hostname']
+                            queue_name = item['queue']
 
                             if hostname:
-                                s.removeHost(hostname,cluster_user)
+                                s.removeHost(hostname,cluster_user, queue=queue_name)
 
                             item.delete()
 


### PR DESCRIPTION
I'm working on the implementation of a Heterogeneous CFN Cluster (like mentioned in awslabs/cfncluster#120) and would like to have this included to cfncluster-node package. Otherwise custom Chef-cookbook and custom cfncluster-node pypi package have to be used, which makes my template less compatible with original CFN Cluster implementation.

Main idea is:
- AutoScalingGroup in cfn-template sets a "queue" tag for each Compute Node
- sqswatcher.py parses this tag (if present), saves it to dynamodb and passes to the scheduler plugin
- Scheduler plugin creates a queue with the same name and adds/removes this host to this queue; if "queue" tag is not present host is added to common queue.

Last step is currently implemented for slurm only.

I expect these changes to be compatible with normal CFN Cluster template.
