### PR TITLE
Concurrency issues during scaledown

### DIFF
--- a/nodewatcher/nodewatcher.cfg
+++ b/nodewatcher/nodewatcher.cfg
@@ -4,3 +4,5 @@ scheduler = test
 proxy = NONE
 scaledown_idletime = 10
 stack_name = test
+table_name = instances
+asg_name = test

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -18,15 +18,13 @@ import urllib2
 import os
 import time
 import sys
-import tempfile
 import logging
 import boto3
+from boto3.dynamodb.conditions import Attr
 import ConfigParser
 from botocore.exceptions import ClientError
 from botocore.config import Config
 import json
-import atexit
-import errno
 
 
 log = logging.getLogger(__name__)
@@ -34,9 +32,26 @@ _DATA_DIR = "/var/run/nodewatcher/"
 _IDLETIME_FILE = _DATA_DIR + "node_idletime.json"
 _CURRENT_IDLETIME = 'current_idletime'
 
-def getConfig(instance_id):
-    log.debug('reading /etc/nodewatcher.cfg')
 
+def get_asg_name(stack_name, region, proxy_config):
+    asg_conn = boto3.client('autoscaling', region_name=region, config=proxy_config)
+    asg_name = ""
+    no_asg = True
+
+    while no_asg:
+        try:
+            r = asg_conn.describe_tags(Filters=[{'Name': 'value', 'Values': [stack_name]}])
+            asg_name = r.get('Tags')[0].get('ResourceId')
+            no_asg = False
+        except IndexError as e:
+            log.error("No asg found for cluster %s" % stack_name)
+            time.sleep(30)
+
+    return asg_name
+
+
+def get_config():
+    log.debug('reading /etc/nodewatcher.cfg')
     config = ConfigParser.RawConfigParser()
     config.read('/etc/nodewatcher.cfg')
     if config.has_option('nodewatcher', 'loglevel'):
@@ -52,29 +67,14 @@ def getConfig(instance_id):
 
     _scaledown_idletime = int(config.get('nodewatcher', 'scaledown_idletime'))
     _stack_name = config.get('nodewatcher', 'stack_name')
-    try:
-        _asg = config.get('nodewatcher', 'asg')
-    except ConfigParser.NoOptionError:
-        ec2 = boto3.resource('ec2', region_name=_region, config=proxy_config)
-
-        instances = ec2.instances.filter(InstanceIds=[instance_id])
-        instance = next(iter(instances or []), None)
-        _asg = filter(lambda tag: tag.get('Key') == 'aws:autoscaling:groupName', instance.tags)[0].get('Value')
-        log.debug("discovered asg: %s" % _asg)
-        config.set('nodewatcher', 'asg', _asg)
-
-        tup = tempfile.mkstemp(dir=os.getcwd())
-        fd = os.fdopen(tup[0], 'w')
-        config.write(fd)
-        fd.close
-
-        os.rename(tup[1], 'nodewatcher.cfg')
+    _table_name = config.get('nodewatcher', 'table_name')
+    _asg = get_asg_name(_stack_name, _region, proxy_config)
 
     log.debug("region=%s asg=%s scheduler=%s prox_config=%s idle_time=%s" % (_region, _asg, _scheduler, proxy_config, _scaledown_idletime))
-    return _region, _asg, _scheduler, proxy_config, _scaledown_idletime, _stack_name
+    return _region, _asg, _scheduler, proxy_config, _scaledown_idletime, _stack_name, _table_name
 
-def getInstanceId():
 
+def get_instance_id():
     try:
         _instance_id = urllib2.urlopen("http://169.254.169.254/latest/meta-data/instance-id").read()
     except urllib2.URLError:
@@ -85,8 +85,90 @@ def getInstanceId():
 
     return _instance_id
 
-def getHostname():
 
+def load_scheduler_module(scheduler):
+    scheduler = 'nodewatcher.plugins.' + scheduler
+    _scheduler = __import__(scheduler)
+    _scheduler = sys.modules[scheduler]
+
+    log.debug("scheduler=%s" % repr(_scheduler))
+
+    return _scheduler
+
+
+def node_has_jobs(scheduler, hostname):
+
+    _jobs = scheduler.has_jobs(hostname)
+
+    log.info("jobs=%s" % _jobs)
+
+    return _jobs
+
+
+def get_idle_nodes(scheduler):
+    idle_nodes = scheduler.get_idle_nodes()
+    log.info("idle_node_count=%s" % len(idle_nodes))
+
+    return idle_nodes
+
+
+def queue_has_pending_jobs(scheduler):
+    _has_pending_jobs, _error = scheduler.has_pending_jobs()
+    log.info("has_pending_jobs=%s, error=%s" % (_has_pending_jobs, _error))
+    return _has_pending_jobs, _error
+
+
+def get_current_cluster_size(scheduler):
+    current_cluster_size = scheduler.get_current_cluster_size()
+    log.info("current_cluster_size=%s" % current_cluster_size)
+    return current_cluster_size
+
+
+def lock_host(scheduler, hostname):
+    log.info("locking %s" % hostname)
+
+    _r = scheduler.lock_host(hostname, False)
+
+    time.sleep(15) # allow for some settling
+
+    return _r
+
+
+def unlock_host(scheduler,hostname):
+    log.info("unlocking %s" % hostname)
+
+    _r = scheduler.lock_host(hostname, True)
+
+    time.sleep(15) # allow for some settling
+
+    return _r
+
+
+def self_terminate(dynamodb_table, asg_conn, instance_id):
+    log.info("terminating %s" % instance_id)
+    try:
+        dynamodb_table.update_item(
+            Key={'instanceId': instance_id},
+            UpdateExpression='SET #terminated_by_cluster = :terminated',
+            ExpressionAttributeNames={'#terminated_by_cluster': 'terminated_by_cluster'},
+            ExpressionAttributeValues={':terminated': True}
+        )
+        asg_conn.terminate_instance_in_auto_scaling_group(InstanceId=instance_id, ShouldDecrementDesiredCapacity=True)
+        return True
+    except ClientError as ex:
+        log.error("terminate_instance_in_auto_scaling_group failed with exception %s" % ex)
+    return False
+
+
+def get_stack_creation_status(stack_name, region, proxy_config):
+    log.info('Checking for status of the stack %s' % stack_name)
+    cfn_client = boto3.client('cloudformation', region_name=region, config=proxy_config)
+    stacks = cfn_client.describe_stacks(StackName=stack_name)
+    return stacks['Stacks'][0]['StackStatus'] == 'CREATE_COMPLETE' or \
+           stacks['Stacks'][0]['StackStatus'] == 'UPDATE_COMPLETE'
+
+
+def get_hostname():
     try:
         _hostname = urllib2.urlopen("http://169.254.169.254/latest/meta-data/local-hostname").read()
     except urllib2.URLError:
@@ -97,77 +179,72 @@ def getHostname():
 
     return _hostname
 
-def loadSchedulerModule(scheduler):
-    scheduler = 'nodewatcher.plugins.' + scheduler
-    _scheduler = __import__(scheduler)
-    _scheduler = sys.modules[scheduler]
 
-    log.debug("scheduler=%s" % repr(_scheduler))
+def check_if_terminable(dynamodb_table, min_size):
+    log.info("Checking if this node is terminable")
+    try:
+        dynamodb_table.update_item(
+            Key={'instanceId': 'current_cluster_size'},
+            UpdateExpression='SET #count = #count - :count',
+            ConditionExpression=Attr('count').gt(min_size),
+            ExpressionAttributeNames={'#count': 'count'},
+            ExpressionAttributeValues={':count': 1}
+        )
+        return True
+    except ClientError as ex:
+        log.info("Node is not terminable. Failed with ex " % ex)
+        item = dynamodb_table.get_item(ConsistentRead=True, Key={"instanceId": "current_cluster_size"})
+        if item.get('Item') is not None:
+            count = item.get('Item').get('count')
+            log.info("Current count is %s; Minimum size is %s" % (count, min_size))
+        return False
 
-    return _scheduler
 
-def hasJobs(s,hostname):
+def update_table_when_termination_fails(dynamodb_table, instance_id):
+    log.info("Updating table since termination request on this node failed")
+    try:
+        dynamodb_table.update_item(
+            Key={'instanceId': instance_id},
+            UpdateExpression='SET #terminated_by_cluster = :terminated',
+            ExpressionAttributeNames={'#terminated_by_cluster': 'terminated_by_cluster'},
+            ExpressionAttributeValues={':terminated': False}
+        )
+        dynamodb_table.update_item(
+            Key={'instanceId': 'current_cluster_size'},
+            UpdateExpression='SET #count = #count + :count',
+            ExpressionAttributeNames={'#count': 'count'},
+            ExpressionAttributeValues={':count': 1}
+        )
+    except ClientError as ex:
+        log.error("Update table failed with  exception " % ex)
 
-    _jobs = s.hasJobs(hostname)
 
-    log.debug("jobs=%s" % _jobs)
-
-    return _jobs
-
-def hasPendingJobs(s):
-    _has_pending_jobs, _error = s.hasPendingJobs()
-    log.debug("has_pending_jobs=%s, error=%s" % (_has_pending_jobs, _error))
-    return _has_pending_jobs, _error
-
-def lockHost(s,hostname,unlock=False):
-    log.debug("%s %s" % (unlock and "unlocking" or "locking",
-                         hostname))
-
-    _r = s.lockHost(hostname, unlock)
-
-    time.sleep(15) # allow for some settling
-
-    return _r
-
-def selfTerminate(asg_name, asg_conn, instance_id):
-    if not maintainSize(asg_name, asg_conn):
-        log.info("terminating %s" % instance_id)
-        asg_conn.terminate_instance_in_auto_scaling_group(InstanceId=instance_id, ShouldDecrementDesiredCapacity=True)
-
-def maintainSize(asg_name, asg_conn):
+def get_desired_sizes(scheduler, asg_name, asg_conn):
     asg = asg_conn.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name]) \
         .get('AutoScalingGroups')[0]
-    _capacity = asg.get('DesiredCapacity')
-    _min_size = asg.get('MinSize')
-    log.info("capacity=%d min_size=%d" % (_capacity, _min_size))
-    if _capacity > _min_size:
-        log.debug('capacity greater then min size.')
-        return False
-    else:
-        log.debug('capacity less then or equal to min size.')
-        return True
+    asg_desired_capacity = asg.get('DesiredCapacity')
+    log.info("asg_desired=%d" % asg_desired_capacity)
+    total_compute_nodes = get_current_cluster_size(scheduler)
+    log.info("total_compute_nodes=%d" % total_compute_nodes)
+    capacity = min(asg_desired_capacity, total_compute_nodes)
+    min_size = asg.get('MinSize')
 
-
-def stackCreationComplete(stack_name, region, proxy_config):
-    log.info('Checking for status of the stack %s' % stack_name)
-    cfn_client = boto3.client('cloudformation', region_name=region, config=proxy_config)
-    stacks = cfn_client.describe_stacks(StackName=stack_name)
-    return stacks['Stacks'][0]['StackStatus'] == 'CREATE_COMPLETE' or \
-           stacks['Stacks'][0]['StackStatus'] == 'UPDATE_COMPLETE'
+    log.info("capacity=%d min_size=%d" % (capacity, min_size))
+    return min_size, capacity
 
 
 def main():
+    # This daemon runs on the compute nodes.
+    # The purpose of this daemon is to monitor the node and if idle for long enough,
+    # send termination requests to the ASG
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s'
     )
     log.info("nodewatcher startup")
-    instance_id = getInstanceId()
-    hostname = getHostname()
-    region, asg_name, scheduler, proxy_config, idle_time, stack_name = getConfig(instance_id)
+    region, asg_name, scheduler, proxy_config, idle_time, stack_name, table_name = get_config()
 
-
-    s = loadSchedulerModule(scheduler)
+    scheduler = load_scheduler_module(scheduler)
 
     try:
         if not os.path.exists(_DATA_DIR):
@@ -183,57 +260,94 @@ def main():
     else:
         data = {_CURRENT_IDLETIME: 0}
 
+    instance_id = get_instance_id()
+    hostname = get_hostname()
+
+    dynamodb_resource = boto3.resource('dynamodb', region_name=region, config=proxy_config)
+    try:
+        dynamodb_table = dynamodb_resource.Table(table_name)
+    except ClientError as e:
+        log.critical('Creating a table client failed with exception %s. Exiting' % e)
+        raise
+
     stack_creation_complete = False
     termination_in_progress = False
     while True:
-        # if this node is terminating sleep for a long time and wait for termination
+        # If termination is in progress, keep the daemon running as a no-op
         if termination_in_progress:
+            log.info("terminating %s" % instance_id)
             time.sleep(300)
             log.info('%s is still terminating' % hostname)
             continue
         time.sleep(60)
         if not stack_creation_complete:
-            stack_creation_complete = stackCreationComplete(stack_name, region, proxy_config)
+            stack_creation_complete = get_stack_creation_status(stack_name, region, proxy_config)
             log.info('%s creation complete: %s' % (stack_name, stack_creation_complete))
             continue
         asg_conn = boto3.client('autoscaling', region_name=region, config=proxy_config)
 
-        has_jobs = hasJobs(s, hostname)
+        has_jobs = node_has_jobs(scheduler, hostname)
         if has_jobs:
             log.info('Instance has active jobs.')
             data[_CURRENT_IDLETIME] = 0
         else:
-            if maintainSize(asg_name, asg_conn):
+            min_size, current_size = get_desired_sizes(scheduler, asg_name, asg_conn)
+            if current_size <= min_size:
+                log.info('capacity less then or equal to min size. Node not eligible for termination')
                 continue
             else:
+                log.info('local capacity greater then min size')
                 data[_CURRENT_IDLETIME] += 1
                 log.info('Instance %s has no job for the past %s minute(s)' % (instance_id, data[_CURRENT_IDLETIME]))
                 with open(_IDLETIME_FILE, 'w') as outfile:
                     json.dump(data, outfile)
 
                 if data[_CURRENT_IDLETIME] >= idle_time:
-                    lockHost(s, hostname)
-                    has_jobs = hasJobs(s, hostname)
+                    lock_host(scheduler, hostname)
+                    has_jobs = node_has_jobs(scheduler, hostname)
                     if has_jobs:
                         log.info('Instance has active jobs.')
                         data[_CURRENT_IDLETIME] = 0
-                        lockHost(s, hostname, unlock=True)
+                        unlock_host(scheduler, hostname)
                     else:
-                        has_pending_jobs, error = hasPendingJobs(s)
+                        has_pending_jobs, error = queue_has_pending_jobs(scheduler)
                         if not error and not has_pending_jobs:
-                            os.remove(_IDLETIME_FILE)
+                            log.info("Node eligible for termination")
                             try:
-                                selfTerminate(asg_name, asg_conn, instance_id)
-                                termination_in_progress = True
+                                # atomic decrement on the dynamoDB table if the decrement fails,
+                                # it is because the cluster size (as reported by all compute nodes)
+                                # is no longer greater than or equal to min_queue_size
+
+                                node_terminable = check_if_terminable(dynamodb_table, min_size)
+
+                                # if node can be terminated, go ahead and terminate it.
+                                # Dynamo table has been updated before termination
+
+                                if node_terminable:
+                                    termination_in_progress = self_terminate(dynamodb_table, asg_conn, instance_id)
+
+                                    # For some reason if the termination fails
+                                    # (can only fail if asg fails, which is rare)
+                                    # unlock host and increment the count in the table
+                                    if not termination_in_progress:
+                                        log.info("Termination was unsuccessful, unlocking host")
+                                        unlock_host(scheduler, hostname)
+                                        update_table_when_termination_fails(dynamodb_table, instance_id)
+                                    else:
+                                        os.remove(_IDLETIME_FILE)
+                                else:
+                                    unlock_host(scheduler, hostname)
+
                             except ClientError as ex:
                                 log.error('Failed to terminate instance: %s with exception %s' % (instance_id, ex))
-                                lockHost(s, hostname, unlock=True)
+                                unlock_host(scheduler, hostname)
                         else:
                             if has_pending_jobs:
                                 log.info('Queue has pending jobs. Not terminating instance')
                             elif error:
-                                log.info('Encountered an error while polling queue for pending jobs. Not terminating instance')
-                            lockHost(s, hostname, unlock=True)
+                                log.info('Encountered an error while polling queue for pending jobs.'
+                                         'Not terminating instance')
+                            unlock_host(scheduler, hostname)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use optimistic concurrency using hostname as a lock for dynamodb table item.

1. Create a dummy entry in the dynamodb table to keep track of current active nodes

2. To get the current number of active nodes, use information from scheduler instead of just the asg desired value, since the ASG desired value does not reflect bootstrapping.

3. Optimistically update the dummy entry using atomic counter during scaledown in order to prevent excessive termination

4. Keep a count of the total number of nodes as seen by the cluster, not just the ASG

5. For every entry in dynamoDB have a flag indicating if the termination is happening from the nodewatcher

6. If the termination happens outside the nodewatcher for some reason, sqswatcher will decrement the count

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
