### PR TITLE
Node enhancements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,17 +1,13 @@
 [flake8]
-#ignore =
-#    D105, # Missing docstring in magic method
-#    D100, # Missing docstring in public module
-#    D104, # Missing docstring in public package
-#    D107, # Missing docstring in __init__
-#    W503, # line break before binary operator => Conflicts with black style.
-# D103 Missing docstring in public function
-# E402 module level import not at top of file
-# D101 Missing docstring in public class
-# D102 Missing docstring in public method
-# D205 1 blank line required between summary line and description
-# D400 First line should end with a period
-# D401 First line should be in imperative mood
+ignore =
+    D105, # Missing docstring in magic method
+    D100, # Missing docstring in public module
+    D101, # Missing docstring in public class
+    D102, # Missing docstring in public method
+    D103, # Missing docstring in public function
+    D104, # Missing docstring in public package
+    D107, # Missing docstring in __init__
+    W503, # line break before binary operator => Conflicts with black style.
 exclude =
     .tox,
     .git,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+2.x.x
+-----
+
+**BUG FIXES**
+- Fix jobwatcher behaviour that was marking nodes locked by the nodewatcher as busy even if they had been removed
+  already from the ASG Desired count. This was causing, in rare circumstances, a cluster overscaling.
+
+
 2.4.1
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import os
-import sys
 
 from setuptools import find_packages, setup
 

--- a/src/common/remote_command_executor.py
+++ b/src/common/remote_command_executor.py
@@ -63,7 +63,7 @@ class RemoteCommandExecutor:
         """
         if isinstance(command, list):
             command = " ".join(command)
-        logging.info("Executing remote command command on {0}: {1}".format(self.__user_at_hostname, command))
+        logging.info("Executing remote command on {0}: {1}".format(self.__user_at_hostname, command))
         result = None
         try:
             stdin, stdout, stderr = self.__ssh_client.exec_command(command, get_pty=True)

--- a/src/common/remote_command_executor.py
+++ b/src/common/remote_command_executor.py
@@ -33,6 +33,8 @@ class RemoteCommandExecutionError(Exception):
 class RemoteCommandExecutor:
     """Execute remote commands."""
 
+    DEFAULT_TIMEOUT = seconds(5)
+
     def __init__(self, hostname, user, ssh_key_file=None):
         try:
             if not ssh_key_file:
@@ -53,12 +55,14 @@ class RemoteCommandExecutor:
             # Catch all exceptions if we fail to close the clients
             logging.warning("Exception raised when closing remote clients: {0}".format(e))
 
-    def run_remote_command(self, command, timeout=seconds(5), log_error=True, fail_on_error=True):
+    def run_remote_command(self, command, timeout=DEFAULT_TIMEOUT, log_error=True, fail_on_error=True):
         """
         Execute remote command on the configured host.
 
         :param command: command to execute.
+        :param timeout: timeout for command execution in ms
         :param log_error: log errors.
+        :param fail_on_error: raise Exception on command execution failures
         :return: result of the execution.
         """
         if isinstance(command, list):

--- a/src/common/schedulers/converters.py
+++ b/src/common/schedulers/converters.py
@@ -16,7 +16,7 @@ from six import add_metaclass
 
 def from_xml_to_obj(xml, obj_type):
     """
-    Maps a given xml document into a python object.
+    Map a given xml document into a python object.
 
     The python object you want to map the xml into needs to define a MAPPINGS dictionary which declare how
     to map each tag of the xml doc into the object itself.
@@ -55,7 +55,7 @@ def from_xml_to_obj(xml, obj_type):
 
 def from_table_to_obj_list(table, obj_type, separator="|"):
     """
-    Maps a given tabular output into a python object.
+    Map a given tabular output into a python object.
 
     The python object you want to map the table into needs to define a MAPPINGS dictionary which declare how
     to map each row element into the object itself.

--- a/src/common/schedulers/sge_commands.py
+++ b/src/common/schedulers/sge_commands.py
@@ -56,7 +56,10 @@ QCONF_COMMANDS = {
 # or some combination thereof.
 # Refer to qstat man page for additional details.
 # o(rphaned) is not considered as busy since we assume a node in orphaned state is not present in ASG anymore
-SGE_BUSY_STATES = ["u", "C", "s", "d", "D", "E", "P"]
+SGE_BUSY_STATES = ["u", "C", "s", "D", "E", "P"]
+
+# This state is set by nodewatcher when the node is locked and is being terminated.
+SGE_DISABLED_STATE = "d"
 
 # If an o(rphaned) state is displayed for a queue instance, it indicates that the queue instance is no longer demanded
 # by the current cluster queue configuration or the host group configuration. The queue instance is kept because jobs

--- a/src/common/schedulers/sge_commands.py
+++ b/src/common/schedulers/sge_commands.py
@@ -209,6 +209,7 @@ def get_jobs_info(hostname_filter=None, job_state_filter=None):
 def get_pending_jobs_info(max_slots_filter=None, skip_if_state=None):
     """
     Retrieve the list of pending jobs.
+
     :param max_slots_filter: discard jobs that require a number of slots bigger than the given value
     :param skip_if_state: discard jobs that are in the given state
     :return: the list of filtered pending jos.

--- a/src/common/time_utils.py
+++ b/src/common/time_utils.py
@@ -17,5 +17,5 @@ def minutes(min):
 
 
 def seconds(sec):
-    """Convert seconds to milliseconds"""
+    """Convert seconds to milliseconds."""
     return sec * 1000

--- a/src/jobwatcher/__init__.py
+++ b/src/jobwatcher/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #

--- a/src/jobwatcher/plugins/__init__.py
+++ b/src/jobwatcher/plugins/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #

--- a/src/jobwatcher/plugins/sge.py
+++ b/src/jobwatcher/plugins/sge.py
@@ -1,3 +1,13 @@
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 
 from common.schedulers.sge_commands import (
@@ -32,9 +42,7 @@ def get_required_nodes(instance_properties, max_size):
 
 
 def get_busy_nodes():
-    """
-    Count nodes that have at least 1 job running or have a state that makes them unusable for jobs submission.
-    """
+    """Count nodes that have at least 1 job running or have a state that makes them unusable for jobs submission."""
     nodes = get_compute_nodes_info()
     logging.info("Found the following compute nodes:\n%s", nodes)
     busy_nodes = 0

--- a/src/jobwatcher/plugins/sge.py
+++ b/src/jobwatcher/plugins/sge.py
@@ -16,6 +16,7 @@ def _get_required_slots(instance_properties, max_size):
     """Compute the total number of slots required by pending jobs."""
     max_cluster_slots = max_size * instance_properties.get("slots")
     pending_jobs = get_pending_jobs_info(max_slots_filter=max_cluster_slots, skip_if_state=SGE_HOLD_STATE)
+    logging.info("Found the following pending jobs:\n%s", pending_jobs)
     slots = 0
     for job in pending_jobs:
         slots += job.slots
@@ -35,6 +36,7 @@ def get_busy_nodes():
     Count nodes that have at least 1 job running or have a state that makes them unusable for jobs submission.
     """
     nodes = get_compute_nodes_info()
+    logging.info("Found the following compute nodes:\n%s", nodes)
     busy_nodes = 0
     for node in nodes.values():
         if SGE_DISABLED_STATE in node.state:

--- a/src/jobwatcher/plugins/sge.py
+++ b/src/jobwatcher/plugins/sge.py
@@ -2,6 +2,7 @@ import logging
 
 from common.schedulers.sge_commands import (
     SGE_BUSY_STATES,
+    SGE_DISABLED_STATE,
     SGE_HOLD_STATE,
     SGE_ORPHANED_STATE,
     get_compute_nodes_info,
@@ -36,6 +37,8 @@ def get_busy_nodes():
     nodes = get_compute_nodes_info()
     busy_nodes = 0
     for node in nodes.values():
+        if SGE_DISABLED_STATE in node.state:
+            continue
         if (
             any(busy_state in node.state for busy_state in SGE_BUSY_STATES)
             or int(node.slots_used) > 0

--- a/src/jobwatcher/plugins/slurm.py
+++ b/src/jobwatcher/plugins/slurm.py
@@ -37,6 +37,6 @@ def get_busy_nodes():
     output = output.split("\n")
     for line in output:
         line_arr = line.split()
-        if len(line_arr) == 2 and (line_arr[1] in ["mix", "alloc", "drain", "drain*", "down", "down*"]):
+        if len(line_arr) == 2 and (line_arr[1] in ["mix", "alloc", "down", "down*"]):
             nodes += int(line_arr[0])
     return nodes

--- a/src/jobwatcher/plugins/slurm.py
+++ b/src/jobwatcher/plugins/slurm.py
@@ -1,3 +1,13 @@
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 
 from common.schedulers.slurm_commands import PENDING_RESOURCES_REASONS, get_pending_jobs_info

--- a/src/jobwatcher/plugins/slurm.py
+++ b/src/jobwatcher/plugins/slurm.py
@@ -15,6 +15,8 @@ def get_required_nodes(instance_properties, max_size):
         max_nodes_filter=max_size,
         filter_by_pending_reasons=PENDING_RESOURCES_REASONS,
     )
+    logging.info("Found the following pending jobs:\n%s", pending_jobs)
+
     slots_requested = []
     nodes_requested = []
     for job in pending_jobs:
@@ -33,6 +35,7 @@ def get_busy_nodes():
     # 10 idle
     # 1 down*
     output = check_command_output(command)
+    logging.info("Found the following compute nodes:\n%s", output.rstrip())
     nodes = 0
     output = output.split("\n")
     for line in output:

--- a/src/jobwatcher/plugins/torque.py
+++ b/src/jobwatcher/plugins/torque.py
@@ -42,6 +42,7 @@ def get_required_nodes(instance_properties, max_size):
 # get nodes reserved by running jobs
 def get_busy_nodes():
     nodes = get_compute_nodes_info()
+    logging.info("Found the following compute nodes:\n%s", nodes)
     busy_nodes = 0
     for node in nodes.values():
         # when a node is added it transitions from down,offline,MOM-list-not-sent -> down -> free

--- a/src/jobwatcher/plugins/torque.py
+++ b/src/jobwatcher/plugins/torque.py
@@ -46,7 +46,7 @@ def get_busy_nodes():
     for node in nodes.values():
         # when a node is added it transitions from down,offline,MOM-list-not-sent -> down -> free
         if node.jobs or (
-            any(state in ["offline", "state-unknown"] for state in node.state) and "MOM-list-not-sent" not in node.state
+            any(state in ["state-unknown"] for state in node.state) and "MOM-list-not-sent" not in node.state
         ):
             busy_nodes += 1
 

--- a/src/jobwatcher/plugins/utils.py
+++ b/src/jobwatcher/plugins/utils.py
@@ -1,3 +1,13 @@
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 
 log = logging.getLogger(__name__)
@@ -39,7 +49,7 @@ def get_optimal_nodes(nodes_requested, slots_requested, instance_properties):
         log.info("After looking at already allocated nodes, %s more nodes are needed" % num_of_nodes)
 
         # Since the number of available slots were unable to run this job entirely, only add the necessary nodes.
-        for i in range(num_of_nodes):
+        for _ in range(num_of_nodes):
             log.info("Adding node. Using %s slots" % slots_required_per_node)
             slots_remaining_per_node.append(vcpus - slots_required_per_node)
 

--- a/src/nodewatcher/__init__.py
+++ b/src/nodewatcher/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #

--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -146,7 +146,7 @@ def _self_terminate(asg_client, instance_id, decrement_desired=True):
 def _maintain_size(asg_name, asg_client):
     """
     Verify if the desired capacity is lower than the configured min size.
-    
+
     :param asg_name: the ASG to query for
     :param asg_client: ASG boto3 client
     :return: True if the desired capacity is lower than the configured min size.
@@ -170,7 +170,7 @@ def _maintain_size(asg_name, asg_client):
 
 
 def _dump_logs(instance_id):
-    """Dump gzipped /var/log dir to /home/logs/compute/$instance_id.tar.gz"""
+    """Dump gzipped /var/log dir to /home/logs/compute/$instance_id.tar.gz."""
     logs_dir = "/home/logs/compute"
     filename = "{0}/{1}.tar.gz".format(logs_dir, instance_id)
     try:
@@ -187,7 +187,7 @@ def _dump_logs(instance_id):
 
 
 def _terminate_if_down(scheduler_module, config, asg_name, instance_id, max_wait):
-    """Check that node is correctly attached to scheduler otherwise terminate the instance"""
+    """Check that node is correctly attached to scheduler otherwise terminate the instance."""
     asg_client = boto3.client("autoscaling", region_name=config.region, config=config.proxy_config)
 
     @retry(wait_fixed=seconds(10), retry_on_result=lambda result: result is True, stop_max_delay=max_wait)

--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -106,7 +106,7 @@ def _has_jobs(scheduler_module, hostname):
     :param hostname: host to search for
     :return: true if the given host has running jobs
     """
-    _jobs = scheduler_module.hasJobs(hostname)
+    _jobs = scheduler_module.has_jobs(hostname)
     log.debug("jobs=%s" % _jobs)
     return _jobs
 
@@ -120,7 +120,7 @@ def _lock_host(scheduler_module, hostname, unlock=False):
     :param unlock: False to lock the host, True to unlock
     """
     log.debug("%s %s" % (unlock and "unlocking" or "locking", hostname))
-    scheduler_module.lockHost(hostname, unlock)
+    scheduler_module.lock_host(hostname, unlock)
     time.sleep(15)  # allow for some settling
 
 
@@ -311,7 +311,7 @@ def _poll_instance_status(config, scheduler_module, asg_name, hostname, instance
                 idletime = 0
             else:
                 _, _, max_size = get_asg_settings(config.region, config.proxy_config, asg_name)
-                has_pending_jobs, error = scheduler_module.hasPendingJobs(instance_properties, max_size)
+                has_pending_jobs, error = scheduler_module.has_pending_jobs(instance_properties, max_size)
                 if error:
                     log.warning(
                         "Encountered an error while polling queue for pending jobs. Skipping pending jobs check"

--- a/src/nodewatcher/plugins/__init__.py
+++ b/src/nodewatcher/plugins/__init__.py
@@ -1,12 +1,10 @@
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-
-__author__ = "dougalb"

--- a/src/nodewatcher/plugins/sge.py
+++ b/src/nodewatcher/plugins/sge.py
@@ -27,7 +27,7 @@ from common.utils import check_command_output
 log = logging.getLogger(__name__)
 
 
-def hasJobs(hostname):
+def has_jobs(hostname):
     try:
         # Checking for running or suspended jobs on the node
         # According to the manual (man sge_status) h(old) state only appears in conjunction with r(unning) or p(ending)
@@ -39,7 +39,7 @@ def hasJobs(hostname):
         return False
 
 
-def hasPendingJobs(instance_properties, max_size):
+def has_pending_jobs(instance_properties, max_size):
     """
     Check if there is any pending job in the queue.
 
@@ -56,7 +56,7 @@ def hasPendingJobs(instance_properties, max_size):
         return False, True
 
 
-def lockHost(hostname, unlock=False):
+def lock_host(hostname, unlock=False):
     try:
         if unlock:
             unlock_host(hostname)

--- a/src/nodewatcher/plugins/sge.py
+++ b/src/nodewatcher/plugins/sge.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #
@@ -19,9 +19,9 @@ from common.schedulers.sge_commands import (
     get_compute_nodes_info,
     get_jobs_info,
     get_pending_jobs_info,
-    lock_host,
-    unlock_host,
 )
+from common.schedulers.sge_commands import lock_host as sge_lock_host
+from common.schedulers.sge_commands import unlock_host
 from common.utils import check_command_output
 
 log = logging.getLogger(__name__)
@@ -61,14 +61,14 @@ def lock_host(hostname, unlock=False):
         if unlock:
             unlock_host(hostname)
         else:
-            lock_host(hostname)
+            sge_lock_host(hostname)
     except subprocess.CalledProcessError:
         log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)
 
 
 def is_node_down():
     """
-    Check if node is down according to scheduler
+    Check if node is down according to scheduler.
 
     The node is considered as down if:
     - there is a failure contacting the scheduler

--- a/src/nodewatcher/plugins/sge.py
+++ b/src/nodewatcher/plugins/sge.py
@@ -32,6 +32,7 @@ def hasJobs(hostname):
         # Checking for running or suspended jobs on the node
         # According to the manual (man sge_status) h(old) state only appears in conjunction with r(unning) or p(ending)
         jobs = get_jobs_info(hostname_filter=hostname, job_state_filter="rs")
+        logging.info("Found the following running jobs:\n%s", jobs)
         return len(jobs) > 0
     except Exception as e:
         log.error("Failed when checking for running jobs with exception %s", e)
@@ -48,6 +49,7 @@ def hasPendingJobs(instance_properties, max_size):
     try:
         max_cluster_slots = max_size * instance_properties.get("slots")
         pending_jobs = get_pending_jobs_info(max_slots_filter=max_cluster_slots, skip_if_state=SGE_HOLD_STATE)
+        logging.info("Found the following pending jobs:\n%s", pending_jobs)
         return len(pending_jobs) > 0, False
     except Exception as e:
         log.error("Failed when checking for pending jobs with exception %s. Reporting no pending jobs.", e)

--- a/src/nodewatcher/plugins/slurm.py
+++ b/src/nodewatcher/plugins/slurm.py
@@ -18,7 +18,7 @@ from common.utils import check_command_output, run_command
 log = logging.getLogger(__name__)
 
 
-def hasJobs(hostname):
+def has_jobs(hostname):
     # Slurm won't use FQDN
     short_name = hostname.split(".")[0]
     # Checking for running jobs on the node
@@ -33,7 +33,7 @@ def hasJobs(hostname):
     return has_jobs
 
 
-def hasPendingJobs(instance_properties, max_size):
+def has_pending_jobs(instance_properties, max_size):
     """
     Check if there is any pending job in the queue.
 
@@ -53,7 +53,7 @@ def hasPendingJobs(instance_properties, max_size):
         return False, True
 
 
-def lockHost(hostname, unlock=False):
+def lock_host(hostname, unlock=False):
     # hostname format: ip-10-0-0-114.eu-west-1.compute.internal
     hostname = hostname.split(".")[0]
     if unlock:

--- a/src/nodewatcher/plugins/slurm.py
+++ b/src/nodewatcher/plugins/slurm.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #
@@ -81,7 +81,7 @@ def lock_host(hostname, unlock=False):
 
 
 def is_node_down():
-    """Check if node is down according to scheduler"""
+    """Check if node is down according to scheduler."""
     try:
         # retrieves the state of a specific node
         # https://slurm.schedmd.com/sinfo.html#lbAG

--- a/src/nodewatcher/plugins/slurm.py
+++ b/src/nodewatcher/plugins/slurm.py
@@ -25,6 +25,7 @@ def hasJobs(hostname):
     command = ["/opt/slurm/bin/squeue", "-w", short_name, "-h"]
     try:
         output = check_command_output(command)
+        logging.info("Found the following running jobs:\n%s", output.rstrip())
         has_jobs = output != ""
     except subprocess.CalledProcessError:
         has_jobs = False
@@ -45,6 +46,7 @@ def hasPendingJobs(instance_properties, max_size):
             max_nodes_filter=max_size,
             filter_by_pending_reasons=PENDING_RESOURCES_REASONS,
         )
+        logging.info("Found the following pending jobs:\n%s", pending_jobs)
         return len(pending_jobs) > 0, False
     except Exception as e:
         log.error("Failed when checking if node is down with exception %s. Reporting no pending jobs.", e)

--- a/src/nodewatcher/plugins/torque.py
+++ b/src/nodewatcher/plugins/torque.py
@@ -26,7 +26,7 @@ from common.utils import check_command_output, run_command
 log = logging.getLogger(__name__)
 
 
-def hasJobs(hostname):
+def has_jobs(hostname):
     try:
         short_name = hostname.split(".")[0]
         # Checking for running jobs on the node
@@ -40,7 +40,7 @@ def hasJobs(hostname):
         return False
 
 
-def hasPendingJobs(instance_properties, max_size):
+def has_pending_jobs(instance_properties, max_size):
     """
     Check if there is any pending job in the queue.
 
@@ -56,7 +56,7 @@ def hasPendingJobs(instance_properties, max_size):
         return False, True
 
 
-def lockHost(hostname, unlock=False):
+def lock_host(hostname, unlock=False):
     # hostname format: ip-10-0-0-114.eu-west-1.compute.internal
     hostname = hostname.split(".")[0]
     mod = unlock and "-c" or "-o"

--- a/src/nodewatcher/plugins/torque.py
+++ b/src/nodewatcher/plugins/torque.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #
@@ -68,7 +68,7 @@ def lock_host(hostname, unlock=False):
 
 
 def is_node_down():
-    """Check if node is down according to scheduler"""
+    """Check if node is down according to scheduler."""
     try:
         hostname = check_command_output("hostname").strip()
         node = get_compute_nodes_info(hostname_filter=[hostname]).get(hostname)

--- a/src/sqswatcher/__init__.py
+++ b/src/sqswatcher/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #

--- a/src/sqswatcher/plugins/__init__.py
+++ b/src/sqswatcher/plugins/__init__.py
@@ -1,12 +1,10 @@
 # Copyright 2013-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-
-__author__ = "dougalb"

--- a/src/sqswatcher/plugins/sge.py
+++ b/src/sqswatcher/plugins/sge.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #

--- a/src/sqswatcher/plugins/torque.py
+++ b/src/sqswatcher/plugins/torque.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
-# License. A copy of the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
 #
 # http://aws.amazon.com/apache2.0/
 #

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -13,7 +13,6 @@
 import collections
 import json
 import logging
-import os
 import time
 from collections import OrderedDict
 
@@ -165,7 +164,7 @@ def _retry_on_request_limit_exceeded(func):
 
 def _requeue_message(queue, message):
     """
-    Requeue the given message into the specified queue
+    Requeue the given message into the specified queue.
 
     :param queue: the queue where to send the message
     :param message: the message to requeue

--- a/tests/common/schedulers/test_sge_commands.py
+++ b/tests/common/schedulers/test_sge_commands.py
@@ -245,7 +245,7 @@ def test_sge_host_parsing(sge_host_xml, expected_output, test_datadir):
         ),
         (
             (
-                'root@ip-10-0-0-208.eu-west-1.compute.internal removed "ip-10-0-0-157.eu-west-1.compute.internal" from administrative host list\n'
+                'root@ip-10-0-0-208.eu-west-1.compute.internal removed "ip-10-0-0-157.eu-west-1.compute.internal" from administrative host list\n'  # noqa E501
                 'denied: administrative host "ip-10-0-0-155" does not exist\n'
                 'can\'t resolve hostname "ip-10-0-0"'
             ),
@@ -254,7 +254,7 @@ def test_sge_host_parsing(sge_host_xml, expected_output, test_datadir):
         ),
         (
             (
-                'root@ip-10-0-0-208.eu-west-1.compute.internal removed "ip-10-0-0-157.eu-west-1.compute.internal" from submit host list\n'
+                'root@ip-10-0-0-208.eu-west-1.compute.internal removed "ip-10-0-0-157.eu-west-1.compute.internal" from submit host list\n'  # noqa E501
                 'denied: submit host "ip-10-0-0-155" does not exist\n'
                 'can\'t resolve hostname "ip-10-0-0"'
             ),
@@ -263,7 +263,7 @@ def test_sge_host_parsing(sge_host_xml, expected_output, test_datadir):
         ),
         (
             (
-                'root@ip-10-0-0-208.eu-west-1.compute.internal removed "ip-10-0-0-157.eu-west-1.compute.internal" from execution host list\n'
+                'root@ip-10-0-0-208.eu-west-1.compute.internal removed "ip-10-0-0-157.eu-west-1.compute.internal" from execution host list\n'  # noqa E501
                 'denied: execution host "ip-10-0-0-155" does not exist\n'
                 'can\'t resolve hostname "ip-10-0-0"'
             ),

--- a/tests/common/schedulers/test_torque_commands.py
+++ b/tests/common/schedulers/test_torque_commands.py
@@ -114,7 +114,9 @@ def test_delete_nodes(qmgr_output, hosts, expected_succeeded_hosts, mocker):
         for i in range(0, len(hosts), chunk_size):
             calls.append(
                 call(
-                    '/opt/torque/bin/qmgr -c "delete node {0} "'.format(",".join(hosts[i : i + chunk_size])),
+                    '/opt/torque/bin/qmgr -c "delete node {0} "'.format(
+                        ",".join(hosts[i : i + chunk_size])  # noqa E203: incompatible with black
+                    ),
                     log_error=False,
                 )
             )
@@ -142,7 +144,8 @@ def test_delete_nodes(qmgr_output, hosts, expected_succeeded_hosts, mocker):
                     name="ip-10-0-1-237",
                     slots=4,
                     state=["job-exclusive"],
-                    jobs="1/136.ip-10-0-0-196.eu-west-1.compute.internal,2/137.ip-10-0-0-196.eu-west-1.compute.internal,"
+                    jobs="1/136.ip-10-0-0-196.eu-west-1.compute.internal,"
+                    "2/137.ip-10-0-0-196.eu-west-1.compute.internal,"
                     "0,3/138.ip-10-0-0-196.eu-west-1.compute.internal",
                     note="",
                 ),

--- a/tests/jobwatcher/plugins/test_sge.py
+++ b/tests/jobwatcher/plugins/test_sge.py
@@ -107,6 +107,14 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
                     state="d",
                     jobs=[],
                 ),
+                "ip-10-0-0-175.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-175.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="adu",
+                    jobs=[],
+                ),
                 "ip-10-0-0-171.eu-west-1.compute.internal": SgeHost(
                     name="ip-10-0-0-171.eu-west-1.compute.internal",
                     slots_total=0,
@@ -116,7 +124,7 @@ from jobwatcher.plugins.sge import get_busy_nodes, get_required_nodes
                     jobs=[],
                 ),
             },
-            3,
+            2,
         ),
         (
             {

--- a/tests/jobwatcher/plugins/test_torque.py
+++ b/tests/jobwatcher/plugins/test_torque.py
@@ -48,7 +48,7 @@ from jobwatcher.plugins.torque import get_busy_nodes, get_required_nodes
             2,
         ),
         ({}, 0),
-        ({"ip-10-0-0-196": TorqueHost(name="ip-10-0-0-196", slots=1000, state=["down", "offline"], jobs=None)}, 1),
+        ({"ip-10-0-0-196": TorqueHost(name="ip-10-0-0-196", slots=1000, state=["down", "offline"], jobs=None)}, 0),
         (
             {
                 "ip-10-0-0-196": TorqueHost(

--- a/tests/jobwatcher/plugins/test_torque.py
+++ b/tests/jobwatcher/plugins/test_torque.py
@@ -41,7 +41,8 @@ from jobwatcher.plugins.torque import get_busy_nodes, get_required_nodes
                     name="ip-10-0-1-237",
                     slots=4,
                     state="job-exclusive",
-                    jobs="1/136.ip-10-0-0-196.eu-west-1.compute.internal,2/137.ip-10-0-0-196.eu-west-1.compute.internal,"
+                    jobs="1/136.ip-10-0-0-196.eu-west-1.compute.internal,"
+                    "2/137.ip-10-0-0-196.eu-west-1.compute.internal,"
                     "0,3/138.ip-10-0-0-196.eu-west-1.compute.internal",
                 ),
             },

--- a/tests/jobwatcher/unittests.py
+++ b/tests/jobwatcher/unittests.py
@@ -5,7 +5,7 @@ from jobwatcher.plugins import utils
 instance_properties = {"slots": 8}
 
 
-class optimal_node_count_tests(unittest.TestCase):
+class OptimalNodeCountTests(unittest.TestCase):
     def test_empty_lists(self):
         nodes = utils.get_optimal_nodes([], [], instance_properties)
         expected = 0

--- a/tests/nodewatcher/plugins/test_sge.py
+++ b/tests/nodewatcher/plugins/test_sge.py
@@ -12,7 +12,7 @@ import pytest
 
 from assertpy import assert_that
 from common.schedulers.sge_commands import SGE_HOLD_STATE, SgeHost, SgeJob
-from nodewatcher.plugins.sge import hasJobs, hasPendingJobs, is_node_down
+from nodewatcher.plugins.sge import has_jobs, has_pending_jobs, is_node_down
 
 
 @pytest.mark.parametrize(
@@ -103,7 +103,7 @@ def test_has_pending_jobs(pending_jobs, expected_result, mocker):
     instance_properties = {"slots": 4}
     max_cluster_size = 10
 
-    assert_that(hasPendingJobs(instance_properties, max_cluster_size)).is_equal_to(expected_result)
+    assert_that(has_pending_jobs(instance_properties, max_cluster_size)).is_equal_to(expected_result)
     mock.assert_called_with(
         max_slots_filter=max_cluster_size * instance_properties["slots"], skip_if_state=SGE_HOLD_STATE
     )
@@ -122,5 +122,5 @@ def test_has_jobs(jobs, expected_result, mocker):
 
     hostname = "ip-1-0-0-1"
 
-    assert_that(hasJobs(hostname)).is_equal_to(expected_result)
+    assert_that(has_jobs(hostname)).is_equal_to(expected_result)
     mock.assert_called_with(hostname_filter=hostname, job_state_filter="rs")

--- a/tests/nodewatcher/plugins/test_slurm.py
+++ b/tests/nodewatcher/plugins/test_slurm.py
@@ -12,7 +12,7 @@ import pytest
 
 from assertpy import assert_that
 from common.schedulers.slurm_commands import PENDING_RESOURCES_REASONS, SlurmJob
-from nodewatcher.plugins.slurm import hasPendingJobs
+from nodewatcher.plugins.slurm import has_pending_jobs
 
 
 @pytest.mark.parametrize(
@@ -56,7 +56,7 @@ def test_has_pending_jobs(pending_jobs, expected_result, mocker):
     instance_properties = {"slots": 4}
     max_cluster_size = 10
 
-    assert_that(hasPendingJobs(instance_properties, max_cluster_size)).is_equal_to(expected_result)
+    assert_that(has_pending_jobs(instance_properties, max_cluster_size)).is_equal_to(expected_result)
     mock.assert_called_with(
         filter_by_pending_reasons=PENDING_RESOURCES_REASONS,
         max_nodes_filter=max_cluster_size,

--- a/tests/nodewatcher/plugins/test_torque.py
+++ b/tests/nodewatcher/plugins/test_torque.py
@@ -12,7 +12,7 @@ import pytest
 
 from assertpy import assert_that
 from common.schedulers.torque_commands import TorqueHost, TorqueJob, TorqueResourceList
-from nodewatcher.plugins.torque import hasJobs, hasPendingJobs, is_node_down
+from nodewatcher.plugins.torque import has_jobs, has_pending_jobs, is_node_down
 
 
 @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ def test_has_pending_jobs(pending_jobs, expected_result, mocker):
     instance_properties = {"slots": 4}
     max_cluster_size = 10
 
-    assert_that(hasPendingJobs(instance_properties, max_cluster_size)).is_equal_to(expected_result)
+    assert_that(has_pending_jobs(instance_properties, max_cluster_size)).is_equal_to(expected_result)
     mock.assert_called_with(max_slots_filter=instance_properties["slots"])
 
 
@@ -134,5 +134,5 @@ def test_has_jobs(jobs, expected_result, mocker):
 
     hostname = "ip-1-0-0-1.eu-west-1.compute.internal"
 
-    assert_that(hasJobs(hostname)).is_equal_to(expected_result)
+    assert_that(has_jobs(hostname)).is_equal_to(expected_result)
     mock.assert_called_with(filter_by_exec_hosts={hostname.split(".")[0]}, filter_by_states=["R", "S"])

--- a/tox.ini
+++ b/tox.ini
@@ -161,14 +161,14 @@ skip_install = true
 deps =
     {[testenv:black-check]deps}
     {[testenv:isort-check]deps}
-    # {[testenv:flake8]deps}
+    {[testenv:flake8]deps}
     # {[testenv:pylint]deps}
     # {[testenv:bandit]deps}
     # {[testenv:readme]deps}
 commands =
     {[testenv:black-check]commands}
     {[testenv:isort-check]commands}
-    # {[testenv:flake8]commands}
+    {[testenv:flake8]commands}
     # {[testenv:pylint]commands}
     # {[testenv:bandit]commands}
     # {[testenv:readme]commands}


### PR DESCRIPTION
**Do not count as busy nodes locked by the nodewatcher**
After a node is locked by the nodewatcher it soon gets terminated and the ASG desired gets decremented. For this reason jobwatcher should not consider such nodes as busy since they are already removed from the ASG desired count. In case we consider them as busy the cluster is going to overscale.

**Log additional data in jobwatcher and nodewatcher**
Add details on pending and running jobs in jobwatcher and nodewatcher log files. This should allow a better debugging in case of reported issues with the scaling logic

**Small fixes and refactoring**
- Rename functions to comply with Python conventions
- Fix typo in log message

**Fix flake8 warnings and enable it in tox/travis**
Fixed all flake8 warnings and enabled flake linter in tox/travis

***
Tested in: integration_tests/157

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
