### PR TITLE
Do not scale up and maintain size when job has invalid CPU requirements

### DIFF
--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -92,7 +92,7 @@ def _poll_scheduler_status(config, asg_name, scheduler_module):
             log.critical("Error detecting number of required nodes. The cluster will not scale up.")
 
         elif pending == 0:
-            log.info("There are no pending jobs. Noop.")
+            log.info("There are no pending jobs or the requirements on pending jobs cannot be satisfied. Noop.")
 
         else:
             # Get current number of nodes

--- a/jobwatcher/plugins/utils.py
+++ b/jobwatcher/plugins/utils.py
@@ -15,18 +15,18 @@ def get_optimal_nodes(nodes_requested, slots_requested, instance_properties):
     vcpus = instance_properties.get("slots")
     slots_remaining_per_node = []
 
-    for node_idx, num_of_nodes in enumerate(nodes_requested):
-        log.info("Requested %s nodes and %s slots" % (num_of_nodes, slots_requested[node_idx]))
+    for slots, num_of_nodes in zip(slots_requested, nodes_requested):
+        log.info("Requested %s nodes and %s slots" % (num_of_nodes, slots))
         # For simplicity, uniformly distribute the numbers of cpus requested across all the requested nodes
-        slots_required_per_node = -(-slots_requested[node_idx] // num_of_nodes)
+        slots_required_per_node = -(-slots // num_of_nodes)
 
         if slots_required_per_node > vcpus:
-            # If slots required per node is greater than vcpus, add additional nodes
-            # and recalculate slots_required_per_node
-            log.info("Slots required per node is greater than vcpus, recalculating")
-            num_of_nodes = -(-slots_requested[node_idx] // vcpus)
-            slots_required_per_node = -(-slots_requested[node_idx] // num_of_nodes)
-            log.info("Recalculated: %s nodes and %s slots required per node" % (num_of_nodes, slots_required_per_node))
+            log.warning(
+                "Slots required per node (%d) is greater than vcpus available on single node (%d), skipping job...",
+                slots_required_per_node,
+                vcpus,
+            )
+            continue
 
         # Verify if there are enough available slots in the nodes allocated in the previous rounds
         for slot_idx, slots_available in enumerate(slots_remaining_per_node):

--- a/tests/jobwatcher/unittests.py
+++ b/tests/jobwatcher/unittests.py
@@ -9,36 +9,32 @@ class optimal_node_count_tests(unittest.TestCase):
     def test_empty_lists(self):
         nodes = utils.get_optimal_nodes([], [], instance_properties)
         expected = 0
-        self.assertEqual(nodes, expected, "test_empty_lists failed. Got %s; Expected: %s" % (nodes, expected))
+        self.assertEqual(nodes, expected)
 
     def test_each_node_at_capacity(self):
         nodes = utils.get_optimal_nodes([1, 5, 3], [8, 40, 24], instance_properties)
         expected = 9
-        self.assertEqual(nodes, expected, "test_exact_fit failed. Got %s; Expected: %s" % (nodes, expected))
+        self.assertEqual(nodes, expected)
 
-    def test_only_vcpus(self):
-        nodes = utils.get_optimal_nodes([1], [27], instance_properties)
-        expected = 4
-        self.assertEqual(nodes, expected, "test_exact_fit failed. Got %s; Expected: %s" % (nodes, expected))
+    def test_slots_requested_greater_than_available(self):
+        nodes = utils.get_optimal_nodes([1], [9], instance_properties)
+        expected = 0
+        self.assertEqual(nodes, expected)
 
     def test_each_node_half_capacity(self):
         nodes = utils.get_optimal_nodes([1, 5, 3], [4, 20, 12], instance_properties)
         expected = 5
-        self.assertEqual(nodes, expected, "test_exact_fit failed: Got %s; Expected: %s" % (nodes, expected))
+        self.assertEqual(nodes, expected)
 
     def test_each_node_one_vcpu_except_max(self):
         nodes = utils.get_optimal_nodes([1, 5, 3], [1, 40, 1], instance_properties)
         expected = 8
-        self.assertEqual(
-            nodes, expected, "test_each_node_one_vcpu_except_max failed: Got %s; Expected: %s" % (nodes, expected)
-        )
+        self.assertEqual(nodes, expected)
 
     def test_each_node_partial_capacity(self):
         nodes = utils.get_optimal_nodes([1, 5, 3, 2], [6, 35, 1, 1], instance_properties)
         expected = 6
-        self.assertEqual(
-            nodes, expected, "test_each_node_partial_capacity failed: Got %s; Expected: %s" % (nodes, expected)
-        )
+        self.assertEqual(nodes, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes the following issues:
- Cluster won't scale up in case a submitted job requires more slots per node than the max available on the specific instance type. The fix is applied to slurm and torque schedulers. SGE does not have the concept of slots reserved per node.
- [slurm only] cluster won't maintain the current size in case the only pending jobs are those with invalid CPU requirements. This fix still needs to be applied to torque scheduler.

Some minimal tests: https://github.com/aws/aws-parallelcluster/pull/1020 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
