### PR TITLE
sqswatcher/jobwatcher: use correct number of slots for dummy nodes and fetch instance type to support updates

### DIFF
--- a/common/sge.py
+++ b/common/sge.py
@@ -20,28 +20,26 @@ SGE_BIN_DIR = SGE_BIN_PATH + "/"
 SGE_ENV = {"SGE_ROOT": SGE_ROOT, "PATH": "{0}/bin:{1}:/bin:/usr/bin".format(SGE_ROOT, SGE_BIN_PATH)}
 
 
-def check_sge_command_output(command, log):
+def check_sge_command_output(command):
     """
     Execute SGE shell command, by exporting the appropriate environment.
 
     :param command: command to execute
-    :param log: logger
     :raise: subprocess.CalledProcessError if the command fails
     """
     command = _prepend_sge_bin_dir(command)
-    return check_command_output(command, log, SGE_ENV)
+    return check_command_output(command, SGE_ENV)
 
 
-def run_sge_command(command, log):
+def run_sge_command(command):
     """
     Execute SGE shell command, by exporting the appropriate environment.
 
     :param command: command to execute
-    :param log: logger
     :raise: subprocess.CalledProcessError if the command fails
     """
     command = _prepend_sge_bin_dir(command)
-    run_command(command, log, SGE_ENV)
+    run_command(command, SGE_ENV)
 
 
 def _prepend_sge_bin_dir(command):

--- a/common/utils.py
+++ b/common/utils.py
@@ -11,7 +11,7 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-
+import logging
 import os
 import shlex
 import subprocess
@@ -20,6 +20,9 @@ import sys
 import boto3
 from future.moves.subprocess import check_output
 from retrying import retry
+
+
+log = logging.getLogger(__name__)
 
 
 class CriticalError(Exception):
@@ -47,14 +50,13 @@ def load_module(module):
     wait_exponential_max=80000,
     retry_on_exception=lambda exception: isinstance(exception, IndexError)
 )
-def get_asg_name(stack_name, region, proxy_config, log):
+def get_asg_name(stack_name, region, proxy_config):
     """
     Get autoscaling group name associated to the given stack.
 
     :param stack_name: stack name to search for
     :param region: AWS region
     :param proxy_config: Proxy configuration
-    :param log: logger
     :raise ASGNotFoundError if the ASG is not found (after the timeout) or if an unexpected error occurs
     :return: the ASG name
     """
@@ -71,7 +73,7 @@ def get_asg_name(stack_name, region, proxy_config, log):
         raise CriticalError("Unable to get ASG for stack {0}. Failed with exception: {1}".format(stack_name, e))
 
 
-def get_asg_settings(region, proxy_config, asg_name, log):
+def get_asg_settings(region, proxy_config, asg_name):
     try:
         asg_client = boto3.client("autoscaling", region_name=region, config=proxy_config)
         asg = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name]).get('AutoScalingGroups')[0]
@@ -86,13 +88,12 @@ def get_asg_settings(region, proxy_config, asg_name, log):
         raise
 
 
-def check_command_output(command, log, env=None, raise_on_error=True):
+def check_command_output(command, env=None, raise_on_error=True):
     """
     Execute shell command and retrieve command output.
 
     :param command: command to execute
     :param env: a dictionary containing environment variables
-    :param log: logger
     :param raise_on_error: True to raise subprocess.CalledProcessError on errors
     :return: the command output
     :raise: subprocess.CalledProcessError if the command fails
@@ -100,26 +101,24 @@ def check_command_output(command, log, env=None, raise_on_error=True):
     return _run_command(
         lambda _command, _env: check_output(_command, env=_env, stderr=subprocess.STDOUT, universal_newlines=True),
         command,
-        log,
         env,
         raise_on_error,
     )
 
 
-def run_command(command, log, env=None, raise_on_error=True):
+def run_command(command, env=None, raise_on_error=True):
     """
     Execute shell command.
 
     :param command: command to execute
     :param env: a dictionary containing environment variables
-    :param log: logger
     :param raise_on_error: True to raise subprocess.CalledProcessError on errors
     :raise: subprocess.CalledProcessError if the command fails
     """
-    _run_command(lambda _command, _env: subprocess.check_call(_command, env=_env), command, log, env, raise_on_error)
+    _run_command(lambda _command, _env: subprocess.check_call(_command, env=_env), command, env, raise_on_error)
 
 
-def _run_command(command_function, command, log, env=None, raise_on_error=True):
+def _run_command(command_function, command, env=None, raise_on_error=True):
     try:
         if isinstance(command, str) or isinstance(command, unicode):
             command = shlex.split(command.encode("ascii"))
@@ -142,7 +141,7 @@ def _run_command(command_function, command, log, env=None, raise_on_error=True):
         raise
 
 
-def get_cloudformation_stack_parameters(region, proxy_config, stack_name, log):
+def get_cloudformation_stack_parameters(region, proxy_config, stack_name):
     try:
         cfn_client = boto3.client("cloudformation", region_name=region, config=proxy_config)
         response = cfn_client.describe_stacks(StackName=stack_name)

--- a/common/utils.py
+++ b/common/utils.py
@@ -140,3 +140,17 @@ def _run_command(command_function, command, log, env=None, raise_on_error=True):
     except OSError as e:
         log.error("Unable to execute the command %s. Failed with exception: %s", command, e)
         raise
+
+
+def get_cloudformation_stack_parameters(region, proxy_config, stack_name, log):
+    try:
+        cfn_client = boto3.client("cloudformation", region_name=region, config=proxy_config)
+        response = cfn_client.describe_stacks(StackName=stack_name)
+        parameters = {}
+        for parameter in response["Stacks"][0]["Parameters"]:
+            parameters[parameter["ParameterKey"]] = parameter["ParameterValue"]
+
+        return parameters
+    except Exception as e:
+        log.error("Failed when retrieving stack parameters for stack %s with exception %s", stack_name, e)
+        raise

--- a/common/utils.py
+++ b/common/utils.py
@@ -271,6 +271,12 @@ def _get_vcpus_by_instance_type(instances, instance_type):
         raise CriticalError(error_msg)
 
 
-def get_compute_instance_type(region, proxy_config, stack_name):
-    parameters = get_cloudformation_stack_parameters(region, proxy_config, stack_name)
-    return parameters["ComputeInstanceType"]
+@retry(stop_max_attempt_number=3, wait_fixed=5000)
+def get_compute_instance_type(region, proxy_config, stack_name, fallback):
+    try:
+        parameters = get_cloudformation_stack_parameters(region, proxy_config, stack_name)
+        return parameters["ComputeInstanceType"]
+    except Exception:
+        if fallback:
+            return fallback
+        raise

--- a/jobwatcher/jobwatcher.cfg
+++ b/jobwatcher/jobwatcher.cfg
@@ -7,4 +7,3 @@ stack_name = test
 scheduler = test
 proxy = NONE
 cfncluster_dir = ./ 
-compute_instance_type = c4.xlarge

--- a/jobwatcher/jobwatcher.cfg
+++ b/jobwatcher/jobwatcher.cfg
@@ -1,9 +1,0 @@
-# Testing config file
-# Create an ASG with name Test
-[jobwatcher]
-region = us-east-1
-asg_name = Test
-stack_name = test
-scheduler = test
-proxy = NONE
-cfncluster_dir = ./ 

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -184,7 +184,7 @@ def _get_vcpus_by_instance_type(pricing_file, instance_type):
 
 
 def _get_compute_instance_type(config):
-    parameters = get_cloudformation_stack_parameters(config.region, config.proxy_config, config.stack_name, log)
+    parameters = get_cloudformation_stack_parameters(config.region, config.proxy_config, config.stack_name)
     return parameters["ComputeInstanceType"]
 
 
@@ -256,7 +256,7 @@ def _poll_scheduler_status(config, asg_name, scheduler_module):
             log.info("%d nodes requested, %d nodes running", pending, running)
 
             # get current limits
-            _, current_desired, max_size = get_asg_settings(config.region, config.proxy_config, asg_name, log)
+            _, current_desired, max_size = get_asg_settings(config.region, config.proxy_config, asg_name)
 
             # Check to make sure requested number of instances is within ASG limits
             required = running + pending
@@ -288,7 +288,7 @@ def main():
     log.info("jobwatcher startup")
     try:
         config = _get_config()
-        asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config, log)
+        asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config)
 
         scheduler_module = load_module("jobwatcher.plugins." + config.scheduler)
 

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -80,7 +80,9 @@ def _poll_scheduler_status(config, asg_name, scheduler_module):
     instance_type = None
     while True:
         # Get instance properties
-        new_instance_type = get_compute_instance_type(config.region, config.proxy_config, config.stack_name)
+        new_instance_type = get_compute_instance_type(
+            config.region, config.proxy_config, config.stack_name, fallback=instance_type
+        )
         if new_instance_type != instance_type:
             instance_type = new_instance_type
             instance_properties = get_instance_properties(config.region, config.proxy_config, instance_type)

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -14,178 +14,22 @@
 
 import ConfigParser
 import collections
-import json
 import logging
-import os
 import time
 
 import boto3
 from botocore.config import Config
-from botocore.exceptions import ClientError
 from retrying import retry
 
 from common.utils import (
-    CriticalError,
     get_asg_name,
     load_module,
     get_asg_settings,
-    get_cloudformation_stack_parameters
+    get_compute_instance_type,
+    get_instance_properties
 )
 
 log = logging.getLogger(__name__)
-
-
-def _read_cfnconfig():
-    """
-    Read configuration file.
-
-    :return: a dictionary containing the configuration parameters
-    """
-    cfnconfig_params = {}
-    cfnconfig_file = "/opt/parallelcluster/cfnconfig"
-    log.info("Reading %s", cfnconfig_file)
-    with open(cfnconfig_file) as f:
-        for kvp in f:
-            key, value = kvp.partition('=')[::2]
-            cfnconfig_params[key.strip()] = value.strip()
-    return cfnconfig_params
-
-
-@retry(stop_max_attempt_number=3, wait_fixed=5000)
-def _get_vcpus_from_pricing_file(config, instance_type):
-    """
-    Read pricing file and get number of vcpus for the given instance type.
-
-    :param config: JobwatcherConfiguration object
-    :return: the number of vcpus or -1 if the instance type cannot be found
-    """
-    _create_data_dir(config.pcluster_dir)
-
-    folder = config.pcluster_dir
-    if not folder.endswith("/"):
-        folder += "/"
-    pricing_file = folder + "instances.json"
-    if not os.path.isfile(pricing_file) or not _pricing_file_has_instance_type(instance_type, pricing_file):
-        _fetch_pricing_file(pricing_file, config.region, config.proxy_config)
-
-    return _get_vcpus_by_instance_type(pricing_file, instance_type)
-
-
-def _pricing_file_has_instance_type(instance_type, pricing_file):
-    with open(pricing_file) as f:
-        instances = json.load(f)
-        return instance_type in instances
-
-
-def _get_instance_properties(config, instance_type):
-    """
-    Get instance properties for the given instance type, according to the cfn_scheduler_slots configuration parameter.
-
-    :param config: JobwatcherConfiguration object
-    :return: a dictionary containing the instance properties. E.g. {'slots': <slots>}
-    """
-    # get vcpus from the pricing file
-    vcpus = _get_vcpus_from_pricing_file(config, instance_type)
-
-    try:
-        cfnconfig_params = _read_cfnconfig()
-        cfn_scheduler_slots = cfnconfig_params["cfn_scheduler_slots"]
-    except KeyError:
-        log.error("Required config parameter 'cfn_scheduler_slots' not found in cfnconfig file. Assuming 'vcpus'")
-        cfn_scheduler_slots = "vcpus"
-
-    if cfn_scheduler_slots == "cores":
-        log.info("Instance %s will use number of cores as slots based on configuration." % instance_type)
-        slots = -(-vcpus//2)
-
-    elif cfn_scheduler_slots == "vcpus":
-        log.info("Instance %s will use number of vcpus as slots based on configuration." % instance_type)
-        slots = vcpus
-
-    elif cfn_scheduler_slots.isdigit():
-        slots = int(cfn_scheduler_slots)
-        log.info("Instance %s will use %s slots based on configuration." % (instance_type, slots))
-
-        if slots <= 0:
-            log.error(
-                "cfn_scheduler_slots config parameter '{0}' must be greater than 0. Assuming 'vcpus'".format(
-                    cfn_scheduler_slots
-                )
-            )
-            slots = vcpus
-    else:
-        log.error("cfn_scheduler_slots config parameter '%s' is invalid. Assuming 'vcpus'" % cfn_scheduler_slots)
-        slots = vcpus
-
-    return {'slots': slots}
-
-
-def _create_data_dir(pcluster_dir):
-    """
-    Create jobwatcher data dir.
-
-    :param pcluster_dir: the folder to create.
-    :raise CriticalError if unable to create the folder.
-    """
-    try:
-        if not os.path.exists(pcluster_dir):
-            os.makedirs(pcluster_dir)
-    except OSError as e:
-        log.critical("Could not create directory {0}. Failed with exception: {1}".format(pcluster_dir, e))
-        raise
-
-
-def _fetch_pricing_file(pricing_file, region, proxy_config):
-    """
-    Download pricing file.
-
-    :param pricing_file: pricing file path
-    :param region: AWS Region
-    :param proxy_config: Proxy Configuration
-    :raise ClientError if unable to download the pricing file.
-    """
-    bucket_name = '%s-aws-parallelcluster' % region
-    try:
-        s3 = boto3.resource('s3', region_name=region, config=proxy_config)
-        s3.Bucket(bucket_name).download_file('instances/instances.json', pricing_file)
-    except ClientError as e:
-        log.critical("Could not save instance mapping file {0} from S3 bucket {1}. Failed with exception: {2}".format(
-            pricing_file, bucket_name, e)
-        )
-        raise
-
-
-def _get_vcpus_by_instance_type(pricing_file, instance_type):
-    """
-    Get vcpus for the given instance type from the pricing file.
-
-    :param pricing_file: pricing file path
-    :param instance_type: The instance type to search for
-    :return: the number of vcpus for the given instance type
-    :raise CriticalError if unable to find the given instance or whatever error.
-    """
-    try:
-        # read vcpus value from file
-        with open(pricing_file) as f:
-            instances = json.load(f)
-            vcpus = int(instances[instance_type]["vcpus"])
-            log.info("Instance %s has %s vcpus." % (instance_type, vcpus))
-            return vcpus
-    except KeyError:
-        error_msg = "Unable to get vcpus from file {0}. Instance type {1} not found.".format(
-            pricing_file, instance_type
-        )
-        log.critical(error_msg)
-        raise CriticalError(error_msg)
-    except Exception:
-        error_msg = "Unable to get vcpus for the instance type {0} from file {1}".format(instance_type, pricing_file)
-        log.critical(error_msg)
-        raise CriticalError(error_msg)
-
-
-def _get_compute_instance_type(config):
-    parameters = get_cloudformation_stack_parameters(config.region, config.proxy_config, config.stack_name)
-    return parameters["ComputeInstanceType"]
 
 
 JobwatcherConfig = collections.namedtuple(
@@ -236,10 +80,10 @@ def _poll_scheduler_status(config, asg_name, scheduler_module):
     instance_type = None
     while True:
         # Get instance properties
-        new_instance_type = _get_compute_instance_type(config)
+        new_instance_type = get_compute_instance_type(config.region, config.proxy_config, config.stack_name)
         if new_instance_type != instance_type:
             instance_type = new_instance_type
-            instance_properties = _get_instance_properties(config, instance_type)
+            instance_properties = get_instance_properties(config.region, config.proxy_config, instance_type)
 
         # Get number of nodes requested
         pending = scheduler_module.get_required_nodes(instance_properties)

--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 # get nodes requested from pending jobs
 def get_required_nodes(instance_properties):
     command = "qstat -g d -s p -u '*'"
-    _output = check_sge_command_output(command, log)
+    _output = check_sge_command_output(command)
     slots = 0
     output = _output.split("\n")[2:]
     for line in output:
@@ -23,7 +23,7 @@ def get_required_nodes(instance_properties):
 # if a host has 1 or more job running on it, it'll be marked busy
 def get_busy_nodes(instance_properties):
     command = "qstat -f"
-    _output = check_sge_command_output(command, log)
+    _output = check_sge_command_output(command)
     nodes = 0
     output = _output.split("\n")[2:]
     for line in output:

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -16,7 +16,7 @@ def get_required_nodes(instance_properties):
     # 2-PD-1-24-Licenses
     # 3-PD-1-24-PartitionNodeLimit
     # 4-R-1-24-
-    output = check_command_output(command, log)
+    output = check_command_output(command)
     slots_requested = []
     nodes_requested = []
     output = output.split("\n")
@@ -39,7 +39,7 @@ def get_busy_nodes(instance_properties):
     # 2 mix
     # 4 alloc
     # 10 idle
-    output = check_command_output(command, log)
+    output = check_command_output(command)
     nodes = 0
     output = output.split("\n")
     for line in output:

--- a/jobwatcher/plugins/torque.py
+++ b/jobwatcher/plugins/torque.py
@@ -20,7 +20,7 @@ def get_required_nodes(instance_properties):
     # 2.ip-172-31-11-1.ec2.i  centos      batch    job.sh             5387     2      4       --   01:00:00 R  00:08:27
 
     status = ['Q']
-    _output = check_command_output(command, log)
+    _output = check_command_output(command)
     output = _output.split("\n")[5:]
     slots_requested = []
     nodes_requested = []
@@ -52,7 +52,7 @@ def get_busy_nodes(instance_properties):
     #       <mom_manager_port>15003</mom_manager_port>
     #    </Node>
     # </Data>
-    _output = check_command_output(command, log)
+    _output = check_command_output(command)
     root = ElementTree.fromstring(_output)
     count = 0
     # See how many nodes have jobs

--- a/nodewatcher/nodewatcher.cfg
+++ b/nodewatcher/nodewatcher.cfg
@@ -1,6 +1,0 @@
-[nodewatcher]
-region = us-east-1
-scheduler = test
-proxy = NONE
-scaledown_idletime = 10
-stack_name = test

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -297,7 +297,7 @@ def main():
         instance_id = _get_metadata("instance-id")
         hostname = _get_metadata("local-hostname")
         log.info("Instance id is %s, hostname is %s", instance_id, hostname)
-        asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config, log)
+        asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config)
 
         _poll_instance_status(config, scheduler_module, asg_name, hostname, instance_id)
     except Exception as e:

--- a/nodewatcher/plugins/sge.py
+++ b/nodewatcher/plugins/sge.py
@@ -32,7 +32,7 @@ def hasJobs(hostname):
     # 17 0.50500 STDIN      ec2-user     r     02/06/2019 11:06:30 all.q@ip-172-31-68-26.ec2.inte MASTER 2
 
     try:
-        output = check_sge_command_output(command, log)
+        output = check_sge_command_output(command)
         has_jobs = output != ""
     except subprocess.CalledProcessError:
         has_jobs = False
@@ -52,7 +52,7 @@ def hasPendingJobs():
     #      73 0.55500 job.sh     ec2-user     qw    08/08/2018 22:37:25                                    1
 
     try:
-        output = check_sge_command_output(command, log)
+        output = check_sge_command_output(command)
         lines = filter(None, output.split("\n"))
         has_pending = True if len(lines) > 1 else False
         error = False
@@ -68,6 +68,6 @@ def lockHost(hostname, unlock=False):
     command = ["qmod", mod, "all.q@%s" % hostname]
 
     try:
-        run_sge_command(command, log)
+        run_sge_command(command)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -24,7 +24,7 @@ def hasJobs(hostname):
     # Checking for running jobs on the node
     command = ['/opt/slurm/bin/squeue', '-w', short_name, '-h']
     try:
-        output = check_command_output(command, log)
+        output = check_command_output(command)
         has_jobs = output != ""
     except subprocess.CalledProcessError:
         has_jobs = False
@@ -40,7 +40,7 @@ def hasPendingJobs():
     #  Priority
     #  PartitionNodeLimit
     try:
-        output = check_command_output(command, log)
+        output = check_command_output(command)
         has_pending = len(filter(lambda reason: reason in PENDING_RESOURCES_REASONS, output.split("\n"))) > 0
         error = False
     except subprocess.CalledProcessError:
@@ -72,6 +72,6 @@ def lockHost(hostname, unlock=False):
             'Reason="Shutting down"',
         ]
     try:
-        run_command(command, log)
+        run_command(command)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -58,7 +58,7 @@ def hasPendingJobs():
     # batch                0     24   yes   yes    24     0     0     0     0     0 E     0
     # test1                0     26   yes   yes    26     0     0     0     0     0 E     0
     try:
-        output = check_command_output(command, log)
+        output = check_command_output(command)
         lines = filter(None, output.split("\n"))
         if len(lines) < 3:
             log.error("Unable to check pending jobs. The command '%s' does not return a valid output", command)
@@ -85,6 +85,6 @@ def lockHost(hostname, unlock=False):
     mod = unlock and '-c' or '-o'
     command = ['/opt/torque/bin/pbsnodes', mod, hostname]
     try:
-        run_command(command, log)
+        run_command(command)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 def _is_host_configured(command, hostname):
-    output = check_sge_command_output(command, log)
+    output = check_sge_command_output(command)
     # Expected output
     # ip-172-31-66-16.ec2.internal
     # ip-172-31-74-69.ec2.internal
@@ -39,14 +39,14 @@ def addHost(hostname, cluster_user, slots, max_cluster_size):
     # Adding host as administrative host
     try:
         command = ("qconf -ah %s" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     except subprocess.CalledProcessError:
         log.warning("Unable to add host %s as administrative host", hostname)
 
     # Adding host as submit host
     try:
         command = ("qconf -as %s" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     except subprocess.CalledProcessError:
         log.warning("Unable to add host %s as submission host", hostname)
 
@@ -71,7 +71,7 @@ report_variables      NONE
         # Add host as an execution host
         try:
             command = ("qconf -Ae %s" % t.name)
-            run_sge_command(command, log)
+            run_sge_command(command)
         except subprocess.CalledProcessError:
             log.warning("Unable to add host %s as execution host", hostname)
 
@@ -111,14 +111,14 @@ report_variables      NONE
     # Add the host to the all.q
     try:
         command = ("qconf -aattr hostgroup hostlist %s @allhosts" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     except subprocess.CalledProcessError:
         log.warning("Unable to add host %s to all.q", hostname)
 
     # Set the numbers of slots for the host
     try:
         command = ('qconf -aattr queue slots ["%s=%s"] all.q' % (hostname, slots))
-        run_sge_command(command, log)
+        run_sge_command(command)
     except subprocess.CalledProcessError:
         log.warning("Unable to set the number of slots for the host %s", hostname)
 
@@ -131,7 +131,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     if _is_host_configured(command, hostname):
         # Removing host as administrative host
         command = ("qconf -dh %s" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     else:
         log.info('Host %s is not administrative host', hostname)
 
@@ -139,7 +139,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     # Purge hostname from all.q
     try:
         command = ("qconf -purge queue '*' all.q@%s" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     except subprocess.CalledProcessError:
         log.warning("Unable to remove host %s from all.q", hostname)
 
@@ -147,7 +147,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     # Remove host from @allhosts group
     try:
         command = ("qconf -dattr hostgroup hostlist %s @allhosts" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     except subprocess.CalledProcessError:
         log.warning("Unable to remove host %s from @allhosts group", hostname)
 
@@ -156,7 +156,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     if _is_host_configured(command, hostname):
         # Removing host as execution host
         command = ("qconf -de %s" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     else:
         log.info('Host %s is not execution host', hostname)
 
@@ -165,7 +165,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     if _is_host_configured(command, hostname):
         # Removing host as submission host
         command = ("qconf -ds %s" % hostname)
-        run_sge_command(command, log)
+        run_sge_command(command)
     else:
         log.info('Host %s is not submission host', hostname)
 

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -170,7 +170,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
         log.info('Host %s is not submission host', hostname)
 
 
-def update_cluster(max_cluster_size, cluster_user, update_events):
+def update_cluster(max_cluster_size, cluster_user, update_events, instance_properties):
     failed = []
     succeeded = []
     for event in update_events:

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -55,7 +55,7 @@ def _restart_master_node():
     else:
         command = ["/etc/init.d/slurm", "restart"]
     try:
-        run_command(command, log)
+        run_command(command)
     except Exception as e:
         log.error("Failed when restarting slurm daemon on master node with exception %s", e)
         raise
@@ -106,7 +106,7 @@ def _reconfigure_nodes():
     log.info("Reconfiguring slurm")
     command = ["/opt/slurm/bin/scontrol", "reconfigure"]
     try:
-        run_command(command, log)
+        run_command(command)
     except Exception as e:
         log.error("Failed when reconfiguring slurm daemon with exception %s", e)
 

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -113,7 +113,7 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     run_command(command, raise_on_error=False)
 
 
-def update_cluster(max_cluster_size, cluster_user, update_events):
+def update_cluster(max_cluster_size, cluster_user, update_events, instance_properties):
     failed = []
     succeeded = []
     for event in update_events:

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -37,7 +37,7 @@ def wakeupSchedOn(hostname):
     host_state = None
     while isHostInitState(host_state) and times > 0:
         try:
-            output = check_command_output(command, log)
+            output = check_command_output(command)
             # Ex.1: <Data><Node><name>ip-10-0-76-39</name><state>down,offline,MOM-list-not-sent</state><power_state>Running</power_state>
             #        <np>1</np><ntype>cluster</ntype><mom_service_port>15002</mom_service_port><mom_manager_port>15003</mom_manager_port></Node></Data>
             # Ex 2: <Data><Node><name>ip-10-0-76-39</name><state>free</state><power_state>Running</power_state><np>1</np><ntype>cluster</ntype>
@@ -57,7 +57,7 @@ def wakeupSchedOn(hostname):
 
     if host_state == "free":
         command = "/opt/torque/bin/qmgr -c \"set server scheduling=true\""
-        run_command(command, log, raise_on_error=False)
+        run_command(command, raise_on_error=False)
     elif times == 0:
         log.error("Host %s is still in state %s" % (hostname, host_state))
     else:
@@ -68,10 +68,10 @@ def addHost(hostname, cluster_user, slots, max_cluster_size):
     log.info('Adding %s with %s slots' % (hostname, slots))
 
     command = ("/opt/torque/bin/qmgr -c 'create node %s np=%s'" % (hostname, slots))
-    run_command(command, log, raise_on_error=False)
+    run_command(command, raise_on_error=False)
 
     command = ('/opt/torque/bin/pbsnodes -c %s' % hostname)
-    run_command(command, log, raise_on_error=False)
+    run_command(command, raise_on_error=False)
 
     # Connect and hostkey
     ssh = paramiko.SSHClient()
@@ -107,10 +107,10 @@ def removeHost(hostname, cluster_user, max_cluster_size):
     log.info('Removing %s', hostname)
 
     command = ('/opt/torque/bin/pbsnodes -o %s' % hostname)
-    run_command(command, log, raise_on_error=False)
+    run_command(command, raise_on_error=False)
 
     command = ("/opt/torque/bin/qmgr -c 'delete node %s'" % hostname)
-    run_command(command, log, raise_on_error=False)
+    run_command(command, raise_on_error=False)
 
 
 def update_cluster(max_cluster_size, cluster_user, update_events):

--- a/sqswatcher/sqswatcher.cfg
+++ b/sqswatcher/sqswatcher.cfg
@@ -1,9 +1,0 @@
-[sqswatcher]
-region = us-east-1
-sqsqueue = AS-SQS
-table_name = instances
-scheduler = test
-cluster_user = ec2-user
-proxy = NONE
-max_queue_size = 1
-stack_name = test

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -45,7 +45,7 @@ log = logging.getLogger(__name__)
 
 SQSWatcherConfig = collections.namedtuple(
     "SQSWatcherConfig",
-    ["region", "scheduler", "sqsqueue", "table_name", "cluster_user", "proxy_config", "max_queue_size", "stack_name"],
+    ["region", "scheduler", "sqsqueue", "table_name", "cluster_user", "proxy_config", "stack_name"],
 )
 
 Host = collections.namedtuple("Host", ["instance_id", "hostname", "slots"])
@@ -73,7 +73,6 @@ def _get_config():
     sqsqueue = config.get("sqswatcher", "sqsqueue")
     table_name = config.get("sqswatcher", "table_name")
     cluster_user = config.get("sqswatcher", "cluster_user")
-    max_queue_size = int(config.get("sqswatcher", "max_queue_size"))
     stack_name = config.get("sqswatcher", "stack_name")
 
     _proxy = config.get("sqswatcher", "proxy")
@@ -83,18 +82,17 @@ def _get_config():
 
     log.info(
         "Configured parameters: region=%s scheduler=%s sqsqueue=%s table_name=%s cluster_user=%s "
-        "proxy=%s max_queue_size=%d stack_name=%s",
+        "proxy=%s stack_name=%s",
         region,
         scheduler,
         sqsqueue,
         table_name,
         cluster_user,
         _proxy,
-        max_queue_size,
         stack_name,
     )
     return SQSWatcherConfig(
-        region, scheduler, sqsqueue, table_name, cluster_user, proxy_config, max_queue_size, stack_name
+        region, scheduler, sqsqueue, table_name, cluster_user, proxy_config, stack_name
     )
 
 
@@ -339,7 +337,7 @@ def _poll_queue(sqs_config, queue, table, asg_name):
     """
     scheduler_module = load_module("sqswatcher.plugins." + sqs_config.scheduler)
 
-    max_cluster_size = sqs_config.max_queue_size
+    max_cluster_size = None
     instance_type = None
     while True:
         new_max_cluster_size = _retrieve_max_cluster_size(sqs_config, asg_name, max_cluster_size)
@@ -359,7 +357,7 @@ def _poll_queue(sqs_config, queue, table, asg_name):
             sqs_config,
             table,
             queue,
-            new_max_cluster_size,
+            max_cluster_size,
             instance_properties,
             force_cluster_update,
         )

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -309,7 +309,7 @@ def _process_sqs_messages(
 
 def _retrieve_max_cluster_size(sqs_config, asg_name, fallback):
     try:
-        _, _, max_size = get_asg_settings(sqs_config.region, sqs_config.proxy_config, asg_name, log)
+        _, _, max_size = get_asg_settings(sqs_config.region, sqs_config.proxy_config, asg_name)
         return max_size
     except Exception:
         return fallback
@@ -352,7 +352,7 @@ def main():
         config = _get_config()
         queue = _get_sqs_queue(config.region, config.sqsqueue, config.proxy_config)
         table = _get_ddb_table(config.region, config.table_name, config.proxy_config)
-        asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config, log)
+        asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config)
 
         _poll_queue(config, queue, table, asg_name)
     except Exception as e:

--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -340,9 +340,11 @@ def _poll_queue(sqs_config, queue, table, asg_name):
     max_cluster_size = None
     instance_type = None
     while True:
-        new_max_cluster_size = _retrieve_max_cluster_size(sqs_config, asg_name, max_cluster_size)
-        # Get instance properties
-        new_instance_type = get_compute_instance_type(sqs_config.region, sqs_config.proxy_config, sqs_config.stack_name)
+        # dynamically retrieve max_cluster_size and compute_instance_type
+        new_max_cluster_size = _retrieve_max_cluster_size(sqs_config, asg_name, fallback=max_cluster_size)
+        new_instance_type = get_compute_instance_type(
+            sqs_config.region, sqs_config.proxy_config, sqs_config.stack_name, fallback=instance_type
+        )
         force_cluster_update = new_max_cluster_size != max_cluster_size or new_instance_type != instance_type
         if new_instance_type != instance_type:
             instance_type = new_instance_type


### PR DESCRIPTION
Instance properties containing the number of vcpus to use whan adding a node to the scheduler was computed only when the jobwatcher is initialized and was using a static instance type value read from the jobwatcher config file. In case of an update of the compute instance type the jobwatcher was still using the old cpu values to compute the number of instances to start when scaling up the cluster. Now the instance properties are re-computed at every iteration of the jobwatcher and the instance type is retrieved from the cloudformation stack parameters. A better solution would consist in updating and reloading the node daemons every time a pcluster update operation is performed.

sqswatcher is now also setting the correct number of slots for the dummy-nodes and these are dynamically updated in case of cluster updates.

Additional minor enhancements:
- remove log parameter from all common.utils function. There is no need to pass the specific logger since the logging output is the same if we initialize the logger in the util module
- remove unneeded max_queue_size from sqs_config. This value is fetched from asg config
- remove unused daemons test config files to prevent these from becoming out of sync


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
