### PR TITLE
Simplify the logic to detect if a sge compute node has jobs running

### DIFF
--- a/nodewatcher/plugins/sge.py
+++ b/nodewatcher/plugins/sge.py
@@ -18,8 +18,19 @@ log = logging.getLogger(__name__)
 
 
 def hasJobs(hostname):
-    # Checking for running jobs on the node
+    # Checking for running jobs on the node, with parallel job view expanded (-g t)
     _command = ['/opt/sge/bin/lx-amd64/qstat', '-g', 't', '-l', 'hostname=%s' % hostname, '-u', '*']
+
+    # Command output
+    # job-ID  prior   name       user         state submit/start at     queue                          master ja-task-ID
+    # ------------------------------------------------------------------------------------------------------------------
+    # 16 0.6 0500 job.sh     ec2-user     r     02/06/2019 11:06:30 all.q@ip-172-31-68-26.ec2.inte SLAVE
+    #                                                               all.q@ip-172-31-68-26.ec2.inte SLAVE
+    #                                                               all.q@ip-172-31-68-26.ec2.inte SLAVE
+    #                                                               all.q@ip-172-31-68-26.ec2.inte SLAVE
+    # 17 0.50500 STDIN      ec2-user     r     02/06/2019 11:06:30 all.q@ip-172-31-68-26.ec2.inte MASTER 1
+    # 17 0.50500 STDIN      ec2-user     r     02/06/2019 11:06:30 all.q@ip-172-31-68-26.ec2.inte MASTER 2
+
     try:
         _output = subprocess.Popen(_command,
                                   stdout=subprocess.PIPE,

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -26,6 +26,7 @@ def hasJobs(hostname):
         output = subprocess.Popen(_command, stdout=subprocess.PIPE).communicate()[0]
     except subprocess.CalledProcessError:
         log.error("Failed to run %s\n" % _command)
+        _output = ""
 
     if output == "":
         _jobs = False

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -43,6 +43,7 @@ def hasJobs(hostname):
         status, output = runPipe(commands)
     except subprocess.CalledProcessError:
         log.error("Failed to run %s\n" % commands)
+        _output = ""
 
     if output == "":
         _jobs = False


### PR DESCRIPTION
This patch revert https://github.com/aws/aws-parallelcluster-node/commit/1adb8579fe5a7f6db700a01ace958a2a5dca014d
in which the check was buggy because it was checking a hostname as a
substring of another hostname

This new code also works for parallel jobs and align its behaviour to
what is done for the other schedulers

It has been tested with normal job, array job and parallel job.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
