### PR TITLE
Add timeout to ssh connection when retrieving ssh keys

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -129,7 +129,7 @@ def run_command(command, env=None, raise_on_error=True, execute_as_user=None, lo
     """
     _run_command(
         lambda _command, _env, _preexec_fn: subprocess.check_call(
-            _command, env=_env, preexec_fn=_preexec_fn, timeout=timeout
+            _command, env=_env, preexec_fn=_preexec_fn, timeout=timeout, stdout=subprocess.DEVNULL
         ),
         command,
         env,


### PR DESCRIPTION
Paramiko does not set a timeout on the socket when Transport is creating the socket. Passing the socket explicitly to enforce a timeout.

Paramiko code: https://github.com/paramiko/paramiko/blob/master/paramiko/transport.py#L409

Also discard stdout when using check_call to avoid polluting the logs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
