### PR TITLE
Make "install sge on compute nodes" action idempotent

### DIFF
--- a/src/common/schedulers/sge_commands.py
+++ b/src/common/schedulers/sge_commands.py
@@ -136,7 +136,8 @@ def remove_hosts_from_queue(hosts):
 def install_sge_on_compute_nodes(hosts, cluster_user):
     """Start sge on compute nodes in parallel."""
     command = (
-        "sudo sh -c 'cd {0} && {0}/inst_sge -noremote -x -auto /opt/parallelcluster/templates/sge/sge_inst.conf'"
+        "sudo sh -c 'ps aux | grep [s]ge_execd || "
+        "(cd {0} && {0}/inst_sge -noremote -x -auto /opt/parallelcluster/templates/sge/sge_inst.conf)'"
     ).format(sge.SGE_ROOT)
     hostnames = [host.hostname for host in hosts]
     result = RemoteCommandExecutor.run_remote_command_on_multiple_hosts(command, hostnames, cluster_user)


### PR DESCRIPTION
During host addition, all the operations should be idempotent in order to allow retries in case the procedure fails at any of the steps
This mitigate https://github.com/aws/aws-parallelcluster/issues/1327

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
