### PR TITLE
sqswatcher - torque: add background thread to trigger scheduling cycle

### DIFF
--- a/src/sqswatcher/plugins/sge.py
+++ b/src/sqswatcher/plugins/sge.py
@@ -96,3 +96,7 @@ def update_cluster(max_cluster_size, cluster_user, update_events, instance_prope
             failed.append(event)
 
     return failed, succeeded
+
+
+def init():
+    pass

--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -127,3 +127,7 @@ def update_cluster(max_cluster_size, cluster_user, update_events, instance_prope
     except Exception as e:
         log.error("Encountered error when processing events: %s", e)
         return update_events, []
+
+
+def init():
+    pass

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -332,6 +332,7 @@ def _poll_queue(sqs_config, queue, table, asg_name):
     :param table: DB table resource object
     """
     scheduler_module = load_module("sqswatcher.plugins." + sqs_config.scheduler)
+    scheduler_module.init()
 
     max_cluster_size = None
     instance_type = None

--- a/tests/common/schedulers/test_torque_commands.py
+++ b/tests/common/schedulers/test_torque_commands.py
@@ -22,7 +22,6 @@ from common.schedulers.torque_commands import (
     get_compute_nodes_info,
     get_jobs_info,
     get_pending_jobs_info,
-    wait_nodes_initialization,
 )
 from tests.common import read_text
 
@@ -113,19 +112,6 @@ def test_delete_nodes(qmgr_output, hosts, expected_succeeded_hosts, mocker):
         assert_that(succeeded_hosts).contains_only(*expected_succeeded_hosts)
     else:
         assert_that(succeeded_hosts).is_empty()
-
-
-def test_wait_nodes_initialization(mocker, test_datadir):
-    pbsnodes_output = read_text(test_datadir / "pbsnodes_output.xml")
-    mock = mocker.patch(
-        "common.schedulers.torque_commands.check_command_output", return_value=pbsnodes_output, autospec=True
-    )
-
-    hosts = ["ip-10-0-1-242", "ip-10-0-0-196"]
-    result = wait_nodes_initialization(hosts)
-
-    mock.assert_called_with("/opt/torque/bin/pbsnodes -x {0}".format(" ".join(hosts)), raise_on_error=False)
-    assert_that(result).is_true()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A background thread automatically triggers a torque scheduling cycle every
minute if any pending job is present in the queue.

This is to work around the fact that torque does not trigger a scheduling cycle
when new nodes get added but only in the following situations:
- A job newly becomes eligible to execute. The job may be a new job in an execution queue, or a job in an execution queue that just changed state from held or waiting to queued. [ SCH_SCHEDULE_NEW ]
- An executing job terminates. [ SCH_SCHEDULE_TERM ]
- The time interval since the prior cycle specified by the server attribute scheduler_iteration is reached.  [ SCH_SCHEDULE_TIME ] (This is 600 seconds by default)
- The server attribute scheduling is set or reset to true. If set true, even if it’s value was true, the scheduler will be cycled. This provides the administrator/operator a means on forcing a scheduling cycle. [ SCH_SCHEDULE_CMD ]
- If the scheduler was cycled and it requested one and only one job to be run, then the scheduler will be recycled by the server. This event is a bit abstruse.  It exists to ‘‘simplify’’ a scheduler. The scheduler only need worry about choosing the one best job per cycle. If other jobs can also be run, it will get another chance to pick the next job. Should a scheduler run none or more than one job in a cycle it is clear that it need not be recalled until conditions change and one of the above trigger the next cycle. [ SCH_SCHEDULE_RECYC ]
- If the server recently recovered, the first scheduling cycle, resulting from any of the above, will be indicated uniquely. [ SCH_SCHEDULE_FIRST ]


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
