### PR TITLE
Increase max retrieved SQS messages and improved daemons loop execution rate

### DIFF
--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -209,7 +209,12 @@ def _terminate_if_down(scheduler_module, config, asg_name, instance_id, max_wait
         _self_terminate(asg_client, instance_id, decrement_desired=not _maintain_size(asg_name, asg_client))
 
 
-@retry(wait_fixed=seconds(10), retry_on_result=lambda result: result is False, stop_max_delay=minutes(10))
+@retry(
+    wait_exponential_multiplier=seconds(1),
+    wait_exponential_max=seconds(10),
+    retry_on_result=lambda result: result is False,
+    stop_max_delay=minutes(10),
+)
 def _wait_for_stack_ready(stack_name, region, proxy_config):
     """
     Verify if the Stack is in one of the *_COMPLETE states.

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -15,6 +15,7 @@ import json
 import logging
 import time
 from collections import OrderedDict
+from datetime import datetime
 
 import boto3
 from botocore.config import Config
@@ -342,6 +343,8 @@ def _poll_queue(sqs_config, queue, table, asg_name):
     instance_type = None
     cluster_properties_refresh_timer = 0
     while True:
+        start_time = datetime.now()
+
         force_cluster_update = False
         # dynamically retrieve max_cluster_size and compute_instance_type
         if (
@@ -374,7 +377,11 @@ def _poll_queue(sqs_config, queue, table, asg_name):
             instance_properties,
             force_cluster_update,
         )
-        time.sleep(LOOP_TIME)
+
+        end_time = datetime.now()
+        time_delta = (end_time - start_time).total_seconds()
+        if time_delta < LOOP_TIME:
+            time.sleep(LOOP_TIME - time_delta)
 
 
 @retry(wait_fixed=seconds(LOOP_TIME))


### PR DESCRIPTION
- Subtract daemons loop execution time from overall sleep time: this allows to run daemons iterations at a constant frequency that does not depend on the loop execution time

- Increase max retrieved SQS messages from 50 to 200. Also make this number configurable with a sqswatcher config directive: max_processed_messages.

Tested manually. Need to run integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
