### PR TITLE
Fallback to empty string on subprocess.CalledProcessError with python 2.6

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -136,7 +136,7 @@ def _run_command(command_function, command, env=None, raise_on_error=True):
             raise
         else:
             log.warning(e)
-            return e.output
+            return e.output if hasattr(e, "output") else ""
     except OSError as e:
         log.error("Unable to execute the command %s. Failed with exception: %s", command, e)
         raise


### PR DESCRIPTION
In python 2.6 CalledProcessError does not contain the output of the failed command

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
