### PR TITLE
Dropping tests for python 3.4 due to deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     license="Apache License 2.0",
     packages=find_packages("src", exclude=["tests"]),
     package_dir={"": "src"},
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     install_requires=requires,
     entry_points=dict(console_scripts=console_scripts),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{34,35,36,37}
+    py{35,36,37}
     code-linters
 
 # Default testenv. Used to run tests on all python versions.
@@ -8,7 +8,7 @@ envlist =
 whitelist_externals =
     bash
 deps =
-    py{34,35,36,37}: -rtests/requirements.txt
+    py{35,36,37}: -rtests/requirements.txt
 commands =
     bash ./tests/test.sh
     python -m unittest discover -s tests/jobwatcher -p "*tests.py"


### PR DESCRIPTION
https://devguide.python.org/devcycle/#end-of-life-branches

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
