### PR TITLE
Cleanup and refactor daemons code

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import sys
+import time
+
+import boto3
+
+
+class ASGNotFoundError(Exception):
+    pass
 
 
 def load_module(module):
@@ -27,3 +34,36 @@ def load_module(module):
     # get module from the loaded maps
     scheduler_module = sys.modules[module]
     return scheduler_module
+
+
+def get_asg_name(stack_name, region, proxy_config, log, attempts=4, delay=30):
+    """
+    Get autoscaling group name associated to the given stack.
+
+    :param stack_name: stack name to search for
+    :param region: AWS region
+    :param proxy_config: Proxy configuration
+    :param log: logger
+    :param attempts: the number of times to try before giving up if the ASG is not yet ready
+    :param delay: delay between retries in seconds
+    :raise ASGNotFoundError if the ASG is not found (after the timeout) or if an unexpected error occurs
+    :return: the ASG name
+    """
+    asg_client = boto3.client("autoscaling", region_name=region, config=proxy_config)
+
+    count = 0
+    while True:
+        try:
+            response = asg_client.describe_tags(Filters=[{"Name": "Value", "Values": [stack_name]}])
+            asg_name = response.get("Tags")[0].get("ResourceId")
+            log.info("ASG %s found for the stack %s", asg_name, stack_name)
+            return asg_name
+        except IndexError:
+            if count < attempts:
+                log.warning("No ASG found for stack %s, waiting %s seconds...", stack_name, delay)
+                time.sleep(delay)
+                count += 1
+            else:
+                raise ASGNotFoundError("Unable to get ASG for stack %s" % stack_name)
+        except Exception as e:
+            raise ASGNotFoundError("Unable to get ASG for stack %s. Failed with exception: %s" % (stack_name, e))

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -26,8 +26,6 @@ from botocore.exceptions import ClientError
 from common.utils import get_asg_name, load_module
 
 log = logging.getLogger(__name__)
-pricing_file = '/opt/parallelcluster/instances.json'
-cfnconfig_file = '/opt/parallelcluster/cfnconfig'
 
 
 def _read_cfnconfig():
@@ -37,6 +35,8 @@ def _read_cfnconfig():
     :return: a dictionary containing the configuration parameters
     """
     cfnconfig_params = {}
+    cfnconfig_file = "/opt/parallelcluster/cfnconfig"
+    log.info("Reading %s", cfnconfig_file)
     with open(cfnconfig_file) as f:
         for kvp in f:
             key, value = kvp.partition('=')[::2]
@@ -51,6 +51,7 @@ def _get_vcpus_from_pricing_file(instance_type):
     :param instance_type: the instance type to search for.
     :return: the number of vcpus or -1 if the instance type cannot be found
     """
+    pricing_file = "/opt/parallelcluster/instances.json"
     with open(pricing_file) as f:
         instances = json.load(f)
         try:
@@ -74,9 +75,7 @@ def _get_instance_properties(instance_type):
         cfnconfig_params = _read_cfnconfig()
         cfn_scheduler_slots = cfnconfig_params["cfn_scheduler_slots"]
     except KeyError:
-        log.error(
-            "Required config parameter 'cfn_scheduler_slots' not found in file %s. Assuming 'vcpus'" % cfnconfig_file
-        )
+        log.error("Required config parameter 'cfn_scheduler_slots' not found in cfnconfig file. Assuming 'vcpus'")
         cfn_scheduler_slots = "vcpus"
 
     vcpus = _get_vcpus_from_pricing_file(instance_type)

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -224,14 +224,13 @@ def main():
             else:
                 # Get current number of nodes
                 running = scheduler_module.get_busy_nodes(instance_properties)
-                log.info("%s jobs pending; %s jobs running" % (pending, running))
+                log.info("%d nodes requested, %d nodes running", pending, running)
 
                 # connect to asg
                 asg_client = boto3.client('autoscaling', region_name=config.region, config=config.proxy_config)
 
                 # get current limits
                 current_desired, max_size = _get_asg_settings(asg_client, asg_name)
-                log.info("%d nodes requested, %d nodes running" % (pending, running))
 
                 # Check to make sure requested number of instances is within ASG limits
                 required = running + pending

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -238,7 +238,6 @@ def main():
                     else:
                         has_pending_jobs, error = _has_pending_jobs(scheduler_module)
                         if not error and not has_pending_jobs:
-                            os.remove(idletime_file)
                             try:
                                 _self_terminate(asg_name, asg_conn, instance_id)
                                 termination_in_progress = True

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python2.6
+#!/usr/bin/env python
 
-# Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
 # License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
@@ -24,7 +25,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-from common.utils import load_module
+from common.utils import get_asg_name, load_module
 
 log = logging.getLogger(__name__)
 
@@ -80,7 +81,6 @@ def _get_metadata(metadata_path):
         sys.exit(1)
 
     log.debug("%s=%s", metadata_path, metadata_value)
-
     return metadata_value
 
 
@@ -181,13 +181,7 @@ def main():
     instance_id = _get_metadata("instance-id")
     hostname = _get_metadata("local-hostname")
     log.info('Instance id is %s, hostname is %s', instance_id, hostname)
-
-    # get ASG name
-    ec2 = boto3.resource('ec2', region_name=config.region, config=config.proxy_config)
-    instances = ec2.instances.filter(InstanceIds=[instance_id])
-    instance = next(iter(instances or []), None)
-    asg_name = filter(lambda tag: tag.get('Key') == 'aws:autoscaling:groupName', instance.tags)[0].get('Value')
-    log.info("The ASG associated to the stack %s is %s", config.stack_name, asg_name)
+    asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config, log)
 
     scheduler_module = load_module("nodewatcher.plugins." + config.scheduler)
 

--- a/nodewatcher/plugins/openlava.py
+++ b/nodewatcher/plugins/openlava.py
@@ -12,7 +12,6 @@
 __author__ = 'dougalb'
 
 import subprocess
-import os
 import logging
 
 log = logging.getLogger(__name__)
@@ -21,9 +20,10 @@ def getJobs(hostname):
     # Checking for running jobs on the node
     command = ['/opt/openlava/bin/bjobs', '-m', hostname, '-u', 'all']
     try:
-       output = subprocess.Popen(command, stdout=subprocess.PIPE).communicate()[0]
+        output = subprocess.Popen(command, stdout=subprocess.PIPE).communicate()[0]
     except subprocess.CalledProcessError:
-        log.error("Failed to run %s\n" % _command)
+        log.error("Failed to run %s\n" % command)
+        output = ""
 
     if output == "":
         _jobs = False
@@ -31,6 +31,7 @@ def getJobs(hostname):
         _jobs = True
 
     return _jobs
+
 
 def lockHost(hostname, unlock=False):
     # http://wp.auburn.edu/morgaia/?p=103

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -26,7 +26,7 @@ def hasJobs(hostname):
         output = subprocess.Popen(_command, stdout=subprocess.PIPE).communicate()[0]
     except subprocess.CalledProcessError:
         log.error("Failed to run %s\n" % _command)
-        _output = ""
+        output = ""
 
     if output == "":
         _jobs = False
@@ -34,6 +34,7 @@ def hasJobs(hostname):
         _jobs = True
 
     return _jobs
+
 
 def hasPendingJobs():
     command = "/opt/slurm/bin/squeue -t PD --noheader"
@@ -61,6 +62,7 @@ def hasPendingJobs():
         has_pending = True
 
     return has_pending, error
+
 
 def lockHost(hostname, unlock=False):
     pass

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -18,6 +18,7 @@ import shlex
 
 log = logging.getLogger(__name__)
 
+
 def runPipe(cmds):
     try:
         p1 = subprocess.Popen(cmds[0].split(' '), stdin = None, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
@@ -36,6 +37,7 @@ def runPipe(cmds):
     else:
         return (False, stderr)
 
+
 def hasJobs(hostname):
     # Checking for running jobs on the node
     commands = ['/opt/torque/bin/qstat -r -t -n -1', ('grep ' + hostname.split('.')[0])]
@@ -43,7 +45,7 @@ def hasJobs(hostname):
         status, output = runPipe(commands)
     except subprocess.CalledProcessError:
         log.error("Failed to run %s\n" % commands)
-        _output = ""
+        output = ""
 
     if output == "":
         _jobs = False
@@ -51,6 +53,7 @@ def hasJobs(hostname):
         _jobs = True
 
     return _jobs
+
 
 def hasPendingJobs():
     command = "/opt/torque/bin/qstat -Q"
@@ -87,6 +90,7 @@ def hasPendingJobs():
     has_pending = pending > 0
 
     return has_pending, error
+
 
 def lockHost(hostname, unlock=False):
     # https://lists.sdsc.edu/pipermail/npaci-rocks-discussion/2007-November/027919.html


### PR DESCRIPTION
All the daemons:
* Use namedtuple to manage configuration parameters

nodewatcher: 
* do not remove idletime file before self termination. 
If there is an error during the self termination phase we need the idletime file to try to remove the instance in the next daemon execution.
If the instance is deleted correctly the file removal is useless.
* create functions to manage idletime file.
* simplify code by using idletime variable and not a json object.
* fix internal variable names

jobwatcher and nodewatcher:
* Move `get_asg_name` function to `common/utils`. 
From now the function will raise an exception after a timeout if the ASG name can't be found (there was an infinite loop).
In a future patch we have to catch and manage the different exceptions

sqswatcher and jobwatcher:
* avoid global variables
