### PR TITLE
Pin dependency of cryptography package

### DIFF
--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,3 +1,4 @@
 pycparser==2.18
 idna==2.6
 paramiko==2.3.3
+cryptography==2.1.4

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if sys.version_info[:2] == (2, 6):
     requires.append('argparse>=1.4')
     requires.append('idna==2.6')
     requires.append('paramiko==2.3.3')
+    requires.append('cryptography==2.1.4')  # dependency of paramiko
     requires.append('pycparser==2.18')
 else:
     requires.append('paramiko>=2.4.2')


### PR DESCRIPTION
This is a transitive dependency used by paramiko which starting from version
2.5 became incompatible with python 2.6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
