### PR TITLE
Enhancements to improve sqswatcher resilience capacity

### DIFF
--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -74,9 +74,7 @@ def _restart_compute_daemons(hostname, cluster_user):
     # This blocks until command completes
     return_code = stdout.channel.recv_exit_status()
     if return_code != 0:
-        error_message = "Failed when restarting slurmd on compute node {0}".format(hostname)
-        log.error(error_message)
-        raise Exception(error_message)
+        raise Exception("Failed when restarting slurmd on compute node %s", hostname)
     ssh_client.close()
 
 

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -70,7 +70,7 @@ def _restart_compute_daemons(hostname, cluster_user):
         "then sudo systemctl restart slurmd.service; "
         'else sudo sh -c "/etc/init.d/slurm restart 2>&1 > /tmp/slurmdstart.log"; fi'
     )
-    stdin, stdout, stderr = ssh_client.exec_command(command, timeout=15)
+    stdin, stdout, stderr = ssh_client.exec_command(command)
     # This blocks until command completes
     return_code = stdout.channel.recv_exit_status()
     if return_code != 0:


### PR DESCRIPTION
- Failed SQS events are re-queued up to 2 times and then discarded. This is done to avoid processing an event that keeps failing forever.
- raise exception when _restart_compute_daemons fails to enable retries in these cases
 - also reduced the wait_fixed retry time to 2 seconds since there is a timeout on the thread pool that consists in 10 seconds per hosts batch
- add item to dynamodb also on failed ADD events. This allows the REMOVE event to successfully remove partially configured nodes from scheduler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
