### PR TITLE
Parallel processing of SQS messages

### DIFF
--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -9,10 +9,12 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-import subprocess
+from future.moves.subprocess import check_output
+
 import logging
-import shlex
 import os
+import shlex
+import subprocess
 
 from common.slurm import PENDING_RESOURCES_REASONS
 
@@ -23,7 +25,7 @@ def _run_command(command):
     try:
         if isinstance(command, str):
             command = shlex.split(command)
-        return subprocess.check_output(command, env=dict(os.environ), universal_newlines=True)
+        return check_output(command, env=dict(os.environ), universal_newlines=True)
     except subprocess.CalledProcessError as e:
         # CalledProcessError.__str__ already produces a significant error message
         log.error(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3>=1.7.55
 paramiko>=2.4.2
 python-dateutil>=2.6.1
 retrying>=1.3.3
+future

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -3,3 +3,4 @@ idna==2.6
 paramiko==2.3.3
 cryptography==2.1.4
 retrying>=1.3.3
+future

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ console_scripts = ['sqswatcher = sqswatcher.sqswatcher:main',
                    'nodewatcher = nodewatcher.nodewatcher:main',
                    'jobwatcher = jobwatcher.jobwatcher:main']
 version = "2.2.1"
-requires = ['boto3>=1.7.55', 'python-dateutil>=2.6.1', 'retrying>=1.3.3']
+requires = ['boto3>=1.7.55', 'python-dateutil>=2.6.1', 'retrying>=1.3.3', 'future']
 
 if sys.version_info[:2] == (2, 6):
     # For python2.6 we have to require argparse since it

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -178,3 +178,25 @@ def removeHost(hostname, cluster_user, max_cluster_size):
         _run_sge_command(command, raise_exception=True)
     else:
         log.info('Host %s is not submission host', hostname)
+
+
+def update_cluster_nodes(max_cluster_size, cluster_user, update_events):
+    failed = []
+    succeeded = []
+    for event in update_events:
+        try:
+            if event.action == "REMOVE":
+                removeHost(event.host.hostname, cluster_user, max_cluster_size)
+            elif event.action == "ADD":
+                addHost(event.host.hostname, cluster_user, event.host.slots, max_cluster_size)
+            succeeded.append(event)
+        except Exception as e:
+            log.error(
+                "Encountered error when processing %s event for host %s: %s",
+                event.action,
+                event.host.hostname,
+                e,
+            )
+            failed.append(event)
+
+    return failed, succeeded

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -180,7 +180,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
         log.info('Host %s is not submission host', hostname)
 
 
-def update_cluster_nodes(max_cluster_size, cluster_user, update_events):
+def update_cluster(max_cluster_size, cluster_user, update_events):
     failed = []
     succeeded = []
     for event in update_events:

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -146,3 +146,25 @@ def removeHost(hostname, cluster_user, max_cluster_size):
 
     _restart_master_node()
     _reconfigure_nodes()
+
+
+def update_cluster_nodes(max_cluster_size, cluster_user, update_events):
+    failed = []
+    succeeded = []
+    for event in update_events:
+        try:
+            if event.action == "REMOVE":
+                removeHost(event.host.hostname, cluster_user, max_cluster_size)
+            elif event.action == "ADD":
+                addHost(event.host.hostname, cluster_user, event.host.slots, max_cluster_size)
+            succeeded.append(event)
+        except Exception as e:
+            log.error(
+                "Encountered error when processing %s event for host %s: %s",
+                event.action,
+                event.host.hostname,
+                e,
+            )
+            failed.append(event)
+
+    return failed, succeeded

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -142,37 +142,6 @@ def _write_node_list(node_list, max_cluster_size):
     move(abs_path, PCLUSTER_NODES_CONFIG)
 
 
-def addHost(hostname, cluster_user, slots, max_cluster_size):
-    log.info("Adding %s with %s slots" % (hostname, slots))
-
-    # Get the current node list
-    node_list = _read_node_list()
-    # Add new node
-    new_node = "NodeName={nodename} CPUs={cpus} State=UNKNOWN\n".format(nodename=hostname, cpus=slots)
-    if new_node not in node_list:
-        node_list.append(new_node)
-    # Write new config
-    _write_node_list(node_list, max_cluster_size)
-
-    _restart_master_node()
-    _restart_compute_node(hostname, cluster_user)
-    _reconfigure_nodes()
-
-
-def removeHost(hostname, cluster_user, max_cluster_size):
-    log.info("Removing %s", hostname)
-
-    # Get the current node list
-    node_list = _read_node_list()
-    # Remove node
-    node_list = [node for node in node_list if hostname not in node]
-    # Write new config
-    _write_node_list(node_list, max_cluster_size)
-
-    _restart_master_node()
-    _reconfigure_nodes()
-
-
 def update_cluster_nodes(max_cluster_size, cluster_user, update_events):
     # Get the current node list
     node_list = _read_node_list()

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -70,7 +70,7 @@ def _restart_master_node():
 
 
 @retry(stop_max_attempt_number=3, wait_fixed=10000)
-def _restart_compute_node(hostname, cluster_user):
+def _restart_compute_daemons(hostname, cluster_user):
     log.info("Restarting slurm on compute node %s", hostname)
     ssh_client = _ssh_connect(hostname, cluster_user)
     command = (
@@ -89,7 +89,7 @@ def _restart_compute_node(hostname, cluster_user):
 def _restart_compute_node_worker(args):
     hostname = args[0]
     try:
-        _restart_compute_node(*args)
+        _restart_compute_daemons(*args)
         return hostname, True
     except Exception:
         return hostname, False
@@ -142,7 +142,7 @@ def _write_node_list(node_list, max_cluster_size):
     move(abs_path, PCLUSTER_NODES_CONFIG)
 
 
-def update_cluster_nodes(max_cluster_size, cluster_user, update_events):
+def update_cluster(max_cluster_size, cluster_user, update_events):
     # Get the current node list
     node_list = _read_node_list()
     nodes_to_restart = []

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -126,3 +126,24 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     command = ("/opt/torque/bin/qmgr -c 'delete node %s'" % hostname)
     __runCommand(command)
 
+
+def update_cluster_nodes(max_cluster_size, cluster_user, update_events):
+    failed = []
+    succeeded = []
+    for event in update_events:
+        try:
+            if event.action == "REMOVE":
+                removeHost(event.host.hostname, cluster_user, max_cluster_size)
+            elif event.action == "ADD":
+                addHost(event.host.hostname, cluster_user, event.host.slots, max_cluster_size)
+            succeeded.append(event)
+        except Exception as e:
+            log.error(
+                "Encountered error when processing %s event for host %s: %s",
+                event.action,
+                event.host.hostname,
+                e,
+            )
+            failed.append(event)
+
+    return failed, succeeded

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -127,7 +127,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     __runCommand(command)
 
 
-def update_cluster_nodes(max_cluster_size, cluster_user, update_events):
+def update_cluster(max_cluster_size, cluster_user, update_events):
     failed = []
     succeeded = []
     for event in update_events:

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -206,10 +206,11 @@ def _parse_sqs_messages(messages, sqs_config, table):
             update_event = None
 
         if update_event:
-            if instance_id in update_events:
+            hostname = update_event.host.hostname
+            if hostname in update_events:
                 # delete first to preserve messages order in dict
-                del update_events[instance_id]
-            update_events[instance_id] = update_event
+                del update_events[hostname]
+            update_events[hostname] = update_event
         else:
             # discarding message
             log.warning("Discarding message %s", message)

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -268,7 +268,7 @@ def _process_sqs_messages(update_events, scheduler_module, sqs_config, table, qu
     if not update_events:
         return
 
-    failed_events, succeeded_events = scheduler_module.update_cluster_nodes(
+    failed_events, succeeded_events = scheduler_module.update_cluster(
         sqs_config.max_queue_size, sqs_config.cluster_user, update_events
     )
 


### PR DESCRIPTION
* SQS messages are now processed in batches of up to 50 messages
* SLURM: update of scheduler nodes is also performed in batches
  * Slurm daemon is restarted on up to 10 compute nodes at a time
* Error handling messages was heavily refactored and improved. Messages for nodes that failed to be processed are re-queued at the end of the queue.

Performed some benchmarking of the improvements for Slurm:
* Schedulers sees all nodes after ASG has scaled up completely with a delay of
  * **NEW CODE** < 2 mins => **4.5 times faster**
  * **OLD CODE** < 9 mins
* Schedulers sees 0 nodes after ASG has scaled down completely with a delay of
  * **NEW CODE** < 1 mins => **15 times faster**
  * **OLD CODE** < 15 mins (also this time grows linearly with the number of nodes)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
