### PR TITLE
Avoid to process multiple times a bad host

### DIFF
--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -11,23 +11,18 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-__author__ = 'dougalb'
-
-from datetime import datetime
-import urllib2
+import ConfigParser
+import json
+import logging
 import os
-import time
 import sys
 import tempfile
-import logging
-import boto3
-import ConfigParser
-from botocore.exceptions import ClientError
-from botocore.config import Config
-import json
-import atexit
-import errno
+import time
+import urllib2
 
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
 
 log = logging.getLogger(__name__)
 _DATA_DIR = "/var/run/nodewatcher/"
@@ -171,8 +166,7 @@ def main():
         if not os.path.exists(_DATA_DIR):
             os.makedirs(_DATA_DIR)
     except OSError as ex:
-        log.critical('Creating directory %s to persist current idle time failed with exception: %s '
-                     % (_DATA_DIR, ex))
+        log.critical('Creating directory %s to persist current idle time failed with exception: %s ' % (_DATA_DIR, ex))
         raise
 
     if os.path.isfile(_IDLETIME_FILE):

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -80,7 +80,7 @@ def wakeupSchedOn(hostname):
         log.debug("Host %s is in state %s" % (hostname, host_state))
 
 def addHost(hostname,cluster_user,slots):
-    log.info('Adding %s', hostname)
+    log.info('Adding %s with %s slots' % (hostname, slots))
 
     command = ("/opt/torque/bin/qmgr -c 'create node %s np=%s'" % (hostname, slots))
     __runCommand(command)


### PR DESCRIPTION
If the hostname was empty or when an exception was raised the related message was not removed from the queue.

The _sqswatcher_ process crashed with an exception and a new sqswatcher process started.

The bad message remained in the queue and after the [SQS visibility timeout](https://docs.aws.amazon.com/en_us/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html) it was processed by the new sqswatcher process, crashing again.

Now we are logging the error, breaking the loop and deleting the message from the queue, for both COMPUTE_READY 417e48015cc1d08a1bfd70a8136c482eac9cee8e and EC2_INSTANCE_TERMINATE  c49e0672797ace0da96a4e5e8bf07775bf2c671b cases.

If a bad host is not added to the cluster, it will be be automatically stopped after the scaledown_idletime
I fixed the sge behaviour with aff0f3121e8a2bf72f889ce72d84460a94b183c3.

Issue: https://github.com/aws/aws-parallelcluster/issues/743

I tested it with:
- sge centos7 
- slurm ubuntu1604
- torque alinux