### PR TITLE
Avoid daemon crashing

### DIFF
--- a/common/sge.py
+++ b/common/sge.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python2.6
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+from common.utils import check_command_output, run_command
+
+SGE_ROOT = "/opt/sge"
+SGE_BIN_PATH = SGE_ROOT + "/bin/lx-amd64"
+SGE_BIN_DIR = SGE_BIN_PATH + "/"
+SGE_ENV = {"SGE_ROOT": SGE_ROOT, "PATH": "{0}/bin:{1}:/bin:/usr/bin".format(SGE_ROOT, SGE_BIN_PATH)}
+
+
+def check_sge_command_output(command, log):
+    """
+    Execute SGE shell command, by exporting the appropriate environment.
+
+    :param command: command to execute
+    :param log: logger
+    :raise: subprocess.CalledProcessError if the command fails
+    """
+    if isinstance(command, str) or isinstance(command, unicode):
+        command = SGE_BIN_DIR + command
+    else:
+        command = [SGE_BIN_DIR] + command
+    return check_command_output(command, SGE_ENV, log)
+
+
+def run_sge_command(command, log):
+    """
+    Execute SGE shell command, by exporting the appropriate environment.
+
+    :param command: command to execute
+    :param log: logger
+    :raise: subprocess.CalledProcessError if the command fails
+    """
+    if isinstance(command, str) or isinstance(command, unicode):
+        command = SGE_BIN_DIR + command
+    else:
+        command = [SGE_BIN_DIR] + command
+    run_command(command, SGE_ENV, log)
+

--- a/common/sge.py
+++ b/common/sge.py
@@ -32,7 +32,7 @@ def check_sge_command_output(command, log):
         command = SGE_BIN_DIR + command
     else:
         command = [SGE_BIN_DIR] + command
-    return check_command_output(command, SGE_ENV, log)
+    return check_command_output(command, log, SGE_ENV)
 
 
 def run_sge_command(command, log):
@@ -47,5 +47,5 @@ def run_sge_command(command, log):
         command = SGE_BIN_DIR + command
     else:
         command = [SGE_BIN_DIR] + command
-    run_command(command, SGE_ENV, log)
+    run_command(command, log, SGE_ENV)
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -22,6 +22,11 @@ class ASGNotFoundError(Exception):
     pass
 
 
+class CriticalError(Exception):
+    """Critical error for the daemon."""
+    pass
+
+
 def load_module(module):
     """
     Load python module.

--- a/common/utils.py
+++ b/common/utils.py
@@ -85,7 +85,7 @@ def get_asg_settings(region, proxy_config, asg_name, log):
         raise
 
 
-def check_command_output(command, env, log):
+def check_command_output(command, log, env=None):
     """
     Execute shell command and retrieve command output.
 
@@ -98,6 +98,9 @@ def check_command_output(command, env, log):
     try:
         if isinstance(command, str) or isinstance(command, unicode):
             command = shlex.split(command.encode("ascii"))
+        if env is None:
+            env = {}
+
         env.update(os.environ.copy())
         log.debug("Executing command: %s" % command)
         return check_output(command, env=env, stderr=subprocess.STDOUT, universal_newlines=True)
@@ -110,7 +113,7 @@ def check_command_output(command, env, log):
         raise
 
 
-def run_command(command, env, log):
+def run_command(command, log, env=None):
     """
     Execute shell command.
 
@@ -122,6 +125,9 @@ def run_command(command, env, log):
     try:
         if isinstance(command, str) or isinstance(command, unicode):
             command = shlex.split(command.encode("ascii"))
+        if env is None:
+            env = {}
+
         env.update(os.environ.copy())
         log.debug("Executing command: %s" % command)
         subprocess.check_call(command, env=env)

--- a/common/utils.py
+++ b/common/utils.py
@@ -44,6 +44,7 @@ def load_module(module):
 @retry(
     stop_max_attempt_number=5,
     wait_exponential_multiplier=10000,
+    wait_exponential_max=80000,
     retry_on_exception=lambda exception: isinstance(exception, IndexError)
 )
 def get_asg_name(stack_name, region, proxy_config, log):

--- a/common/utils.py
+++ b/common/utils.py
@@ -13,13 +13,9 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import sys
-import time
 
 import boto3
-
-
-class ASGNotFoundError(Exception):
-    pass
+from retrying import retry
 
 
 class CriticalError(Exception):
@@ -41,7 +37,12 @@ def load_module(module):
     return scheduler_module
 
 
-def get_asg_name(stack_name, region, proxy_config, log, attempts=4, delay=30):
+@retry(
+    stop_max_attempt_number=5,
+    wait_exponential_multiplier=10000,
+    retry_on_exception=lambda exception: isinstance(exception, IndexError)
+)
+def get_asg_name(stack_name, region, proxy_config, log):
     """
     Get autoscaling group name associated to the given stack.
 
@@ -49,29 +50,20 @@ def get_asg_name(stack_name, region, proxy_config, log, attempts=4, delay=30):
     :param region: AWS region
     :param proxy_config: Proxy configuration
     :param log: logger
-    :param attempts: the number of times to try before giving up if the ASG is not yet ready
-    :param delay: delay between retries in seconds
     :raise ASGNotFoundError if the ASG is not found (after the timeout) or if an unexpected error occurs
     :return: the ASG name
     """
     asg_client = boto3.client("autoscaling", region_name=region, config=proxy_config)
-
-    count = 0
-    while True:
-        try:
-            response = asg_client.describe_tags(Filters=[{"Name": "Value", "Values": [stack_name]}])
-            asg_name = response.get("Tags")[0].get("ResourceId")
-            log.info("ASG %s found for the stack %s", asg_name, stack_name)
-            return asg_name
-        except IndexError:
-            if count < attempts:
-                log.warning("No ASG found for stack %s, waiting %s seconds...", stack_name, delay)
-                time.sleep(delay)
-                count += 1
-            else:
-                raise ASGNotFoundError("Unable to get ASG for stack %s" % stack_name)
-        except Exception as e:
-            raise ASGNotFoundError("Unable to get ASG for stack %s. Failed with exception: %s" % (stack_name, e))
+    try:
+        response = asg_client.describe_tags(Filters=[{"Name": "Value", "Values": [stack_name]}])
+        asg_name = response.get("Tags")[0].get("ResourceId")
+        log.info("ASG %s found for the stack %s", asg_name, stack_name)
+        return asg_name
+    except IndexError:
+        log.warning("Unable to get ASG for stack %s", stack_name)
+        raise
+    except Exception as e:
+        raise CriticalError("Unable to get ASG for stack {0}. Failed with exception: {1}".format(stack_name, e))
 
 
 def get_asg_settings(region, proxy_config, asg_name, log):

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -258,19 +258,13 @@ def _poll_scheduler_status(config, asg_name, scheduler_module, instance_properti
 
 @retry()
 def main():
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
     log.info("jobwatcher startup")
     try:
         config = _get_config()
         asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config, log)
-
-        # get instance properties
         instance_properties = _get_instance_properties(config)
 
-        # load scheduler
         scheduler_module = load_module("jobwatcher.plugins." + config.scheduler)
 
         _poll_scheduler_status(config, asg_name, scheduler_module, instance_properties)

--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -1,16 +1,14 @@
 import logging
 
-from common.utils import check_command_output
+from common.sge import check_sge_command_output
 
 log = logging.getLogger(__name__)
 
 
 # get nodes requested from pending jobs
 def get_required_nodes(instance_properties):
-    command = "/opt/sge/bin/lx-amd64/qstat -g d -s p -u '*'"
-    _output = check_command_output(
-        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}, log
-    )
+    command = "qstat -g d -s p -u '*'"
+    _output = check_sge_command_output(command, log)
     slots = 0
     output = _output.split("\n")[2:]
     for line in output:
@@ -24,10 +22,8 @@ def get_required_nodes(instance_properties):
 # get nodes reserved by running jobs
 # if a host has 1 or more job running on it, it'll be marked busy
 def get_busy_nodes(instance_properties):
-    command = "/opt/sge/bin/lx-amd64/qstat -f"
-    _output = check_command_output(
-        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}, log
-    )
+    command = "qstat -f"
+    _output = check_sge_command_output(command, log)
     nodes = 0
     output = _output.split("\n")[2:]
     for line in output:

--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -1,6 +1,6 @@
 import logging
 
-from utils import check_command_output
+from common.utils import check_command_output
 
 log = logging.getLogger(__name__)
 
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 def get_required_nodes(instance_properties):
     command = "/opt/sge/bin/lx-amd64/qstat -g d -s p -u '*'"
     _output = check_command_output(
-        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}
+        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}, log
     )
     slots = 0
     output = _output.split("\n")[2:]
@@ -26,7 +26,7 @@ def get_required_nodes(instance_properties):
 def get_busy_nodes(instance_properties):
     command = "/opt/sge/bin/lx-amd64/qstat -f"
     _output = check_command_output(
-        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}
+        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}, log
     )
     nodes = 0
     output = _output.split("\n")[2:]

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -1,8 +1,8 @@
 import logging
 
 from common.slurm import PENDING_RESOURCES_REASONS
-from utils import check_command_output, get_optimal_nodes
-
+from common.utils import check_command_output
+from utils import get_optimal_nodes
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def get_required_nodes(instance_properties):
     # 2-PD-1-24-Licenses
     # 3-PD-1-24-PartitionNodeLimit
     # 4-R-1-24-
-    output = check_command_output(command, {})
+    output = check_command_output(command, {}, log)
     slots_requested = []
     nodes_requested = []
     output = output.split("\n")
@@ -39,7 +39,7 @@ def get_busy_nodes(instance_properties):
     # 2 mix
     # 4 alloc
     # 10 idle
-    output = check_command_output(command, {})
+    output = check_command_output(command, {}, log)
     nodes = 0
     output = output.split("\n")
     for line in output:

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -16,7 +16,7 @@ def get_required_nodes(instance_properties):
     # 2-PD-1-24-Licenses
     # 3-PD-1-24-PartitionNodeLimit
     # 4-R-1-24-
-    output = check_command_output(command, {}, log)
+    output = check_command_output(command, log)
     slots_requested = []
     nodes_requested = []
     output = output.split("\n")
@@ -39,7 +39,7 @@ def get_busy_nodes(instance_properties):
     # 2 mix
     # 4 alloc
     # 10 idle
-    output = check_command_output(command, {}, log)
+    output = check_command_output(command, log)
     nodes = 0
     output = output.split("\n")
     for line in output:

--- a/jobwatcher/plugins/torque.py
+++ b/jobwatcher/plugins/torque.py
@@ -1,7 +1,8 @@
 import logging
 from xml.etree import ElementTree
 
-from utils import check_command_output, get_optimal_nodes
+from common.utils import check_command_output
+from utils import get_optimal_nodes
 
 log = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def get_required_nodes(instance_properties):
     # 2.ip-172-31-11-1.ec2.i  centos      batch    job.sh             5387     2      4       --   01:00:00 R  00:08:27
 
     status = ['Q']
-    _output = check_command_output(command, {})
+    _output = check_command_output(command, {}, log)
     output = _output.split("\n")[5:]
     slots_requested = []
     nodes_requested = []
@@ -51,7 +52,7 @@ def get_busy_nodes(instance_properties):
     #       <mom_manager_port>15003</mom_manager_port>
     #    </Node>
     # </Data>
-    _output = check_command_output(command, {})
+    _output = check_command_output(command, {}, log)
     root = ElementTree.fromstring(_output)
     count = 0
     # See how many nodes have jobs

--- a/jobwatcher/plugins/torque.py
+++ b/jobwatcher/plugins/torque.py
@@ -20,7 +20,7 @@ def get_required_nodes(instance_properties):
     # 2.ip-172-31-11-1.ec2.i  centos      batch    job.sh             5387     2      4       --   01:00:00 R  00:08:27
 
     status = ['Q']
-    _output = check_command_output(command, {}, log)
+    _output = check_command_output(command, log)
     output = _output.split("\n")[5:]
     slots_requested = []
     nodes_requested = []
@@ -52,7 +52,7 @@ def get_busy_nodes(instance_properties):
     #       <mom_manager_port>15003</mom_manager_port>
     #    </Node>
     # </Data>
-    _output = check_command_output(command, {}, log)
+    _output = check_command_output(command, log)
     root = ElementTree.fromstring(_output)
     count = 0
     # See how many nodes have jobs

--- a/jobwatcher/plugins/utils.py
+++ b/jobwatcher/plugins/utils.py
@@ -1,29 +1,6 @@
 import logging
-import os
-import shlex
-import subprocess
-
-from future.moves.subprocess import check_output
 
 log = logging.getLogger(__name__)
-
-
-def check_command_output(command, env):
-    """
-    Execute shell command and retrieve command output.
-
-    :param command: command to execute
-    :param env: a dictionary containing environment variables
-    :return: the command output
-    """
-    try:
-        env.update(os.environ.copy())
-        log.debug("Executing command: %s" % command)
-        return check_output(shlex.split(command), env=env, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as e:
-        # CalledProcessError.__str__ already produces a significant error message
-        log.error(e)
-        raise
 
 
 def get_optimal_nodes(nodes_requested, slots_requested, instance_properties):

--- a/jobwatcher/plugins/utils.py
+++ b/jobwatcher/plugins/utils.py
@@ -17,11 +17,9 @@ def check_command_output(command, env):
     :return: the command output
     """
     try:
-        with open(os.devnull, "rb") as devnull:
-            env.update(os.environ.copy())
-            log.debug("Executing command: %s" % command)
-            # /dev/null to stdin redirect is used to detach the command process from the daemon one
-            return check_output(shlex.split(command), env=env, stderr=subprocess.STDOUT, stdin=devnull)
+        env.update(os.environ.copy())
+        log.debug("Executing command: %s" % command)
+        return check_output(shlex.split(command), env=env, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         # CalledProcessError.__str__ already produces a significant error message
         log.error(e)

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -286,10 +286,7 @@ def _poll_instance_status(config, scheduler_module, asg_name, hostname, instance
 
 @retry()
 def main():
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
     log.info("nodewatcher startup")
     try:
         config = _get_config()

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -17,7 +17,6 @@ import collections
 import json
 import logging
 import os
-import sys
 import time
 import urllib2
 
@@ -25,7 +24,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-from common.utils import get_asg_name, load_module
+from common.utils import CriticalError, get_asg_name, load_module
 
 log = logging.getLogger(__name__)
 
@@ -77,8 +76,9 @@ def _get_metadata(metadata_path):
     try:
         metadata_value = urllib2.urlopen("http://169.254.169.254/latest/meta-data/{0}".format(metadata_path)).read()
     except urllib2.URLError:
-        log.critical("Unable to get {0} metadata".format(metadata_path))
-        sys.exit(1)
+        error_msg = "Unable to get {0} metadata".format(metadata_path)
+        log.critical(error_msg)
+        raise CriticalError(error_msg)
 
     log.debug("%s=%s", metadata_path, metadata_value)
     return metadata_value

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -24,7 +24,7 @@ def hasJobs(hostname):
     # Checking for running jobs on the node
     command = ['/opt/slurm/bin/squeue', '-w', short_name, '-h']
     try:
-        output = check_command_output(command, {}, log)
+        output = check_command_output(command, log)
         has_jobs = output != ""
     except subprocess.CalledProcessError:
         has_jobs = False
@@ -40,7 +40,7 @@ def hasPendingJobs():
     #  Priority
     #  PartitionNodeLimit
     try:
-        output = check_command_output(command, {}, log)
+        output = check_command_output(command, log)
         has_pending = len(filter(lambda reason: reason in PENDING_RESOURCES_REASONS, output.split("\n"))) > 0
         error = False
     except subprocess.CalledProcessError:
@@ -72,6 +72,6 @@ def lockHost(hostname, unlock=False):
             'Reason="Shutting down"',
         ]
     try:
-        run_command(command, {}, log)
+        run_command(command, log)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -58,7 +58,7 @@ def hasPendingJobs():
     # batch                0     24   yes   yes    24     0     0     0     0     0 E     0
     # test1                0     26   yes   yes    26     0     0     0     0     0 E     0
     try:
-        output = check_command_output(command, {}, log)
+        output = check_command_output(command, log)
         lines = filter(None, output.split("\n"))
         if len(lines) < 3:
             log.error("Unable to check pending jobs. The command '%s' does not return a valid output", command)
@@ -85,6 +85,6 @@ def lockHost(hostname, unlock=False):
     mod = unlock and '-c' or '-o'
     command = ['/opt/torque/bin/pbsnodes', mod, hostname]
     try:
-        run_command(command, {}, log)
+        run_command(command, log)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -9,12 +9,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-__author__ = 'dougalb'
-
-import subprocess
-import os
 import logging
-import shlex
+import subprocess
+
+from common.utils import CriticalError, check_command_output, run_command
 
 log = logging.getLogger(__name__)
 
@@ -43,16 +41,12 @@ def hasJobs(hostname):
     commands = ['/opt/torque/bin/qstat -r -t -n -1', ('grep ' + hostname.split('.')[0])]
     try:
         status, output = runPipe(commands)
+        has_jobs = output != ""
     except subprocess.CalledProcessError:
         log.error("Failed to run %s\n" % commands)
-        output = ""
+        has_jobs = False
 
-    if output == "":
-        _jobs = False
-    else:
-        _jobs = True
-
-    return _jobs
+    return has_jobs
 
 
 def hasPendingJobs():
@@ -63,41 +57,34 @@ def hasPendingJobs():
     # ----------------   ---   ----    --    --   ---   ---   ---   ---   ---   --- -   ---
     # batch                0     24   yes   yes    24     0     0     0     0     0 E     0
     # test1                0     26   yes   yes    26     0     0     0     0     0 E     0
-
-    _command = shlex.split(command)
-    error = False
-    has_pending = False
     try:
-        process = subprocess.Popen(_command, env=dict(os.environ),
-                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError:
-        log.error("Failed to run %s\n" % command)
+        output = check_command_output(command, {}, log)
+        lines = filter(None, output.split("\n"))
+        if len(lines) < 3:
+            log.error("Unable to check pending jobs. The command '%s' does not return a valid output", command)
+            raise CriticalError
+
+        pending = 0
+        for idx, line in enumerate(lines):
+            if idx < 2:
+                continue
+            queue_status = line.split()
+            pending += int(queue_status[5])
+
+        has_pending = pending > 0
+        error = False
+    except (subprocess.CalledProcessError, CriticalError):
         error = True
-
-    output = process.communicate()[0]
-
-    lines = filter(None, output.split("\n"))
-    if len(lines) < 3:
-        error = True
-        return has_pending, error
-    pending = 0
-    for idx, line in enumerate(lines):
-        if idx < 2:
-            continue
-        queue_status = line.split()
-        pending += int(queue_status[5])
-
-    has_pending = pending > 0
+        has_pending = False
 
     return has_pending, error
 
 
 def lockHost(hostname, unlock=False):
     # https://lists.sdsc.edu/pipermail/npaci-rocks-discussion/2007-November/027919.html
-    _mod = unlock and '-c' or '-o'
-    command = ['/opt/torque/bin/pbsnodes', _mod, hostname]
+    mod = unlock and '-c' or '-o'
+    command = ['/opt/torque/bin/pbsnodes', mod, hostname]
     try:
-        subprocess.check_call(command)
+        run_command(command, {}, log)
     except subprocess.CalledProcessError:
-        log.error("Failed to run %s\n" % command)
-
+        log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -18,15 +18,14 @@ from tempfile import NamedTemporaryFile
 
 import paramiko
 
-from common.utils import check_command_output, run_command
+import common.sge as sge
+from common.sge import check_sge_command_output, run_sge_command
 
 log = logging.getLogger(__name__)
 
 
 def _is_host_configured(command, hostname):
-    output = check_command_output(
-        command, {'SGE_ROOT': '/opt/sge', 'PATH': '/opt/sge/bin:/opt/sge/bin/lx-amd64:/bin:/usr/bin'}, log
-    )
+    output = check_sge_command_output(command, log)
     # Expected output
     # ip-172-31-66-16.ec2.internal
     # ip-172-31-74-69.ec2.internal
@@ -39,15 +38,15 @@ def addHost(hostname, cluster_user, slots, max_cluster_size):
 
     # Adding host as administrative host
     try:
-        command = ("/opt/sge/bin/lx-amd64/qconf -ah %s" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -ah %s" % hostname)
+        run_sge_command(command, log)
     except subprocess.CalledProcessError:
         log.warning("Unable to add host %s as administrative host", hostname)
 
     # Adding host as submit host
     try:
-        command = ("/opt/sge/bin/lx-amd64/qconf -as %s" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -as %s" % hostname)
+        run_sge_command(command, log)
     except subprocess.CalledProcessError:
         log.warning("Unable to add host %s as submission host", hostname)
 
@@ -64,15 +63,15 @@ report_variables      NONE
 """
 
     with NamedTemporaryFile() as t:
-        temp_template = open(t.name,'w')
+        temp_template = open(t.name, 'w')
         temp_template.write(qconf_Ae_template % hostname)
         temp_template.flush()
         os.fsync(t.fileno())
 
         # Add host as an execution host
         try:
-            command = ('/opt/sge/bin/lx-amd64/qconf -Ae %s' % t.name)
-            run_command(command, {}, log)
+            command = ("qconf -Ae %s" % t.name)
+            run_sge_command(command, log)
         except subprocess.CalledProcessError:
             log.warning("Unable to add host %s as execution host", hostname)
 
@@ -81,19 +80,19 @@ report_variables      NONE
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     hosts_key_file = os.path.expanduser("~" + cluster_user) + '/.ssh/known_hosts'
     user_key_file = os.path.expanduser("~" + cluster_user) + '/.ssh/id_rsa'
-    iter=0
-    connected=False
+    iter = 0
+    connected = False
     while iter < 3 and connected is False:
         try:
             log.info('Connecting to host: %s iter: %d' % (hostname, iter))
             ssh.connect(hostname, username=cluster_user, key_filename=user_key_file)
-            connected=True
+            connected = True
         except socket.error, e:
             log.error('Socket error: %s' % e)
             time.sleep(10 + iter)
             iter = iter + 1
             if iter == 3:
-               log.critical("Unable to provison host")
+               log.critical("Unable to provision host")
                return
     try:
         ssh.load_host_keys(hosts_key_file)
@@ -101,7 +100,9 @@ report_variables      NONE
         ssh._host_keys_filename = None
         pass
     ssh.save_host_keys(hosts_key_file)
-    command = "sudo sh -c \'cd /opt/sge && /opt/sge/inst_sge -noremote -x -auto /opt/parallelcluster/templates/sge/sge_inst.conf\'"
+    command = (
+        "sudo sh -c \'cd {0} && {0}/inst_sge -noremote -x -auto /opt/parallelcluster/templates/sge/sge_inst.conf\'"
+    ).format(sge.SGE_ROOT)
     stdin, stdout, stderr = ssh.exec_command(command)
     while not stdout.channel.exit_status_ready():
         time.sleep(1)
@@ -109,15 +110,15 @@ report_variables      NONE
 
     # Add the host to the all.q
     try:
-        command = ("/opt/sge/bin/lx-amd64/qconf -aattr hostgroup hostlist %s @allhosts" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -aattr hostgroup hostlist %s @allhosts" % hostname)
+        run_sge_command(command, log)
     except subprocess.CalledProcessError:
         log.warning("Unable to add host %s to all.q", hostname)
 
     # Set the numbers of slots for the host
     try:
-        command = ('/opt/sge/bin/lx-amd64/qconf -aattr queue slots ["%s=%s"] all.q' % (hostname,slots))
-        run_command(command, {}, log)
+        command = ('qconf -aattr queue slots ["%s=%s"] all.q' % (hostname, slots))
+        run_sge_command(command, log)
     except subprocess.CalledProcessError:
         log.warning("Unable to set the number of slots for the host %s", hostname)
 
@@ -126,45 +127,45 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     log.info('Removing %s', hostname)
 
     # Check if host is administrative host
-    command = "/opt/sge/bin/lx-amd64/qconf -sh"
+    command = "qconf -sh"
     if _is_host_configured(command, hostname):
         # Removing host as administrative host
-        command = ("/opt/sge/bin/lx-amd64/qconf -dh %s" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -dh %s" % hostname)
+        run_sge_command(command, log)
     else:
         log.info('Host %s is not administrative host', hostname)
 
     # Check if host is in all.q (qconf -sq all.q)
     # Purge hostname from all.q
     try:
-        command = ("/opt/sge/bin/lx-amd64/qconf -purge queue '*' all.q@%s" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -purge queue '*' all.q@%s" % hostname)
+        run_sge_command(command, log)
     except subprocess.CalledProcessError:
         log.warning("Unable to remove host %s from all.q", hostname)
 
     # Check if host is in @allhosts group (qconf -shgrp_resolved @allhosts)
     # Remove host from @allhosts group
     try:
-        command = ("/opt/sge/bin/lx-amd64/qconf -dattr hostgroup hostlist %s @allhosts" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -dattr hostgroup hostlist %s @allhosts" % hostname)
+        run_sge_command(command, log)
     except subprocess.CalledProcessError:
         log.warning("Unable to remove host %s from @allhosts group", hostname)
 
     # Check if host is execution host
-    command = "/opt/sge/bin/lx-amd64/qconf -sel"
+    command = "qconf -sel"
     if _is_host_configured(command, hostname):
         # Removing host as execution host
-        command = ("/opt/sge/bin/lx-amd64/qconf -de %s" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -de %s" % hostname)
+        run_sge_command(command, log)
     else:
         log.info('Host %s is not execution host', hostname)
 
     # Check if host is submission host
-    command = "/opt/sge/bin/lx-amd64/qconf -ss"
+    command = "qconf -ss"
     if _is_host_configured(command, hostname):
         # Removing host as submission host
-        command = ("/opt/sge/bin/lx-amd64/qconf -ds %s" % hostname)
-        run_command(command, {}, log)
+        command = ("qconf -ds %s" % hostname)
+        run_sge_command(command, log)
     else:
         log.info('Host %s is not submission host', hostname)
 

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -55,7 +55,7 @@ def _restart_master_node():
     else:
         command = ["/etc/init.d/slurm", "restart"]
     try:
-        run_command(command, {}, log)
+        run_command(command, log)
     except Exception as e:
         log.error("Failed when restarting slurm daemon on master node with exception %s", e)
         raise
@@ -105,7 +105,7 @@ def _reconfigure_nodes():
     log.info("Reconfiguring slurm")
     command = ["/opt/slurm/bin/scontrol", "reconfigure"]
     try:
-        run_command(command, {}, log)
+        run_command(command, log)
     except Exception as e:
         log.error("Failed when reconfiguring slurm daemon with exception %s", e)
 

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -36,7 +36,7 @@ def wakeupSchedOn(hostname):
     times = 20
     host_state = None
     while isHostInitState(host_state) and times > 0:
-        output = check_command_output(command, {}, log)
+        output = check_command_output(command, log)
         try:
             # Ex.1: <Data><Node><name>ip-10-0-76-39</name><state>down,offline,MOM-list-not-sent</state><power_state>Running</power_state>
             #        <np>1</np><ntype>cluster</ntype><mom_service_port>15002</mom_service_port><mom_manager_port>15003</mom_manager_port></Node></Data>
@@ -57,7 +57,7 @@ def wakeupSchedOn(hostname):
 
     if host_state == "free":
         command = "/opt/torque/bin/qmgr -c \"set server scheduling=true\""
-        run_command(command, {}, log)
+        run_command(command, log)
     elif times == 0:
         log.error("Host %s is still in state %s" % (hostname, host_state))
     else:
@@ -68,10 +68,10 @@ def addHost(hostname, cluster_user, slots, max_cluster_size):
     log.info('Adding %s with %s slots' % (hostname, slots))
 
     command = ("/opt/torque/bin/qmgr -c 'create node %s np=%s'" % (hostname, slots))
-    run_command(command, {}, log)
+    run_command(command, log)
 
     command = ('/opt/torque/bin/pbsnodes -c %s' % hostname)
-    run_command(command, {}, log)
+    run_command(command, log)
 
     # Connect and hostkey
     ssh = paramiko.SSHClient()
@@ -107,10 +107,10 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     log.info('Removing %s', hostname)
 
     command = ('/opt/torque/bin/pbsnodes -o %s' % hostname)
-    run_command(command, {}, log)
+    run_command(command, log)
 
     command = ("/opt/torque/bin/qmgr -c 'delete node %s'" % hostname)
-    run_command(command, {}, log)
+    run_command(command, log)
 
 
 def update_cluster(max_cluster_size, cluster_user, update_events):

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -9,40 +9,24 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-__author__ = 'dougalb'
-
-import subprocess as sub
-import os
-import paramiko
 import logging
-import shlex
-import time
-import xml.etree.ElementTree as xmltree
+import os
 import socket
+import time
+from xml.etree import ElementTree
+
+import paramiko
+
+from common.utils import check_command_output, run_command
 
 log = logging.getLogger(__name__)
-
-def __runCommand(command):
-    log.debug(repr(command))
-    _command = shlex.split(str(command))
-    log.debug(_command)
-
-    DEV_NULL = open(os.devnull, "rb")
-    try:
-        process = sub.Popen(_command, env=dict(os.environ), stdout=sub.PIPE, stderr=sub.STDOUT, stdin=DEV_NULL)
-        stdout = process.communicate()[0]
-        exitcode = process.poll()
-        if exitcode != 0:
-            log.error("Failed to run %s:\n%s" % (_command, stdout))
-        return stdout
-    finally:
-        DEV_NULL.close()
 
 
 def isHostInitState(host_state):
     # Node states http://docs.adaptivecomputing.com/torque/6-0-2/adminGuide/help.htm#topics/torque/8-resources/resources.htm#nodeStates
     init_states = ("down", "offline", "unknown", str(None))
     return str(host_state).startswith(init_states)
+
 
 def wakeupSchedOn(hostname):
     log.info('Waking up scheduler on host %s', hostname)
@@ -52,7 +36,7 @@ def wakeupSchedOn(hostname):
     times = 20
     host_state = None
     while isHostInitState(host_state) and times > 0:
-        output = __runCommand(command)
+        output = check_command_output(command, {}, log)
         try:
             # Ex.1: <Data><Node><name>ip-10-0-76-39</name><state>down,offline,MOM-list-not-sent</state><power_state>Running</power_state>
             #        <np>1</np><ntype>cluster</ntype><mom_service_port>15002</mom_service_port><mom_manager_port>15003</mom_manager_port></Node></Data>
@@ -61,7 +45,7 @@ def wakeupSchedOn(hostname):
             #        ncpus=1,physmem=1017208kb,availmem=753728kb,totmem=1017208kb,idletime=856,nusers=1,nsessions=1,sessions=19698,
             #        uname=Linux ip-10-0-76-39 4.9.75-25.55.amzn1.x86_64 #1 SMP Fri Jan 5 23:50:27 UTC 2018 x86_64,opsys=linux</status>
             #        <mom_service_port>15002</mom_service_port><mom_manager_port>15003</mom_manager_port></Node></Data>
-            xmlnode = xmltree.XML(output)
+            xmlnode = ElementTree.XML(output)
             host_state = xmlnode.findtext("./Node/state")
         except:
             log.error("Error parsing XML from %s" % output)
@@ -73,20 +57,21 @@ def wakeupSchedOn(hostname):
 
     if host_state == "free":
         command = "/opt/torque/bin/qmgr -c \"set server scheduling=true\""
-        __runCommand(command)
+        run_command(command, {}, log)
     elif times == 0:
         log.error("Host %s is still in state %s" % (hostname, host_state))
     else:
         log.debug("Host %s is in state %s" % (hostname, host_state))
 
+
 def addHost(hostname, cluster_user, slots, max_cluster_size):
     log.info('Adding %s with %s slots' % (hostname, slots))
 
     command = ("/opt/torque/bin/qmgr -c 'create node %s np=%s'" % (hostname, slots))
-    __runCommand(command)
+    run_command(command, {}, log)
 
     command = ('/opt/torque/bin/pbsnodes -c %s' % hostname)
-    __runCommand(command)
+    run_command(command, {}, log)
 
     # Connect and hostkey
     ssh = paramiko.SSHClient()
@@ -117,14 +102,15 @@ def addHost(hostname, cluster_user, slots, max_cluster_size):
 
     wakeupSchedOn(hostname)
 
+
 def removeHost(hostname, cluster_user, max_cluster_size):
     log.info('Removing %s', hostname)
 
     command = ('/opt/torque/bin/pbsnodes -o %s' % hostname)
-    __runCommand(command)
+    run_command(command, {}, log)
 
     command = ("/opt/torque/bin/qmgr -c 'delete node %s'" % hostname)
-    __runCommand(command)
+    run_command(command, {}, log)
 
 
 def update_cluster(max_cluster_size, cluster_user, update_events):
@@ -139,10 +125,7 @@ def update_cluster(max_cluster_size, cluster_user, update_events):
             succeeded.append(event)
         except Exception as e:
             log.error(
-                "Encountered error when processing %s event for host %s: %s",
-                event.action,
-                event.host.hostname,
-                e,
+                "Encountered error when processing %s event for host %s: %s", event.action, event.host.hostname, e,
             )
             failed.append(event)
 

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -332,16 +332,21 @@ def _poll_queue(sqs_config, queue, table, asg_name):
         time.sleep(30)
 
 
+@retry()
 def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
     log.info("sqswatcher startup")
 
-    config = _get_config()
-    queue = _get_sqs_queue(config.region, config.sqsqueue, config.proxy_config)
-    table = _get_ddb_table(config.region, config.table_name, config.proxy_config)
-    asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config, log)
+    try:
+        config = _get_config()
+        queue = _get_sqs_queue(config.region, config.sqsqueue, config.proxy_config)
+        table = _get_ddb_table(config.region, config.table_name, config.proxy_config)
+        asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config, log)
 
-    _poll_queue(config, queue, table, asg_name)
+        _poll_queue(config, queue, table, asg_name)
+    except Exception as e:
+        log.critical(e)
+        raise
 
 
 if __name__ == "__main__":

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -326,7 +326,7 @@ def _poll_queue(sqs_config, queue, table, asg_name):
         time.sleep(30)
 
 
-@retry()
+@retry(wait_fixed=30000)
 def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
     log.info("sqswatcher startup")
@@ -339,7 +339,7 @@ def main():
 
         _poll_queue(config, queue, table, asg_name)
     except Exception as e:
-        log.critical(e)
+        log.critical("An unexpected error occurred: %s", e)
         raise
 
 

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -26,18 +26,10 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from retrying import retry
 
-from common.utils import get_asg_name, get_asg_settings, load_module
-
-
-class HostRemovalError(Exception):
-    pass
+from common.utils import CriticalError, get_asg_name, get_asg_settings, load_module
 
 
 class QueryConfigError(Exception):
-    pass
-
-
-class CriticalError(Exception):
     pass
 
 


### PR DESCRIPTION
- add global retry to the main functions
- use exponential retry to `get_asg_name`
- move `check_command_output` and `run_command` in common and use these functions everywhere.
- simplify and unificate SGE shell command execution. From now the env variable required for SGE commands will be automatically set in a single point.

nodewatcher: 
- avoid to exit when getting metadata and raise an exception
- do not crash if unable to read/store current idletime. fallback by using "on memory" value.

sqswatcher: 
- catching the `subprocess.CalledProcessError` and avoid to raise an exception if not required.
- avoid to log successfully processed event

jobwatcher:
-  improve pricing file fetching and reading