### PR TITLE
Sge: scaling enhancements and unit testing

### DIFF
--- a/common/schedulers/sge_commands.py
+++ b/common/schedulers/sge_commands.py
@@ -56,7 +56,14 @@ QCONF_COMMANDS = {
 # S(ubordinate), d(isabled), D(isabled), E(rror), c(configuration ambiguous), o(rphaned), P(reempted),
 # or some combination thereof.
 # Refer to qstat man page for additional details.
-SGE_BUSY_STATES = ["u", "C", "s", "d", "D", "E", "o", "P"]
+# o(rphaned) is not considered as busy since we assume a node in orphaned state is not present in ASG anymore
+SGE_BUSY_STATES = ["u", "C", "s", "d", "D", "E", "P"]
+
+# If an o(rphaned) state is displayed for a queue instance, it indicates that the queue instance is no longer demanded
+# by the current cluster queue configuration or the host group configuration. The queue instance is kept because jobs
+# which have not yet finished are still associated with it, and it will vanish from qstat output when these jobs
+# have finished.
+SGE_ORPHANED_STATE = "o"
 
 # The states q(ueued)/w(aiting) and h(old) only appear for pending jobs. Pending, unheld job`s are displayed as qw.
 # The h(old) state indicates that a job currently is not eligible for execution due to a hold state assigned to it

--- a/common/schedulers/sge_commands.py
+++ b/common/schedulers/sge_commands.py
@@ -56,7 +56,7 @@ QCONF_COMMANDS = {
 # S(ubordinate), d(isabled), D(isabled), E(rror), c(configuration ambiguous), o(rphaned), P(reempted),
 # or some combination thereof.
 # Refer to qstat man page for additional details.
-SGE_BUSY_STATES = ["u", "C", "s", "d", "D", "E", "o"]
+SGE_BUSY_STATES = ["u", "C", "s", "d", "D", "E", "o", "P"]
 
 # The states q(ueued)/w(aiting) and h(old) only appear for pending jobs. Pending, unheld job`s are displayed as qw.
 # The h(old) state indicates that a job currently is not eligible for execution due to a hold state assigned to it

--- a/common/schedulers/sge_commands.py
+++ b/common/schedulers/sge_commands.py
@@ -264,7 +264,7 @@ class SgeJob(SgeObject):
         "state": {"field": "state"},
         "master": {"field": "node_type"},
         "tasks": {"field": "array_index", "transformation": lambda x: int(x) if x is not None else None},
-        "queue_name": {"field": "hostname"},
+        "queue_name": {"field": "hostname", "transformation": lambda name: name.split("@", 1)[1] if name else None},
     }
 
     def __init__(self, number=None, slots=0, state="", node_type=None, array_index=None, hostname=None):
@@ -310,7 +310,7 @@ class SgeHost(SgeObject):
     #     </job_list>
     # </Queue-List>
     MAPPINGS = {
-        "name": {"field": "name"},
+        "name": {"field": "name", "transformation": lambda name: name.split("@", 1)[1] if name else None},
         "slots_used": {"field": "slots_used", "transformation": int},
         "slots_total": {"field": "slots_total", "transformation": int},
         "slots_resv": {"field": "slots_reserved", "transformation": int},

--- a/common/schedulers/sge_commands.py
+++ b/common/schedulers/sge_commands.py
@@ -184,7 +184,7 @@ def get_compute_nodes_info(hostname_filter=None, job_state_filter=None):
     root = ElementTree.fromstring(output)
     queue_info = root.findall("./queue_info/*")
     hosts_list = [SgeHost.from_xml(ElementTree.tostring(host)) for host in queue_info]
-    return {host.name: host for host in hosts_list}
+    return dict((host.name, host) for host in hosts_list)
 
 
 def get_jobs_info(hostname_filter=None, job_state_filter=None):

--- a/jobwatcher/jobwatcher.py
+++ b/jobwatcher/jobwatcher.py
@@ -85,8 +85,11 @@ def _poll_scheduler_status(config, asg_name, scheduler_module):
             instance_type = new_instance_type
             instance_properties = get_instance_properties(config.region, config.proxy_config, instance_type)
 
+        # get current limits
+        _, current_desired, max_size = get_asg_settings(config.region, config.proxy_config, asg_name)
+
         # Get number of nodes requested
-        pending = scheduler_module.get_required_nodes(instance_properties)
+        pending = scheduler_module.get_required_nodes(instance_properties, max_size)
 
         if pending < 0:
             log.critical("Error detecting number of required nodes. The cluster will not scale up.")
@@ -98,9 +101,6 @@ def _poll_scheduler_status(config, asg_name, scheduler_module):
             # Get current number of nodes
             running = scheduler_module.get_busy_nodes()
             log.info("%d nodes requested, %d nodes busy or unavailable", pending, running)
-
-            # get current limits
-            _, current_desired, max_size = get_asg_settings(config.region, config.proxy_config, asg_name)
 
             # Check to make sure requested number of instances is within ASG limits
             required = running + pending

--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -1,5 +1,6 @@
 import logging
 
+from common.schedulers.sge_commands import SGE_BUSY_STATES, get_compute_nodes_info
 from common.sge import check_sge_command_output
 
 log = logging.getLogger(__name__)
@@ -19,18 +20,18 @@ def get_required_nodes(instance_properties):
     return -(-slots // vcpus)
 
 
-# get nodes reserved by running jobs
-# if a host has 1 or more job running on it, it'll be marked busy
 def get_busy_nodes():
-    command = "qstat -f"
-    _output = check_sge_command_output(command)
-    nodes = 0
-    output = _output.split("\n")[2:]
-    for line in output:
-        line_arr = line.split()
-        if len(line_arr) == 5:
-            # resv/used/tot.
-            (resv, used, total) = line_arr[2].split("/")
-            if int(used) > 0 or int(resv) > 0:
-                nodes += 1
-    return nodes
+    """
+    Count nodes that have at least 1 job running or have a state that makes them unusable for jobs submission.
+    """
+    nodes = get_compute_nodes_info()
+    busy_nodes = 0
+    for node in nodes.values():
+        if (
+            any(busy_state in node.state for busy_state in SGE_BUSY_STATES)
+            or int(node.slots_used) > 0
+            or int(node.slots_reserved) > 0
+        ):
+            busy_nodes += 1
+
+    return busy_nodes

--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -1,6 +1,6 @@
 import logging
 
-from common.schedulers.sge_commands import SGE_BUSY_STATES, get_compute_nodes_info, get_jobs_info
+from common.schedulers.sge_commands import SGE_BUSY_STATES, SGE_HOLD_STATE, get_compute_nodes_info, get_jobs_info
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +18,8 @@ def _get_required_slots(instance_properties, max_size):
                 job.slots,
                 max_cluster_slots,
             )
+        elif SGE_HOLD_STATE in job.state:
+            log.info("Skipping job %s since in hold state (%s)", job.number, job.state)
         else:
             slots += job.slots
 

--- a/jobwatcher/plugins/sge.py
+++ b/jobwatcher/plugins/sge.py
@@ -3,6 +3,7 @@ import logging
 from common.schedulers.sge_commands import (
     SGE_BUSY_STATES,
     SGE_HOLD_STATE,
+    SGE_ORPHANED_STATE,
     get_compute_nodes_info,
     get_pending_jobs_info,
 )
@@ -40,6 +41,13 @@ def get_busy_nodes():
             or int(node.slots_used) > 0
             or int(node.slots_reserved) > 0
         ):
-            busy_nodes += 1
+            if SGE_ORPHANED_STATE in node.state:
+                logging.info(
+                    "Skipping host %s since in orphaned state, hence not in ASG. "
+                    "Host will disappear when assigned jobs are deleted.",
+                    node.name,
+                )
+            else:
+                busy_nodes += 1
 
     return busy_nodes

--- a/jobwatcher/plugins/slurm.py
+++ b/jobwatcher/plugins/slurm.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 # get nodes requested from pending jobs
-def get_required_nodes(instance_properties):
+def get_required_nodes(instance_properties, max_size):
     log.info("Computing number of required nodes for submitted jobs")
     command = "/opt/slurm/bin/squeue -r -h -o '%i-%t-%D-%C-%r'"
     # Example output of squeue

--- a/jobwatcher/plugins/torque.py
+++ b/jobwatcher/plugins/torque.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 # get nodes requested from pending jobs
-def get_required_nodes(instance_properties):
+def get_required_nodes(instance_properties, max_size):
     command = "/opt/torque/bin/qstat -at"
 
     # Example output of torque

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -206,7 +206,10 @@ def _terminate_if_down(scheduler_module, config, asg_name, instance_id, max_wait
 
     @retry(wait_fixed=seconds(10), retry_on_result=lambda result: result is True, stop_max_delay=max_wait)
     def _poll_wait_for_node_ready():
-        return scheduler_module.is_node_down()
+        is_down = scheduler_module.is_node_down()
+        if is_down:
+            log.warning("Node reported as down")
+        return is_down
 
     try:
         _poll_wait_for_node_ready()

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -29,7 +29,14 @@ from configparser import ConfigParser
 from retrying import RetryError, retry
 
 from common.time_utils import minutes, seconds
-from common.utils import CriticalError, get_asg_name, load_module
+from common.utils import (
+    CriticalError,
+    get_asg_name,
+    get_asg_settings,
+    get_compute_instance_type,
+    get_instance_properties,
+    load_module,
+)
 
 log = logging.getLogger(__name__)
 
@@ -111,18 +118,6 @@ def _has_jobs(scheduler_module, hostname):
     _jobs = scheduler_module.hasJobs(hostname)
     log.debug("jobs=%s" % _jobs)
     return _jobs
-
-
-def _has_pending_jobs(scheduler_module):
-    """
-    Verify if there are penging jobs in the cluster.
-
-    :param scheduler_module: scheduler specific module to use
-    :return: true if there are pending jobs and the error code
-    """
-    _has_pending_jobs, _error = scheduler_module.hasPendingJobs()
-    log.debug("has_pending_jobs=%s, error=%s" % (_has_pending_jobs, _error))
-    return _has_pending_jobs, _error
 
 
 def _lock_host(scheduler_module, hostname, unlock=False):
@@ -301,10 +296,19 @@ def _poll_instance_status(config, scheduler_module, asg_name, hostname, instance
     _terminate_if_down(scheduler_module, config, asg_name, instance_id, INITIAL_TERMINATE_TIMEOUT)
 
     idletime = _init_idletime()
+    instance_type = None
     while True:
         time.sleep(60)
         _store_idletime(idletime)
         _terminate_if_down(scheduler_module, config, asg_name, instance_id, TERMINATE_TIMEOUT)
+
+        # Get instance properties
+        new_instance_type = get_compute_instance_type(
+            config.region, config.proxy_config, config.stack_name, fallback=instance_type
+        )
+        if new_instance_type != instance_type:
+            instance_type = new_instance_type
+            instance_properties = get_instance_properties(config.region, config.proxy_config, instance_type)
 
         has_jobs = _has_jobs(scheduler_module, hostname)
         if has_jobs:
@@ -316,7 +320,8 @@ def _poll_instance_status(config, scheduler_module, asg_name, hostname, instance
                 log.info("Not terminating due to min cluster size reached")
                 idletime = 0
             else:
-                has_pending_jobs, error = _has_pending_jobs(scheduler_module)
+                _, _, max_size = get_asg_settings(config.region, config.proxy_config, asg_name)
+                has_pending_jobs, error = scheduler_module.hasPendingJobs(instance_properties, max_size)
                 if error:
                     log.warning(
                         "Encountered an error while polling queue for pending jobs. Skipping pending jobs check"

--- a/nodewatcher/plugins/sge.py
+++ b/nodewatcher/plugins/sge.py
@@ -13,58 +13,39 @@ import logging
 import socket
 import subprocess
 
-from common.schedulers.sge_commands import SGE_ERROR_STATES, get_compute_nodes_info, lock_host, unlock_host
-from common.sge import check_sge_command_output
+from common.schedulers.sge_commands import (
+    SGE_ERROR_STATES,
+    SGE_HOLD_STATE,
+    get_compute_nodes_info,
+    get_jobs_info,
+    get_pending_jobs_info,
+    lock_host,
+    unlock_host,
+)
 from common.utils import check_command_output
 
 log = logging.getLogger(__name__)
 
 
 def hasJobs(hostname):
-    # Checking for running jobs on the node, with parallel job view expanded (-g t)
-    command = "qstat -s rs -g t -l hostname={0} -u '*'".format(hostname)
-
-    # Command output
-    # job-ID  prior   name       user         state submit/start at     queue                          master ja-task-ID
-    # ------------------------------------------------------------------------------------------------------------------
-    # 16 0.6 0500 job.sh     ec2-user     r     02/06/2019 11:06:30 all.q@ip-172-31-68-26.ec2.inte SLAVE
-    #                                                               all.q@ip-172-31-68-26.ec2.inte SLAVE
-    #                                                               all.q@ip-172-31-68-26.ec2.inte SLAVE
-    #                                                               all.q@ip-172-31-68-26.ec2.inte SLAVE
-    # 17 0.50500 STDIN      ec2-user     r     02/06/2019 11:06:30 all.q@ip-172-31-68-26.ec2.inte MASTER 1
-    # 17 0.50500 STDIN      ec2-user     r     02/06/2019 11:06:30 all.q@ip-172-31-68-26.ec2.inte MASTER 2
-
     try:
-        output = check_sge_command_output(command)
-        has_jobs = output != ""
-    except subprocess.CalledProcessError:
-        has_jobs = False
-
-    return has_jobs
-
-
-def hasPendingJobs():
-    command = "qstat -g d -s p -u '*'"
-
-    # Command outputs the pending jobs in the queue in the following format
-    # job-ID  prior   name       user         state submit/start at     queue                          slots ja-task-ID
-    # -----------------------------------------------------------------------------------------------------------------
-    #      70 0.55500 job.sh     ec2-user     qw    08/08/2018 22:37:24                                    1
-    #      71 0.55500 job.sh     ec2-user     qw    08/08/2018 22:37:24                                    1
-    #      72 0.55500 job.sh     ec2-user     qw    08/08/2018 22:37:25                                    1
-    #      73 0.55500 job.sh     ec2-user     qw    08/08/2018 22:37:25                                    1
-
-    try:
-        output = check_sge_command_output(command)
-        lines = filter(None, output.split("\n"))
-        has_pending = True if len(lines) > 1 else False
-        error = False
+        # Checking for running or suspended jobs on the node
+        # According to the manual (man sge_status) h(old) state only appears in conjunction with r(unning) or p(ending)
+        jobs = get_jobs_info(hostname_filter=hostname, job_state_filter="rs")
+        return len(jobs) > 0
     except Exception as e:
-        log.error("Failed when checking if node is down with exception %s. Reporting node as down.", e)
-        error = True
-        has_pending = False
+        log.error("Failed when checking for running jobs with exception %s", e)
+        return False
 
-    return has_pending, error
+
+def hasPendingJobs(instance_properties, max_size):
+    try:
+        max_cluster_slots = max_size * instance_properties.get("slots")
+        pending_jobs = get_pending_jobs_info(max_slots_filter=max_cluster_slots, skip_if_state=SGE_HOLD_STATE)
+        return len(pending_jobs) > 0, False
+    except Exception as e:
+        log.error("Failed when checking if node is down with exception %s. Reporting no pending jobs.", e)
+        return False, True
 
 
 def lockHost(hostname, unlock=False):

--- a/nodewatcher/plugins/sge.py
+++ b/nodewatcher/plugins/sge.py
@@ -71,11 +71,11 @@ def is_node_down():
         hostname = check_command_output("hostname").strip()
         host_fqdn = socket.getfqdn(hostname)
         nodes = get_compute_nodes_info(hostname_filter=hostname)
-        if not any(host in nodes for host in ["all.q@" + hostname, "all.q@" + host_fqdn]):
+        if not any(host in nodes for host in [hostname, host_fqdn]):
             log.warning("Node is not attached to scheduler. Reporting as down")
             return True
 
-        node = nodes.get("all.q@" + host_fqdn, nodes.get("all.q@" + hostname))
+        node = nodes.get(host_fqdn, nodes.get(hostname))
         log.info("Node is in state: '{0}'".format(node.state))
         if all(error_state not in node.state for error_state in SGE_ERROR_STATES):
             return False

--- a/nodewatcher/plugins/slurm.py
+++ b/nodewatcher/plugins/slurm.py
@@ -32,7 +32,7 @@ def hasJobs(hostname):
     return has_jobs
 
 
-def hasPendingJobs():
+def hasPendingJobs(instance_properties, max_size):
     command = "/opt/slurm/bin/squeue -t PD --noheader -o '%c-%r'"
 
     # Command outputs the pending jobs in the queue in the following format

--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -49,7 +49,7 @@ def hasJobs(hostname):
     return has_jobs
 
 
-def hasPendingJobs():
+def hasPendingJobs(instance_properties, max_size):
     command = "/opt/torque/bin/qstat -Q"
 
     # Command outputs the status of the queue in the following format

--- a/tests/common/schedulers/test_sge_commands.py
+++ b/tests/common/schedulers/test_sge_commands.py
@@ -30,8 +30,8 @@ from tests.common import read_text
         (
             "qstat_output_mix.xml",
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=3,
                     slots_reserved=0,
@@ -42,16 +42,16 @@ from tests.common import read_text
                         SgeJob(number="91", slots=1, state="r", node_type="MASTER", array_index=3, hostname=None),
                     ],
                 ),
-                "all.q@ip-10-0-0-52.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-52.eu-west-1.compute.internal",
+                "ip-10-0-0-52.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-52.eu-west-1.compute.internal",
                     slots_total=8,
                     slots_used=0,
                     slots_reserved=0,
                     state="d",
                     jobs=[],
                 ),
-                "all.q@ip-10-0-0-116.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-116.eu-west-1.compute.internal",
+                "ip-10-0-0-116.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-116.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
@@ -89,7 +89,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="hr",
                     node_type="MASTER",
                     array_index=3,
-                    hostname="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-166.eu-west-1.compute.internal",
                 ),
                 SgeJob(
                     number="96",
@@ -97,7 +97,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="r",
                     node_type="MASTER",
                     array_index=None,
-                    hostname="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-166.eu-west-1.compute.internal",
                 ),
                 SgeJob(
                     number="96",
@@ -105,7 +105,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="r",
                     node_type="SLAVE",
                     array_index=None,
-                    hostname="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-166.eu-west-1.compute.internal",
                 ),
                 SgeJob(
                     number="96",
@@ -113,7 +113,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="r",
                     node_type="SLAVE",
                     array_index=None,
-                    hostname="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-166.eu-west-1.compute.internal",
                 ),
                 SgeJob(
                     number="73",
@@ -121,7 +121,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="s",
                     node_type="MASTER",
                     array_index=None,
-                    hostname="all.q@ip-10-0-0-52.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-52.eu-west-1.compute.internal",
                 ),
                 SgeJob(
                     number="94",
@@ -129,7 +129,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="r",
                     node_type="MASTER",
                     array_index=None,
-                    hostname="all.q@ip-10-0-0-52.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-52.eu-west-1.compute.internal",
                 ),
                 SgeJob(
                     number="95",
@@ -137,7 +137,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="hr",
                     node_type="MASTER",
                     array_index=1,
-                    hostname="all.q@ip-10-0-0-52.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-52.eu-west-1.compute.internal",
                 ),
                 SgeJob(
                     number="95",
@@ -145,7 +145,7 @@ def test_get_compute_nodes_info(qstat_mocked_response, expected_output, test_dat
                     state="hr",
                     node_type="MASTER",
                     array_index=2,
-                    hostname="all.q@ip-10-0-0-52.eu-west-1.compute.internal",
+                    hostname="ip-10-0-0-52.eu-west-1.compute.internal",
                 ),
                 SgeJob(number="97", slots=3, state="qw", node_type=None, array_index=None, hostname=None),
                 SgeJob(number="72", slots=8, state="hqw", node_type=None, array_index=None, hostname=None),
@@ -189,7 +189,7 @@ def test_sge_job_parsing(sge_job_xml, expected_output, test_datadir):
         (
             "host.xml",
             SgeHost(
-                name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                name="ip-10-0-0-166.eu-west-1.compute.internal",
                 slots_total=4,
                 slots_used=4,
                 slots_reserved=0,
@@ -205,7 +205,7 @@ def test_sge_job_parsing(sge_job_xml, expected_output, test_datadir):
         (
             "host_no_jobs.xml",
             SgeHost(
-                name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                name="ip-10-0-0-166.eu-west-1.compute.internal",
                 slots_total=4,
                 slots_used=0,
                 slots_reserved=0,

--- a/tests/common/schedulers/test_sge_commands.py
+++ b/tests/common/schedulers/test_sge_commands.py
@@ -28,8 +28,8 @@ from tests.common import read_text
     [
         (
             "qstat_output_mix.xml",
-            [
-                SgeHost(
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
                     name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=3,
@@ -41,7 +41,7 @@ from tests.common import read_text
                         SgeJob(number="91", slots=1, state="r", node_type="MASTER", array_index=3, hostname=None),
                     ],
                 ),
-                SgeHost(
+                "all.q@ip-10-0-0-52.eu-west-1.compute.internal": SgeHost(
                     name="all.q@ip-10-0-0-52.eu-west-1.compute.internal",
                     slots_total=8,
                     slots_used=0,
@@ -49,7 +49,7 @@ from tests.common import read_text
                     state="d",
                     jobs=[],
                 ),
-                SgeHost(
+                "all.q@ip-10-0-0-116.eu-west-1.compute.internal": SgeHost(
                     name="all.q@ip-10-0-0-116.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
@@ -57,10 +57,10 @@ from tests.common import read_text
                     state="au",
                     jobs=[],
                 ),
-            ],
+            },
         ),
-        ("qstat_output_empty.xml", []),
-        ("qstat_output_empty_xml.xml", []),
+        ("qstat_output_empty.xml", {}),
+        ("qstat_output_empty_xml.xml", {}),
     ],
     ids=["mixed_output", "empty_output", "empty_xml_output"],
 )

--- a/tests/jobwatcher/__init__.py
+++ b/tests/jobwatcher/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/jobwatcher/plugins/__init__.py
+++ b/tests/jobwatcher/plugins/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/jobwatcher/plugins/test_sge.py
+++ b/tests/jobwatcher/plugins/test_sge.py
@@ -1,3 +1,13 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 import pytest
 
 from assertpy import assert_that

--- a/tests/jobwatcher/plugins/test_sge.py
+++ b/tests/jobwatcher/plugins/test_sge.py
@@ -1,7 +1,7 @@
 import pytest
 
 from assertpy import assert_that
-from common.schedulers.sge_commands import SgeHost, SgeJob
+from common.schedulers.sge_commands import SGE_HOLD_STATE, SgeHost, SgeJob
 from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
 
 
@@ -124,8 +124,9 @@ def test_get_busy_nodes(cluster_nodes, expected_busy_nodes, mocker):
             4,
         ),
         ([SgeJob(number="89", slots=40, state="qw")], 10),
+        ([SgeJob(number="89", slots=40, state="qwh"), SgeJob(number="90", slots=5, state="qw")], 2),
     ],
-    ids=["single_job", "max_cluster_size", "multiple_jobs", "max_size_job"],
+    ids=["single_job", "max_cluster_size", "multiple_jobs", "max_size_job", "hold_state"],
 )
 def test_get_required_nodes(pending_jobs, expected_required_nodes, mocker):
     mock = mocker.patch("jobwatcher.plugins.sge.get_jobs_info", return_value=pending_jobs, autospec=True)

--- a/tests/jobwatcher/plugins/test_sge.py
+++ b/tests/jobwatcher/plugins/test_sge.py
@@ -20,8 +20,8 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
     [
         (
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=3,
                     slots_reserved=0,
@@ -33,8 +33,8 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
         ),
         (
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
@@ -46,16 +46,16 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
         ),
         (
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
                     state="a",
                     jobs=[],
                 ),
-                "all.q@ip-10-0-0-167.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-167.eu-west-1.compute.internal",
+                "ip-10-0-0-167.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-167.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
@@ -67,48 +67,48 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
         ),
         (
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
                     state="a",
                     jobs=[],
                 ),
-                "all.q@ip-10-0-0-167.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-167.eu-west-1.compute.internal",
+                "ip-10-0-0-167.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-167.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
                     state="",
                     jobs=[],
                 ),
-                "all.q@ip-10-0-0-168.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-168.eu-west-1.compute.internal",
+                "ip-10-0-0-168.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-168.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=1,
                     state="",
                     jobs=[],
                 ),
-                "all.q@ip-10-0-0-169.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-169.eu-west-1.compute.internal",
+                "ip-10-0-0-169.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-169.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=3,
                     slots_reserved=0,
                     state="",
                     jobs=[SgeJob(number="89", slots=1, state="r", node_type="MASTER", array_index=None, hostname=None)],
                 ),
-                "all.q@ip-10-0-0-170.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-170.eu-west-1.compute.internal",
+                "ip-10-0-0-170.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-170.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
                     state="d",
                     jobs=[],
                 ),
-                "all.q@ip-10-0-0-171.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-171.eu-west-1.compute.internal",
+                "ip-10-0-0-171.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-171.eu-west-1.compute.internal",
                     slots_total=0,
                     slots_used=0,
                     slots_reserved=0,
@@ -120,8 +120,8 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
         ),
         (
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,

--- a/tests/jobwatcher/plugins/test_sge.py
+++ b/tests/jobwatcher/plugins/test_sge.py
@@ -1,0 +1,109 @@
+import pytest
+
+from assertpy import assert_that
+from common.schedulers.sge_commands import SgeHost, SgeJob
+from jobwatcher.plugins.sge import get_busy_nodes
+
+
+@pytest.mark.parametrize(
+    "cluster_nodes, expected_busy_nodes",
+    [
+        (
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=3,
+                    slots_reserved=0,
+                    state="",
+                    jobs=[SgeJob(number="89", slots=1, state="r", node_type="MASTER", array_index=None, hostname=None)],
+                )
+            },
+            1,
+        ),
+        (
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="u",
+                    jobs=[],
+                )
+            },
+            1,
+        ),
+        (
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="a",
+                    jobs=[],
+                ),
+                "all.q@ip-10-0-0-167.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-167.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="",
+                    jobs=[],
+                ),
+            },
+            0,
+        ),
+        (
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="a",
+                    jobs=[],
+                ),
+                "all.q@ip-10-0-0-167.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-167.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="",
+                    jobs=[],
+                ),
+                "all.q@ip-10-0-0-168.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-168.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=1,
+                    state="",
+                    jobs=[],
+                ),
+                "all.q@ip-10-0-0-169.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-169.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=3,
+                    slots_reserved=0,
+                    state="",
+                    jobs=[SgeJob(number="89", slots=1, state="r", node_type="MASTER", array_index=None, hostname=None)],
+                ),
+                "all.q@ip-10-0-0-170.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-170.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="d",
+                    jobs=[],
+                ),
+            },
+            3,
+        ),
+    ],
+    ids=["single_running_job", "unavailable_node", "available_nodes", "mixed_nodes"],
+)
+def test_get_busy_nodes(cluster_nodes, expected_busy_nodes, mocker):
+    mocker.patch("jobwatcher.plugins.sge.get_compute_nodes_info", return_value=cluster_nodes, autospec=True)
+
+    assert_that(get_busy_nodes()).is_equal_to(expected_busy_nodes)

--- a/tests/jobwatcher/plugins/test_sge.py
+++ b/tests/jobwatcher/plugins/test_sge.py
@@ -107,11 +107,32 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
                     state="d",
                     jobs=[],
                 ),
+                "all.q@ip-10-0-0-171.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-171.eu-west-1.compute.internal",
+                    slots_total=0,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="ao",
+                    jobs=[],
+                ),
             },
             3,
         ),
+        (
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="auo",
+                    jobs=[],
+                )
+            },
+            0,
+        ),
     ],
-    ids=["single_running_job", "unavailable_node", "available_nodes", "mixed_nodes"],
+    ids=["single_running_job", "unavailable_node", "available_nodes", "mixed_nodes", "orphaned_node"],
 )
 def test_get_busy_nodes(cluster_nodes, expected_busy_nodes, mocker):
     mocker.patch("jobwatcher.plugins.sge.get_compute_nodes_info", return_value=cluster_nodes, autospec=True)

--- a/tests/nodewatcher/__init__.py
+++ b/tests/nodewatcher/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/nodewatcher/plugins/__init__.py
+++ b/tests/nodewatcher/plugins/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/nodewatcher/plugins/test_sge.py
+++ b/tests/nodewatcher/plugins/test_sge.py
@@ -1,3 +1,13 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 import pytest
 
 from assertpy import assert_that

--- a/tests/nodewatcher/plugins/test_sge.py
+++ b/tests/nodewatcher/plugins/test_sge.py
@@ -21,8 +21,8 @@ from nodewatcher.plugins.sge import hasJobs, hasPendingJobs, is_node_down
         (
             "ip-10-0-0-166",
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,
@@ -35,8 +35,8 @@ from nodewatcher.plugins.sge import hasJobs, hasPendingJobs, is_node_down
         (
             "ip-10-0-0-166",
             {
-                "all.q@ip-10-0-0-166": SgeHost(
-                    name="all.q@ip-10-0-0-166", slots_total=4, slots_used=0, slots_reserved=0, state="", jobs=[]
+                "ip-10-0-0-166": SgeHost(
+                    name="ip-10-0-0-166", slots_total=4, slots_used=0, slots_reserved=0, state="", jobs=[]
                 )
             },
             False,
@@ -45,8 +45,8 @@ from nodewatcher.plugins.sge import hasJobs, hasPendingJobs, is_node_down
         (
             "ip-10-0-0-166",
             {
-                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
-                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
                     slots_total=4,
                     slots_used=0,
                     slots_reserved=0,

--- a/tests/nodewatcher/plugins/test_sge.py
+++ b/tests/nodewatcher/plugins/test_sge.py
@@ -1,0 +1,66 @@
+import pytest
+
+from assertpy import assert_that
+from common.schedulers.sge_commands import SgeHost
+from nodewatcher.plugins.sge import is_node_down
+
+
+@pytest.mark.parametrize(
+    "hostname, compute_nodes_output, expected_result",
+    [
+        (
+            "ip-10-0-0-166",
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="",
+                    jobs=[],
+                )
+            },
+            False,
+        ),
+        (
+            "ip-10-0-0-166",
+            {
+                "all.q@ip-10-0-0-166": SgeHost(
+                    name="all.q@ip-10-0-0-166", slots_total=4, slots_used=0, slots_reserved=0, state="", jobs=[]
+                )
+            },
+            False,
+        ),
+        ("ip-10-0-0-166", {}, True),
+        (
+            "ip-10-0-0-166",
+            {
+                "all.q@ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="all.q@ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="u",
+                    jobs=[],
+                )
+            },
+            True,
+        ),
+        ("ip-10-0-0-166", Exception, True),
+    ],
+    ids=["healthy", "healthy_short", "not_attached", "error_state", "exception"],
+)
+def test_terminate_if_down(hostname, compute_nodes_output, expected_result, mocker):
+    mocker.patch("nodewatcher.plugins.sge.check_command_output", return_value=hostname, autospec=True)
+    mocker.patch(
+        "nodewatcher.plugins.sge.socket.getfqdn", return_value=hostname + ".eu-west-1.compute.internal", autospec=True
+    )
+    if compute_nodes_output is Exception:
+        mock = mocker.patch("nodewatcher.plugins.sge.get_compute_nodes_info", side_effect=Exception(), autospec=True)
+    else:
+        mock = mocker.patch(
+            "nodewatcher.plugins.sge.get_compute_nodes_info", return_value=compute_nodes_output, autospec=True
+        )
+
+    assert_that(is_node_down()).is_equal_to(expected_result)
+    mock.assert_called_with(hostname)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     bash ./tests/test.sh
     # Running with discover and not unittest discover for Python 2.6 compatibility
     python -m discover -s tests/jobwatcher -p "*tests.py"
-    py.test -l -v --basetemp={envtmpdir} --cov=common/ --cov-report=term tests/
+    py.test -l -v --basetemp={envtmpdir} --cov=common/ --cov=sqswatcher/ --cov=nodewatcher/ --cov=jobwatcher/ --cov-report=term tests/
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
**nodewatcher - sge: implement logic to self terminate faulty node**
A node is self terminating in case it is not registered with the scheduler or if its state is one of the following:

```
# If the state is u, the corresponding sge_execd(8) cannot be contacted.
# An E(rror) state is displayed for a queue for various reasons such as failing to find executables or directories.
# If an o(rphaned) state is displayed for a queue instance, it indicates that the queue instance is no longer demanded
# by the current cluster queue configuration or the host group configuration. The queue instance is kept because jobs
# which have not yet finished are still associated with it, and it will vanish from qstat output when these jobs have
# finished.
SGE_ERROR_STATES = ["u", "E", "o"]
```

The node is terminated only if it stays in a faulty state for 1 minute. A bigger timeout of 3 minutes is used at the nodewatcher startup to give enough time to the sqswatcher to add the new node.

------

**jobwatcher - sge: include unusable nodes in busy node count**
Report a node as busy if its state is one of the following

```
# The state of the queue - one of u(nknown), a(larm), A(larm), C(alendar suspended), s(uspended),
# S(ubordinate), d(isabled), D(isabled), E(rror), c(configuration ambiguous), o(rphaned), P(reempted), or some combination thereof.
# Refer to qstat man page for additional details.	
SGE_BUSY_STATES = ["u", "C", "s", "d", "D", "E", "o"]
```

------

**jobwatcher - sge: verify cluster limits when computing slots required for jobs**

when computing required nodes, jobs that require a number of slots that is greater than the max allowed by the cluster are discarded. This prevents the cluster from scaling up to its max size without being able to serve the job.

------

**jobwatcher - sge: do not scale up when a job is pending a dependency**
Do not scale if a pending job is in hold state.

```
The states q(ueued)/w(aiting) and h(old) only appear for pending jobs.  Pending, unheld jobs are displayed as qw.  The h(old) state indicates that a job currently is not eligible for execution due to a hold state assigned to it via qhold(1), qalter(1) or the qsub(1) -h option, or  that  the  job  is waiting for completion of the jobs for which job dependencies have been assigned to it job via the -hold_jid or -hold_jid_ad options of qsub(1) or qalter(1).
```

------

**nodewatcher - sge: scale down if pending jobs cannot be scheduled**

nodewatcher filters out pending jobs that cannot be scheduled when checking for pending jobs.

------

**jobwatcher - sge: skip orphaned nodes from busy nodes count**
A node enters an orphaned state when it is removed from scheduler queue and hostgroup. This happens when sqswatcher handled the termination event but could not remove the host completely since a job is still assigned to it. For this reason we can assume the host is not in ASG anymore hence we do not need to include it in the busy node count otherwise the desired of the ASG will spin up an additional unneeded node for each orphaned one.

------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.