### PR TITLE
Torque: fix lock command and improve node deletion

### DIFF
--- a/src/common/schedulers/torque_commands.py
+++ b/src/common/schedulers/torque_commands.py
@@ -55,6 +55,9 @@ def _qmgr_manage_nodes(operation, hosts, error_messages_to_ignore, additional_qm
             return set()
         else:
             output = e.output
+    except Exception as e:
+        logging.error("Failed when executing operation %s on nodes %s with error %s", operation, hostnames, e)
+        return set()
 
     succeeded_hosts = set(hosts)
     # analyze command output to understand if failure can be ignored (e.g. already existing node)

--- a/src/nodewatcher/plugins/torque.py
+++ b/src/nodewatcher/plugins/torque.py
@@ -57,7 +57,8 @@ def hasPendingJobs(instance_properties, max_size):
 
 
 def lockHost(hostname, unlock=False):
-    # https://lists.sdsc.edu/pipermail/npaci-rocks-discussion/2007-November/027919.html
+    # hostname format: ip-10-0-0-114.eu-west-1.compute.internal
+    hostname = hostname.split(".")[0]
     mod = unlock and "-c" or "-o"
     command = [TORQUE_BIN_DIR + "pbsnodes", mod, hostname]
     try:


### PR DESCRIPTION
- lockHost command was using full fqdn instead of short names and so it was failing when setting the nodes to offline state
- limited the number of nodes to delete concurrently since torque takes about 2 seconds per node when deleting multiple nodes at a time. Limiting the number of nodes to remove concurrently in order to control the command timeout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
