### PR TITLE
slurm: add other reasons for the cluster scale up

### DIFF
--- a/common/slurm.py
+++ b/common/slurm.py
@@ -14,5 +14,8 @@
 
 PENDING_RESOURCES_REASONS = [
     "Resources",
-    "Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions"
+    "Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions",
+    "BeginTime",
+    "NodeDown",
+    "Priority"
 ]


### PR DESCRIPTION
We were scaling up only when the job was waiting for resources to become available ([Job reason code](https://slurm.schedmd.com/squeue.html) = **Resources**).

In case of a requeued job the cluster didn't scale up because the pending reason is **NodeDown** and then **BeginTime**. I'm adding them to the list of reasons for the scale up:

```
# failed job because node has been retired --> NF = Node Failure
$ squeue -t all  
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                 2   compute     wrap   ubuntu NF       2:55      1 ip-10-0-2-231

# job requeued
$ scontrol requeue 2

$ squeue -t PD
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                 2   compute     wrap   ubuntu PD       0:00      1 (NodeDown)
$ squeue -t PD --noheader -o '%r'
NodeDown
...
$ squeue -t PD
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                 2   compute     wrap   ubuntu PD       0:00      1 (BeginTime)
$ squeue -t PD --noheader -o '%r'
BeginTime
```

I also added **Priority** because I think that we can scale up if the job is waiting for other higher priority jobs.

This fixes https://github.com/aws/aws-parallelcluster/issues/996