### PR TITLE
nodewatcher - sge: check only for running jobs in hasJobs function

### DIFF
--- a/nodewatcher/plugins/sge.py
+++ b/nodewatcher/plugins/sge.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 def hasJobs(hostname):
     # Checking for running jobs on the node, with parallel job view expanded (-g t)
-    command = "qstat -g t -l hostname={0} -u '*'".format(hostname)
+    command = "qstat -s rs -g t -l hostname={0} -u '*'".format(hostname)
 
     # Command output
     # job-ID  prior   name       user         state submit/start at     queue                          master ja-task-ID


### PR DESCRIPTION
Submitted jobs
```
[centos@ip-10-0-0-208 ~]$ qstat
job-ID  prior   name       user         state submit/start at     queue                          slots ja-task-ID
-----------------------------------------------------------------------------------------------------------------
     67 0.55500 STDIN      centos       r     05/15/2019 10:46:51 all.q@ip-10-0-0-166.eu-west-1.     1
     68 0.00000 STDIN      centos       qw    05/15/2019 10:46:55                                    8
```

With fix:
```
[centos@ip-10-0-0-208 ~]$ qstat -s r -g t -l hostname=ip-10-0-0-166 -u '*'
job-ID  prior   name       user         state submit/start at     queue                          master ja-task-ID
------------------------------------------------------------------------------------------------------------------
     67 0.50500 STDIN      centos       r     05/15/2019 10:46:51 all.q@ip-10-0-0-166.eu-west-1. MASTER
```

Without fix:
```
[centos@ip-10-0-0-208 ~]$ qstat -g t -l hostname=ip-10-0-0-166 -u '*'
job-ID  prior   name       user         state submit/start at     queue                          master ja-task-ID
------------------------------------------------------------------------------------------------------------------
     67 0.50500 STDIN      centos       r     05/15/2019 10:46:51 all.q@ip-10-0-0-166.eu-west-1. MASTER
     68 0.60500 STDIN      centos       qw    05/15/2019 10:46:55
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
