### PR TITLE
sqswatcher - sge: start compute daemon before adding to queue

### DIFF
--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -38,9 +38,9 @@ def _add_hosts(hosts, cluster_user):
 
     succeeded_hosts = exec_qconf_command(hosts, QCONF_COMMANDS["ADD_ADMINISTRATIVE_HOST"])
     succeeded_hosts = exec_qconf_command(succeeded_hosts, QCONF_COMMANDS["ADD_SUBMIT_HOST"])
+    succeeded_hosts = install_sge_on_compute_nodes(succeeded_hosts, cluster_user)
     succeeded_hosts = add_hosts_to_group(succeeded_hosts)
     succeeded_hosts = add_host_slots(succeeded_hosts)
-    succeeded_hosts = install_sge_on_compute_nodes(succeeded_hosts, cluster_user)
     return [host.hostname for host in succeeded_hosts]
 
 


### PR DESCRIPTION
Starting the compute node sge daemon after the node is added to the queue causes
the scheduler to see the node as unknown for a few seconds. If jobwatcher wakes up
in this period it will mark the node as unreachable and spin up a new isntance
causing overscaling


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
