### PR TITLE
Cleanup daemons code

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python2.6
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import sys
+
+
+def load_module(module):
+    """
+    Load python module.
+
+    :param module: module path, relative to the caller one.
+    :return: the loaded scheduler module
+    """
+    # import module
+    __import__(module)
+    # get module from the loaded maps
+    scheduler_module = sys.modules[module]
+    return scheduler_module

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -88,14 +88,14 @@ def _get_metadata(metadata_path):
     :return the metadata value.
     """
     try:
-        _instance_id = urllib2.urlopen("http://169.254.169.254/latest/meta-data/{0}".format(metadata_path)).read()
+        metadata_value = urllib2.urlopen("http://169.254.169.254/latest/meta-data/{0}".format(metadata_path)).read()
     except urllib2.URLError:
         log.critical("Unable to get {0} metadata".format(metadata_path))
         sys.exit(1)
 
-    log.debug("instance_id=%s" % _instance_id)
+    log.debug("%s=%s", metadata_path, metadata_value)
 
-    return _instance_id
+    return metadata_value
 
 
 def _has_jobs(scheduler_module, hostname):

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -24,6 +24,8 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+from common.utils import load_module
+
 log = logging.getLogger(__name__)
 
 
@@ -94,21 +96,6 @@ def _get_metadata(metadata_path):
     log.debug("instance_id=%s" % _instance_id)
 
     return _instance_id
-
-
-def _load_scheduler_module(scheduler):
-    """
-    Load scheduler module, containing scheduler specific functions.
-
-    :param scheduler: scheduler name, it must corresponds to the <scheduler>.py file in the current folder.
-    :return: the scheduler module
-    """
-    scheduler = 'nodewatcher.plugins.' + scheduler
-    _scheduler = __import__(scheduler)
-    _scheduler = sys.modules[scheduler]
-
-    log.debug("scheduler=%s" % repr(_scheduler))
-    return _scheduler
 
 
 def _has_jobs(scheduler_module, hostname):
@@ -208,7 +195,7 @@ def main():
     log.info('Instance id is %s, hostname is %s' % (instance_id, hostname))
     region, asg_name, scheduler, proxy_config, idle_time, stack_name = _get_config(instance_id)
 
-    scheduler_module = _load_scheduler_module(scheduler)
+    scheduler_module = load_module("nodewatcher.plugins." + scheduler)
 
     data_dir = "/var/run/nodewatcher/"
     try:

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -40,34 +40,31 @@ def _get_config():
 
     :return: the configuration parameters
     """
-    _config_file = '/etc/sqswatcher.cfg'
-    log.debug('reading %s' % _config_file)
+    config_file = "/etc/sqswatcher.cfg"
+    log.info("Reading %s", config_file)
 
     config = ConfigParser.RawConfigParser()
-    config.read(_config_file)
-    if config.has_option('sqswatcher', 'loglevel'):
-        lvl = logging._levelNames[config.get('sqswatcher', 'loglevel')]
+    config.read(config_file)
+    if config.has_option("sqswatcher", "loglevel"):
+        lvl = logging._levelNames[config.get("sqswatcher", "loglevel")]
         logging.getLogger().setLevel(lvl)
-    _region = config.get('sqswatcher', 'region')
-    _sqsqueue = config.get('sqswatcher', 'sqsqueue')
-    _table_name = config.get('sqswatcher', 'table_name')
-    _scheduler = config.get('sqswatcher', 'scheduler')
-    _cluster_user = config.get('sqswatcher', 'cluster_user')
-    _proxy = config.get('sqswatcher', 'proxy')
+
+    region = config.get("sqswatcher", "region")
+    scheduler = config.get("sqswatcher", "scheduler")
+    sqsqueue = config.get("sqswatcher", "sqsqueue")
+    table_name = config.get("sqswatcher", "table_name")
+    cluster_user = config.get("sqswatcher", "cluster_user")
+
+    _proxy = config.get("sqswatcher", "proxy")
     proxy_config = Config()
+    if _proxy != "NONE":
+        proxy_config = Config(proxies={"https": _proxy})
 
-    if not _proxy == "NONE":
-        proxy_config = Config(proxies={'https': _proxy})
-
-    log.debug(" ".join("%s=%s" % i
-                       for i in [('_region', _region),
-                                 ('_sqsqueue', _sqsqueue),
-                                 ('_table_name', _table_name),
-                                 ('_scheduler', _scheduler),
-                                 ('_cluster_user', _cluster_user),
-                                 ('_proxy', _proxy)]))
-
-    return _region, _sqsqueue, _table_name, _scheduler, _cluster_user, proxy_config
+    log.info(
+        "Configured parameters: region=%s scheduler=%s sqsqueue=%s table_name=%s cluster_user=%s proxy=%s",
+        region, scheduler, sqsqueue, table_name, cluster_user, _proxy
+    )
+    return region, scheduler, sqsqueue, table_name, cluster_user, proxy_config
 
 
 def _setup_queue(region, queue_name, proxy_config):
@@ -300,7 +297,7 @@ def main():
     log.info("sqswatcher startup")
     global region, cluster_user
 
-    region, sqsqueue, table_name, scheduler, cluster_user, proxy_config = _get_config()
+    region, scheduler, sqsqueue, table_name, cluster_user, proxy_config = _get_config()
     queue = _setup_queue(region, sqsqueue, proxy_config)
     table = _setup_ddb_table(region, table_name, proxy_config)
 


### PR DESCRIPTION
* Generalize `get_scheduler_module` function and move to `common`
* Fix `_get_metadata` logging and internal variable names.

jobwatcher and nodewatcher:
+ log the proxy value and not the `config_proxy` object
+ avoid to write the `asg_name` in the configuration file since the value
should be retrieved only one time, at daemon startup, and it is a simple boto3 call

jobwatcher:
+ define a function to read the configuration file

nodewatcher:
+ move the code to get the ASG name out of the `_get_config` function

Tested with custom node

It's easier to take at look commit by commit.