### PR TITLE
torque: fix ignore requeuing error message

### DIFF
--- a/src/common/schedulers/torque_commands.py
+++ b/src/common/schedulers/torque_commands.py
@@ -109,7 +109,7 @@ def delete_nodes(hosts):
         error_messages_to_ignore=[
             "Unknown node",
             "The server was unable to communicate with the MOM to requeue or delete the job."
-            " The node has been deleted and all jobs on the node have been purged",
+            " The node has been deleted and all jobs on the node have been purged.",
         ],
     )
 

--- a/tests/common/schedulers/test_torque_commands.py
+++ b/tests/common/schedulers/test_torque_commands.py
@@ -68,6 +68,12 @@ def test_add_nodes(qmgr_output, hosts, expected_succeeded_hosts, mocker):
         ),
         ("qmgr obj=ip-10-0-0-157 svr=default: Error", ["ip-10-0-0-157", "ip-10-0-0-155"], ["ip-10-0-0-155"]),
         ("unexpected error message", ["ip-10-0-0-157", "ip-10-0-0-155"], []),
+        (
+            "qmgr obj=ip-10-0-0-157 svr=default: The server was unable to communicate with the MOM to requeue or "
+            "delete the job. The node has been deleted and all jobs on the node have been purged.",
+            ["ip-10-0-0-157", "ip-10-0-0-155"],
+            ["ip-10-0-0-157", "ip-10-0-0-155"],
+        ),
         ("", [], []),
         (subprocess.CalledProcessError(1, "cmd", output="Unknown Error"), ["ip-10-0-0-157", "ip-10-0-0-155"], []),
         (
@@ -81,6 +87,7 @@ def test_add_nodes(qmgr_output, hosts, expected_succeeded_hosts, mocker):
         "already_existing",
         "failed_one_node",
         "unexpected_err_message",
+        "ignore_failure",
         "no_nodes",
         "exception",
         "ignored_exception",


### PR DESCRIPTION
There was a missing . at the end of the message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
