### PR TITLE
Slurm: job dependencies and locking logic

### DIFF
--- a/common/slurm.py
+++ b/common/slurm.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python2.6
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+PENDING_RESOURCES_REASONS = [
+    "Resources",
+    "Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions"
+]

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -44,6 +44,6 @@ def get_busy_nodes(instance_properties):
     output = output.split("\n")
     for line in output:
         line_arr = line.split()
-        if len(line_arr) == 2 and (line_arr[1] == 'mix' or line_arr[1] == 'alloc'):
+        if len(line_arr) == 2 and (line_arr[1] in ['mix', 'alloc', 'drain', 'drain*']):
             nodes += int(line_arr[0])
     return nodes

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -63,4 +63,28 @@ def hasPendingJobs():
 
 
 def lockHost(hostname, unlock=False):
-    pass
+    # hostname format: ip-10-0-0-114.eu-west-1.compute.internal
+    hostname = hostname.split(".")[0]
+    if unlock:
+        log.info("Unlocking host %s", hostname)
+        command = [
+            "/opt/slurm/bin/scontrol",
+            "update",
+            "NodeName={0}".format(hostname),
+            "State=RESUME",
+            'Reason="Unlocking"',
+        ]
+    else:
+        log.info("Locking host %s", hostname)
+        command = [
+            "/opt/slurm/bin/scontrol",
+            "update",
+            "NodeName={0}".format(hostname),
+            "State=DRAIN",
+            'Reason="Shutting down"',
+        ]
+    try:
+        subprocess.check_call(command, env=dict(os.environ))
+    except subprocess.CalledProcessError as e:
+        # CalledProcessError.__str__ already produces a significant error message
+        log.error(e)


### PR DESCRIPTION
* Implement locking/unlocking logic for Slurm compute nodes
* Added logic to use pending job reason when computing the number of nodes needed to serve all submitted jobs. This fixes the following:
  * when a job is pending because a dependency the cluster won’t scale up
  * when a job exceeds the number of max nodes supported by the cluster (max_queue_size configured by the user) the cluster won’t scale up. Currently what we do is to set the ASG at the max although the job would never be scheduled.
* Check pending jobs in scheduler queue before locking the compute node and checking running job on the specific host. This solves the following issue:
  * nodewatcher locks the host to check for pending and running jobs
  * in the meanwhile jobwatcher checks if cluster requires scaling, sees the nodes as locked (terminating), and requires additional capacity.
  * nodewatcher unlocks the host since it finds pending jobs in the queue.  
* Remove code to handle unregistered "EC2 Instance State-change Notification" CW event. This code was also bugged and had some dead code branches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
