### PR TITLE
Sqswatcher: dynamically update cluster size and remove calls to describe_instances

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -67,3 +67,18 @@ def get_asg_name(stack_name, region, proxy_config, log, attempts=4, delay=30):
                 raise ASGNotFoundError("Unable to get ASG for stack %s" % stack_name)
         except Exception as e:
             raise ASGNotFoundError("Unable to get ASG for stack %s. Failed with exception: %s" % (stack_name, e))
+
+
+def get_asg_settings(region, proxy_config, asg_name, log):
+    try:
+        asg_client = boto3.client("autoscaling", region_name=region, config=proxy_config)
+        asg = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name]).get('AutoScalingGroups')[0]
+        min_size = asg.get('MinSize')
+        desired_capacity = asg.get('DesiredCapacity')
+        max_size = asg.get('MaxSize')
+
+        log.info("min/desired/max %d/%d/%d" % (min_size, desired_capacity, max_size))
+        return min_size, desired_capacity, max_size
+    except Exception as e:
+        log.error("Failed when retrieving data for ASG %s with exception %s", asg_name, e)
+        raise

--- a/sqswatcher/sqswatcher.cfg
+++ b/sqswatcher/sqswatcher.cfg
@@ -6,3 +6,4 @@ scheduler = test
 cluster_user = ec2-user
 proxy = NONE
 max_queue_size = 1
+stack_name = test

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -143,7 +143,7 @@ def _setup_ddb_table(region, table_name, proxy_config):
 
 def _retry_on_request_limit_exceeded(func):
     @retry(
-        stop_max_attempt_number=3,
+        stop_max_attempt_number=5,
         wait_exponential_multiplier=5000,
         retry_on_exception=lambda exception: isinstance(exception, ClientError)
         and exception.response.get("Error").get("Code") == "RequestLimitExceeded",
@@ -251,6 +251,8 @@ def _process_instance_terminate_event(message_attrs, message, table):
 def _process_sqs_messages(
     update_events, scheduler_module, sqs_config, table, queue, max_cluster_size, update_max_cluster_size
 ):
+    # Update the scheduler only when there are messages from the queue or
+    # tha ASG max size got updated.
     if not update_events and not update_max_cluster_size:
         return
 


### PR DESCRIPTION
* Dynamically update the number of configured dummy nodes by retrieving the max capacity from ASG
  * This allows to change cluster size in ASG console or with an update
* Retrieve compute ready from SQS message and drop expensive call to ec2.describe_instances
  * This brought an additional improvements in the scaling speed: the scheduler is able to follow the state of the ASG with a delay of less than 1 minute during both scale-up and scale-down. (tested with a cluster of 200 nodes)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
