### PR TITLE
jobwatcher: correctly raise CalledProcessError when running shell commands

### DIFF
--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -1,14 +1,16 @@
 import logging
-import json
-from utils import run_command
+
+from utils import check_command_output
 
 log = logging.getLogger(__name__)
+
 
 # get nodes requested from pending jobs
 def get_required_nodes(instance_properties):
     command = "/opt/sge/bin/lx-amd64/qstat -g d -s p -u '*'"
-    _output = run_command(command, {'SGE_ROOT': '/opt/sge',
-                                    'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'})
+    _output = check_command_output(
+        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}
+    )
     slots = 0
     output = _output.split("\n")[2:]
     for line in output:
@@ -18,12 +20,14 @@ def get_required_nodes(instance_properties):
     vcpus = instance_properties.get('slots')
     return -(-slots // vcpus)
 
+
 # get nodes reserved by running jobs
 # if a host has 1 or more job running on it, it'll be marked busy
 def get_busy_nodes(instance_properties):
     command = "/opt/sge/bin/lx-amd64/qstat -f"
-    _output = run_command(command, {'SGE_ROOT': '/opt/sge',
-                                    'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'})
+    _output = check_command_output(
+        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}
+    )
     nodes = 0
     output = _output.split("\n")[2:]
     for line in output:

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -1,7 +1,7 @@
 import logging
 
 from common.slurm import PENDING_RESOURCES_REASONS
-from utils import run_command, get_optimal_nodes
+from utils import check_command_output, get_optimal_nodes
 
 
 log = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ def get_required_nodes(instance_properties):
     # 2-PD-1-24-Licenses
     # 3-PD-1-24-PartitionNodeLimit
     # 4-R-1-24-
-    output = run_command(command, {})
+    output = check_command_output(command, {})
     slots_requested = []
     nodes_requested = []
     output = output.split("\n")
@@ -39,7 +39,7 @@ def get_busy_nodes(instance_properties):
     # 2 mix
     # 4 alloc
     # 10 idle
-    output = run_command(command, {})
+    output = check_command_output(command, {})
     nodes = 0
     output = output.split("\n")
     for line in output:

--- a/jobwatcher/plugins/torque.py
+++ b/jobwatcher/plugins/torque.py
@@ -1,8 +1,10 @@
 import logging
-import xml.etree.ElementTree as ET
-from utils import run_command, get_optimal_nodes
+from xml.etree import ElementTree
+
+from utils import check_command_output, get_optimal_nodes
 
 log = logging.getLogger(__name__)
+
 
 # get nodes requested from pending jobs
 def get_required_nodes(instance_properties):
@@ -17,7 +19,7 @@ def get_required_nodes(instance_properties):
     # 2.ip-172-31-11-1.ec2.i  centos      batch    job.sh             5387     2      4       --   01:00:00 R  00:08:27
 
     status = ['Q']
-    _output = run_command(command, {})
+    _output = check_command_output(command, {})
     output = _output.split("\n")[5:]
     slots_requested = []
     nodes_requested = []
@@ -49,8 +51,8 @@ def get_busy_nodes(instance_properties):
     #       <mom_manager_port>15003</mom_manager_port>
     #    </Node>
     # </Data>
-    _output = run_command(command, {})
-    root = ET.fromstring(_output)
+    _output = check_command_output(command, {})
+    root = ElementTree.fromstring(_output)
     count = 0
     # See how many nodes have jobs
     for node in root.findall('Node'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ boto3>=1.7.55
 paramiko>=2.4.2
 python-dateutil>=2.6.1
 retrying>=1.3.3
-future
+future>=0.17.1

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -3,4 +3,4 @@ idna==2.6
 paramiko==2.3.3
 cryptography==2.1.4
 retrying>=1.3.3
-future
+future>=0.17.1

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,13 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-console_scripts = ['sqswatcher = sqswatcher.sqswatcher:main',
-                   'nodewatcher = nodewatcher.nodewatcher:main',
-                   'jobwatcher = jobwatcher.jobwatcher:main']
+console_scripts = [
+    'sqswatcher = sqswatcher.sqswatcher:main',
+    'nodewatcher = nodewatcher.nodewatcher:main',
+    'jobwatcher = jobwatcher.jobwatcher:main',
+]
 version = "2.2.1"
-requires = ['boto3>=1.7.55', 'python-dateutil>=2.6.1', 'retrying>=1.3.3', 'future']
+requires = ['boto3>=1.7.55', 'python-dateutil>=2.6.1', 'retrying>=1.3.3', 'future>=0.17.1']
 
 if sys.version_info[:2] == (2, 6):
     # For python2.6 we have to require argparse since it


### PR DESCRIPTION
+ `Popen` is not enough to raise the CalledProcessError, we need to call the `check_output` method.
  NOTE: I'm importing it from `future.moves.subprocess` to support python **2.6**
+ Use `with` statement to manage devnull file.
+ Rename `run_command` to `check_command_output`

Sources:
https://docs.python.org/2/library/subprocess.html#exceptions
http://python-future.org/compatible_idioms.html#subprocess-check-output