### PR TITLE
Stop polling for status in the event of failure

### DIFF
--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -223,7 +223,13 @@ def _wait_for_stack_ready(stack_name, region, proxy_config):
     stacks = cfn_client.describe_stacks(StackName=stack_name)
     stack_status = stacks["Stacks"][0]["StackStatus"]
     log.info("Stack %s is in status: %s", stack_name, stack_status)
-    return stack_status in ["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"]
+    return stack_status in [
+        "CREATE_COMPLETE",
+        "UPDATE_COMPLETE",
+        "UPDATE_ROLLBACK_COMPLETE",
+        "CREATE_FAILED",
+        "UPDATE_FAILED",
+    ]
 
 
 def _init_data_dir():


### PR DESCRIPTION
*Issue #, if available:*
I have a customer leveraging 235 compute nodes. Having this many failures, we often see node failures from a lustre mount issue. This results in a cfn status of "CREATE_FAILED". When that happens, that 235 nodes query describe_stacks every 10 seconds for 10 minutes. This swamps the DescribeStacks API and results in throttling downstream.

*Description of changes:*
Add "CREATE_FAILED" and "UPDATE_FAILED" as potential statuses where the stack is ready. These are final statuses when leveraging the "-nr" switch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
