### PR TITLE
Use Stack Resources in Nodewatcher and Jobwatcher

### DIFF
--- a/nodewatcher/nodewatcher.cfg
+++ b/nodewatcher/nodewatcher.cfg
@@ -3,3 +3,4 @@ region = us-east-1
 scheduler = test
 proxy = NONE
 scaledown_idletime = 10
+stack_name = cfncluster-test

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -21,6 +21,7 @@ import logging
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from utils.utils import load_scheduler_module
 
 log = logging.getLogger(__name__)
 
@@ -96,19 +97,9 @@ def setupDDBTable(region, table_name, proxy_config):
     return _table
 
 
-def loadSchedulerModule(scheduler):
-    scheduler = 'sqswatcher.plugins.' + scheduler
-    _scheduler = __import__(scheduler)
-    _scheduler = sys.modules[scheduler]
-
-    log.debug("scheduler=%s" % repr(_scheduler))
-
-    return _scheduler
-
-
 def pollQueue(scheduler, q, t, proxy_config):
     log.debug("startup")
-    s = loadSchedulerModule(scheduler)
+    s = load_scheduler_module('sqswatcher', scheduler)
 
     while True:
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+__author__ = "seaam"
+
+import boto3
+import logging
+import sys
+from botocore.exceptions import ClientError
+
+log = logging.getLogger(__name__)
+
+def get_asg_name(stack_name, region, proxy_config):
+    cfn = boto3.client('cloudformation', region_name=region, config=proxy_config)
+    asg_name = ""
+
+    try:
+        r = cfn.describe_stack_resource(StackName=stack_name, LogicalResourceId='ComputeFleet')
+        asg_name = r.get('StackResourceDetail').get('PhysicalResourceId')
+        log.info("asg=%s" % asg_name)
+    except ClientError as e:
+        log.error("No asg found for cluster %s" % stack_name)
+        sys.exit(1)
+
+    return asg_name
+
+def load_scheduler_module(module, scheduler):
+    scheduler = '%s.plugins.%s' % (module, scheduler)
+    _scheduler = __import__(scheduler)
+    _scheduler = sys.modules[scheduler]
+
+    log.debug("scheduler=%s" % repr(_scheduler))
+
+    return _scheduler


### PR DESCRIPTION
Sometimes the asg wasn't tagged correctly at first, this solves that issue by using the stack resources to determine the asg name instead of tags.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
