### PR TITLE
nodewatcher: self-terminate node in case of failures

### DIFF
--- a/common/time_utils.py
+++ b/common/time_utils.py
@@ -1,0 +1,21 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+
+def minutes(min):
+    """Convert minutes to milliseconds."""
+    return min * seconds(60)
+
+
+def seconds(sec):
+    """Convert seconds to milliseconds"""
+    return sec * 1000

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -96,8 +96,8 @@ def _poll_scheduler_status(config, asg_name, scheduler_module):
 
         else:
             # Get current number of nodes
-            running = scheduler_module.get_busy_nodes(instance_properties)
-            log.info("%d nodes requested, %d nodes running", pending, running)
+            running = scheduler_module.get_busy_nodes()
+            log.info("%d nodes requested, %d nodes busy or unavailable", pending, running)
 
             # get current limits
             _, current_desired, max_size = get_asg_settings(config.region, config.proxy_config, asg_name)

--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -21,7 +21,7 @@ def get_required_nodes(instance_properties):
 
 # get nodes reserved by running jobs
 # if a host has 1 or more job running on it, it'll be marked busy
-def get_busy_nodes(instance_properties):
+def get_busy_nodes():
     command = "qstat -f"
     _output = check_sge_command_output(command)
     nodes = 0

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -34,16 +34,17 @@ def get_required_nodes(instance_properties):
 
 # get nodes reserved by running jobs
 def get_busy_nodes(instance_properties):
-    command = "/opt/slurm/bin/sinfo -r -h -o '%D %t'"
+    command = "/opt/slurm/bin/sinfo -h -o '%D %t'"
     # Sample output:
     # 2 mix
     # 4 alloc
     # 10 idle
+    # 1 down*
     output = check_command_output(command)
     nodes = 0
     output = output.split("\n")
     for line in output:
         line_arr = line.split()
-        if len(line_arr) == 2 and (line_arr[1] in ["mix", "alloc", "drain", "drain*"]):
+        if len(line_arr) == 2 and (line_arr[1] in ["mix", "alloc", "drain", "drain*", "down", "down*"]):
             nodes += int(line_arr[0])
     return nodes

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -33,7 +33,7 @@ def get_required_nodes(instance_properties):
 
 
 # get nodes reserved by running jobs
-def get_busy_nodes(instance_properties):
+def get_busy_nodes():
     command = "/opt/slurm/bin/sinfo -h -o '%D %t'"
     # Sample output:
     # 2 mix

--- a/jobwatcher/plugins/torque.py
+++ b/jobwatcher/plugins/torque.py
@@ -35,7 +35,7 @@ def get_required_nodes(instance_properties):
 
 
 # get nodes reserved by running jobs
-def get_busy_nodes(instance_properties):
+def get_busy_nodes():
     command = "/opt/torque/bin/pbsnodes -x"
     # The output of the command
     # <?xml version="1.0" encoding="UTF-8"?>

--- a/nodewatcher/plugins/sge.py
+++ b/nodewatcher/plugins/sge.py
@@ -56,7 +56,8 @@ def hasPendingJobs():
         lines = filter(None, output.split("\n"))
         has_pending = True if len(lines) > 1 else False
         error = False
-    except subprocess.CalledProcessError:
+    except Exception as e:
+        log.error("Failed when checking if node is down with exception %s. Reporting node as down.", e)
         error = True
         has_pending = False
 

--- a/nodewatcher/plugins/sge.py
+++ b/nodewatcher/plugins/sge.py
@@ -72,3 +72,9 @@ def lockHost(hostname, unlock=False):
         run_sge_command(command)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)
+
+
+def is_node_down():
+    """Check if node is down according to scheduler"""
+    # ToDo: to be implemented
+    return False

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -89,6 +89,24 @@ def lockHost(hostname, unlock=False):
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)
 
 
+def is_node_down():
+    """Check if node is down according to scheduler"""
+    try:
+        # retrieves the state of a specific node
+        # https://slurm.schedmd.com/sinfo.html#lbAG
+        # Output format:
+        # down*
+        command = "/bin/bash -c \"/opt/slurm/bin/sinfo --noheader -o '%T' -n $(hostname)\""
+        output = check_command_output(command).strip()
+        log.info("Node is in state: '{0}'".format(output))
+        if output and all(state not in output for state in ["down", "drained", "fail"]):
+            return False
+    except Exception as e:
+        log.error("Failed when checking if node is down with exception %s. Reporting node as down.", e)
+
+    return True
+
+
 def _get_node_slots():
     hostname = check_command_output("hostname")
     # retrieves number of slots for a specific node in the cluster.

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -54,7 +54,8 @@ def hasPendingJobs():
                     break
 
         error = False
-    except subprocess.CalledProcessError:
+    except Exception as e:
+        log.warning("Failed when checking for pending jobs with exception %s. Assuming no pending jobs.", e)
         error = True
         has_pending = False
 
@@ -90,6 +91,9 @@ def lockHost(hostname, unlock=False):
 
 def _get_node_slots():
     hostname = check_command_output("hostname")
+    # retrieves number of slots for a specific node in the cluster.
+    # Output format:
+    # 4
     command = "/opt/slurm/bin/sinfo -o '%c' -n {0} -h".format(hostname)
     output = check_command_output(command)
     return int(output)

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -89,3 +89,9 @@ def lockHost(hostname, unlock=False):
         run_command(command)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)
+
+
+def is_node_down():
+    """Check if node is down according to scheduler"""
+    # ToDo: to be implemented
+    return False

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -73,7 +73,8 @@ def hasPendingJobs():
 
         has_pending = pending > 0
         error = False
-    except (subprocess.CalledProcessError, CriticalError):
+    except Exception as e:
+        log.error("Failed when checking if node is down with exception %s. Reporting node as down.", e)
         error = True
         has_pending = False
 

--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -16,9 +16,8 @@ import subprocess
 import time
 from tempfile import NamedTemporaryFile
 
-import paramiko
-
 import common.sge as sge
+import paramiko
 from common.sge import check_sge_command_output, run_sge_command
 
 log = logging.getLogger(__name__)

--- a/sqswatcher/plugins/slurm.py
+++ b/sqswatcher/plugins/slurm.py
@@ -22,9 +22,9 @@ from multiprocessing import Pool
 from shutil import move
 from tempfile import mkstemp
 
-import paramiko
 from retrying import retry
 
+import paramiko
 from common.utils import run_command
 
 log = logging.getLogger(__name__)

--- a/sqswatcher/plugins/torque.py
+++ b/sqswatcher/plugins/torque.py
@@ -16,7 +16,6 @@ import time
 from xml.etree import ElementTree
 
 import paramiko
-
 from common.utils import check_command_output, run_command
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
* nodewatcher: handle broader Exception in hasPendingJobs - this allows to better handle all exceptions that might happen when checking for pending jobs. In such cases we assume there are no pending jobs
* jobwatcher - slurm: add down nodes to busy nodes count - This is done to speedup cluster recovery in case of failing nodes. jobwatcher will start requesting an additional node if possible while nodewatcher will take care of terminating the faulty instance.
* nodewatcher: add logic to self terminate failing node - nodewatcher is now able to self-teminate the instance in case the node is reported as down by the scheduler or if not attached to scheduler at all. The logs are dumped to the shared /home/logs/compute directory in order to facilitate future investigations.
  * at nodewatcher startup there is a timeout of 3 minutes before termination in order to allow the scheduler to register the new node. Note that now the nodewatcher is started at the end of user-data so this delay is not affected by the execution of userdata or custom post_install script
  * every minute nodewatcher verifies the status of the node and if this is marked as down by the scheduler or the scheduler is unresponsive it terminates the node. Before terminating the node 1 minute is allowed for recovery.

Note: functions to verify if node is down for sge and torque still have to be implemented

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
