### PR TITLE
 slurm: dynamic dummy nodes management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3>=1.7.55
 paramiko>=2.4.2
 python-dateutil>=2.6.1
+retrying>=1.3.3

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -2,3 +2,4 @@ pycparser==2.18
 idna==2.6
 paramiko==2.3.3
 cryptography==2.1.4
+retrying>=1.3.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ console_scripts = ['sqswatcher = sqswatcher.sqswatcher:main',
                    'nodewatcher = nodewatcher.nodewatcher:main',
                    'jobwatcher = jobwatcher.jobwatcher:main']
 version = "2.2.1"
-requires = ['boto3>=1.7.55', 'python-dateutil>=2.6.1']
+requires = ['boto3>=1.7.55', 'python-dateutil>=2.6.1', 'retrying>=1.3.3']
 
 if sys.version_info[:2] == (2, 6):
     # For python2.6 we have to require argparse since it

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -66,7 +66,7 @@ def _run_sge_command(command, raise_exception=False):
             raise HostRemovalError
 
 
-def addHost(hostname, cluster_user, slots):
+def addHost(hostname, cluster_user, slots, max_cluster_size):
     log.info('Adding %s with %s slots' % (hostname,slots))
 
     # Adding host as administrative host
@@ -139,7 +139,7 @@ report_variables      NONE
     _run_sge_command(command)
 
 
-def removeHost(hostname, cluster_user):
+def removeHost(hostname, cluster_user, max_cluster_size):
     log.info('Removing %s', hostname)
 
     # Check if host is administrative host

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -1,169 +1,148 @@
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #
-# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
-# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
-# limitations under the License.
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 
-import subprocess as sub
-from tempfile import mkstemp
-from shutil import move
+# This file has a special meaning for pytest. See https://docs.pytest.org/en/2.7.3/plugins.html for
+# additional details.
+
+import logging
 import os
 import os.path
+import subprocess
+from shutil import move
+from tempfile import mkstemp
+
 import paramiko
-import socket
-import time
-import logging
-import re
+from retrying import retry
 
 log = logging.getLogger(__name__)
 
+PCLUSTER_NODES_CONFIG = "/opt/slurm/etc/slurm_parallelcluster_nodes.conf"
 
-def __runCommand(command):
-    _command = command
-    log.debug(repr(command))
+
+def _run_command(command):
     try:
-        sub.check_call(_command, env=dict(os.environ))
-    except sub.CalledProcessError:
-        log.error("Failed to run %s\n" % _command)
+        subprocess.check_call(command, env=dict(os.environ))
+    except subprocess.CalledProcessError as e:
+        # CalledProcessError.__str__ already produces a significant error message
+        log.error(e)
+        raise
 
 
-def __restartSlurm(hostname, cluster_user):
-    # Connect and restart Slurm on compute node
-    ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    hosts_key_file = os.path.expanduser("~" + cluster_user) + '/.ssh/known_hosts'
-    user_key_file = os.path.expanduser("~" + cluster_user) + '/.ssh/id_rsa'
-    iter=0
-    connected=False
-    while iter < 3 and not connected:
-        try:
-            log.info('Connecting to host: %s iter: %d' % (hostname, iter))
-            ssh.connect(hostname, username=cluster_user, key_filename=user_key_file)
-            connected = True
-        except socket.error, e:
-            log.error('Socket error: %s' % e)
-            time.sleep(10 + iter)
-            iter = iter + 1
-            if iter == 3:
-                log.critical("Unable to connect to host")
-                return
+def _ssh_connect(hostname, cluster_user):
+    log.info("Connecting to host: %s" % (hostname))
+    ssh_client = paramiko.SSHClient()
+    ssh_client.load_system_host_keys()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    user_key_file = os.path.expanduser("~" + cluster_user) + "/.ssh/id_rsa"
+
     try:
-        ssh.load_host_keys(hosts_key_file)
-    except IOError:
-        ssh._host_keys_filename = None
-        pass
-    ssh.save_host_keys(hosts_key_file)
-    command = 'if [ -f /etc/systemd/system/slurmd.service ]; then sudo systemctl restart slurmd.service; else sudo sh -c \"/etc/init.d/slurm restart 2>&1 > /tmp/slurmdstart.log\"; fi'
+        ssh_client.connect(hostname=hostname, username=cluster_user, key_filename=user_key_file)
+    except Exception as e:
+        log.error("Failed when connecting to host %s with error: %s", hostname, e)
+        raise
 
-    stdin, stdout, stderr = ssh.exec_command(command)
-    while not stdout.channel.exit_status_ready():
-        time.sleep(1)
-    ssh.close()
+    return ssh_client
 
 
-def __readNodeList():
-    _config = "/opt/slurm/etc/slurm.conf"
-    nodes = {}
-    with open(_config) as slurm_config:
+@retry(stop_max_attempt_number=3, wait_fixed=10000)
+def _restart_master_node():
+    log.info("Restarting slurm on master node")
+    if os.path.isfile("/etc/systemd/system/slurmctld.service"):
+        command = ["sudo", "systemctl", "restart", "slurmctld.service"]
+    else:
+        command = ["/etc/init.d/slurm", "restart"]
+    try:
+        _run_command(command)
+    except Exception as e:
+        log.error("Failed when restarting slurm daemon on master node with exception %s", e)
+        raise
+
+
+@retry(stop_max_attempt_number=3, wait_fixed=10000)
+def _restart_compute_node(hostname, cluster_user):
+    log.info("Restarting slurm on compute node %s", hostname)
+    ssh_client = _ssh_connect(hostname, cluster_user)
+    command = (
+        "if [ -f /etc/systemd/system/slurmd.service ]; "
+        "then sudo systemctl restart slurmd.service; "
+        'else sudo sh -c "/etc/init.d/slurm restart 2>&1 > /tmp/slurmdstart.log"; fi'
+    )
+    stdin, stdout, stderr = ssh_client.exec_command(command, timeout=15)
+    # This blocks until command completes
+    return_code = stdout.channel.recv_exit_status()
+    if return_code != 0:
+        log.error("Failed when restarting slurmd on compute node %s", hostname)
+    ssh_client.close()
+
+
+def _reconfigure_nodes():
+    log.info("Reconfiguring slurm")
+    command = ["/opt/slurm/bin/scontrol", "reconfigure"]
+    try:
+        _run_command(command)
+    except Exception as e:
+        log.error("Failed when reconfiguring slurm daemon with exception %s", e)
+
+
+def _read_node_list():
+    nodes = []
+    with open(PCLUSTER_NODES_CONFIG) as slurm_config:
         for line in slurm_config:
-            if line.startswith('#PARTITION'):
-                partition = line.split(':')[1].rstrip()
-                dummy_node = slurm_config.next()
-                node_name = slurm_config.next()
-                items = node_name.split(' ')
-                node_line = items[0].split('=')
-                if len(node_line[1]) > 0:
-                    nodes[partition] = node_line[1].split(',')
-                else:
-                    nodes[partition] = []
+            if line.startswith("NodeName") and "dummy-compute" not in line:
+                nodes.append(line)
     return nodes
 
 
-def __writeNodeList(node_list, slots=0):
-    _config = "/opt/slurm/etc/slurm.conf"
+def _write_node_list(node_list, max_cluster_size):
+    dummy_nodes_count = max_cluster_size - len(node_list)
     fh, abs_path = mkstemp()
-    with open(abs_path,'w') as new_file:
-        with open(_config) as slurm_config:
-            for line in slurm_config:
-                if line.startswith('#PARTITION'):
-                    # Involved slurm.conf section
-                    # #PARTITION:compute
-                    # NodeName=dummy-compute Procs=2048 State=UNKNOWN
-                    # NodeName=ip-172-31-6-43,ip-172-31-7-230 Procs=1 State=UNKNOWN
-                    # PartitionName=compute Nodes=dummy-compute,ip-172-31-6-43,ip-172-31-7-230 Default=YES MaxTime=INFINITE State=UP
-                    partition_name = line.split(':')[1].rstrip()
-                    new_file.write(line)
-                    dummy_node_line = slurm_config.next()
-                    new_file.write(dummy_node_line)
-                    dummy_nodes = re.search('NodeName=(dummy.*) Procs.* State.*', dummy_node_line).group(1)
-                    node_names_line = slurm_config.next()
-                    partitions_line = slurm_config.next()
-                    node_names_line_items = node_names_line.split(' ')
-                    if slots == 0:
-                        slots = node_names_line_items[1].split('=')[1].strip()
-                    if len(node_list[partition_name]) > 0:
-                        new_file.write('NodeName=' + ','.join(node_list[partition_name]) + ' Procs=%s' % slots + ' ' + ' '.join(node_names_line_items[2:]))
-                    else:
-                        new_file.write('#NodeName= Procs=%s State=UNKNOWN\n' % slots)
-                    partitions_line_items = partitions_line.split(' ')
-                    new_file.write(partitions_line_items[0] + ' Nodes=' + dummy_nodes + ',' + ','.join(node_list[partition_name]) + " " + ' '.join(partitions_line_items[2:]))
-                else:
-                    new_file.write(line)
+    if dummy_nodes_count > 0:
+        os.write(fh, "NodeName=dummy-compute[1-{0}] CPUs=2048 State=FUTURE\n".format(dummy_nodes_count))
+    for node in node_list:
+        os.write(fh, "{0}".format(node))
+
     os.close(fh)
-    # Remove original file
-    os.remove(_config)
-    # Move new file
-    move(abs_path, _config)
     # Update permissions on new file
-    os.chmod(_config, 0744)
+    os.chmod(abs_path, 0o744)
+    # Move new file
+    move(abs_path, PCLUSTER_NODES_CONFIG)
 
 
-def addHost(hostname, cluster_user, slots):
-    log.info('Adding %s with %s slots' % (hostname, slots))
+def addHost(hostname, cluster_user, slots, max_cluster_size):
+    log.info("Adding %s with %s slots" % (hostname, slots))
 
     # Get the current node list
-    node_list = __readNodeList()
-
+    node_list = _read_node_list()
     # Add new node
-    node_list['compute'].append(hostname)
-    __writeNodeList(node_list, slots)
+    new_node = "NodeName={nodename} CPUs={cpus} State=UNKNOWN\n".format(nodename=hostname, cpus=slots)
+    if new_node not in node_list:
+        node_list.append(new_node)
+    # Write new config
+    _write_node_list(node_list, max_cluster_size)
 
-    # Restart slurmctl locally
-    restartMasterNodeSlurm()
+    _restart_master_node()
+    _restart_compute_node(hostname, cluster_user)
+    _reconfigure_nodes()
 
-    # Restart slurmctl on host
-    __restartSlurm(hostname, cluster_user)
 
-    # Reconfifure Slurm, prompts all compute nodes to reread slurm.conf
-    command = ['/opt/slurm/bin/scontrol', 'reconfigure']
-    __runCommand(command)
-
-def removeHost(hostname, cluster_user):
-    log.info('Removing %s', hostname)
+def removeHost(hostname, cluster_user, max_cluster_size):
+    log.info("Removing %s", hostname)
 
     # Get the current node list
-    node_list = __readNodeList()
-
+    node_list = _read_node_list()
     # Remove node
-    node_list['compute'].remove(hostname)
-    __writeNodeList(node_list)
+    node_list = [node for node in node_list if hostname not in node]
+    # Write new config
+    _write_node_list(node_list, max_cluster_size)
 
-    # Restart slurmctl
-    restartMasterNodeSlurm()
-
-    # Reconfifure Slurm, prompts all compute nodes to reread slurm.conf
-    command = ['/opt/slurm/bin/scontrol', 'reconfigure']
-    __runCommand(command)
-
-
-def restartMasterNodeSlurm():
-    if os.path.isfile('/etc/systemd/system/slurmctld.service'):
-        command = ['sudo', 'systemctl', 'restart', 'slurmctld.service']
-    else:
-        command = ['/etc/init.d/slurm', 'restart']
-    __runCommand(command)
+    _restart_master_node()
+    _reconfigure_nodes()

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -79,7 +79,7 @@ def wakeupSchedOn(hostname):
     else:
         log.debug("Host %s is in state %s" % (hostname, host_state))
 
-def addHost(hostname,cluster_user,slots):
+def addHost(hostname, cluster_user, slots, max_cluster_size):
     log.info('Adding %s with %s slots' % (hostname, slots))
 
     command = ("/opt/torque/bin/qmgr -c 'create node %s np=%s'" % (hostname, slots))
@@ -117,7 +117,7 @@ def addHost(hostname,cluster_user,slots):
 
     wakeupSchedOn(hostname)
 
-def removeHost(hostname, cluster_user):
+def removeHost(hostname, cluster_user, max_cluster_size):
     log.info('Removing %s', hostname)
 
     command = ('/opt/torque/bin/pbsnodes -o %s' % hostname)

--- a/sqswatcher/sqswatcher.cfg
+++ b/sqswatcher/sqswatcher.cfg
@@ -5,3 +5,4 @@ table_name = instances
 scheduler = test
 cluster_user = ec2-user
 proxy = NONE
+max_queue_size = 1


### PR DESCRIPTION
Dynamically manage the number of dummy nodes based on the number of real nodes that join the cluster. 

This patch also adds retries when reloading slurm daemon in order to mitigate the failures due to the high reload frequency which is caused by the sequential update of the nodes.

Additionally this also fixes the issue with slurm config being removed and then recreated without an atomic operation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
