### PR TITLE
Added extended hardware info to slurm nodes

### DIFF
--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -130,8 +130,8 @@ def _update_node_lists(update_events):
         elif event.action == "ADD":
             # Only include GPU info if instance has GPU
             gpu_info = "Gres=gpu:tesla:{gpus} ".format(gpus=event.host.gpus) if event.host.gpus != 0 else ""
-            new_node = "NodeName={nodename} CPUs={cpus} {gpu_info}State=UNKNOWN\n".format(
-                nodename=event.host.hostname, cpus=event.host.slots, gpu_info=gpu_info
+            new_node = "NodeName={nodename} RealMemory={memory} CPUs={cpus} {gpu_info}State=UNKNOWN\n".format(
+                nodename=event.host.hostname, memory=event.host.hw_info.memory, cpus=event.host.slots, gpu_info=gpu_info
             )
 
             if new_node not in node_list:
@@ -152,8 +152,8 @@ def _add_dummy_to_node_list(node_list, max_cluster_size, instance_properties):
             gpu_info = "Gres=gpu:tesla:{0} ".format(instance_properties["gpus"])
         node_list.insert(
             0,
-            "NodeName=dummy-compute[1-{0}] CPUs={1} {2}State=FUTURE\n".format(
-                dummy_nodes_count, instance_properties["slots"], gpu_info
+            "NodeName=dummy-compute[1-{0}] RealMemory={1} CPUs={2} {3}State=FUTURE\n".format(
+                dummy_nodes_count, instance_properties["memory"], instance_properties["slots"], gpu_info
             ),
         )
 

--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -130,8 +130,17 @@ def _update_node_lists(update_events):
         elif event.action == "ADD":
             # Only include GPU info if instance has GPU
             gpu_info = "Gres=gpu:tesla:{gpus} ".format(gpus=event.host.gpus) if event.host.gpus != 0 else ""
-            new_node = "NodeName={nodename} RealMemory={memory} CPUs={cpus} {gpu_info}State=UNKNOWN\n".format(
-                nodename=event.host.hostname, memory=event.host.hw_info.memory, cpus=event.host.slots, gpu_info=gpu_info
+            new_node = (
+                "NodeName={nodename} Sockets={sockets} CoresPerSocket={cores_per_socket} "
+                "ThreadsPerCore={threads_per_core} RealMemory={memory} CPUs={cpus} {gpu_info}State=UNKNOWN\n"
+            ).format(
+                nodename=event.host.hostname,
+                sockets=event.host.sockets,
+                cores_per_socket=event.host.cores_per_socket,
+                threads_per_core=event.host.threads_per_core,
+                memory=event.host.memory,
+                cpus=event.host.slots,
+                gpu_info=gpu_info,
             )
 
             if new_node not in node_list:

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -60,8 +60,8 @@ SQSWatcherConfig = collections.namedtuple(
     ],
 )
 
-Host = collections.namedtuple("Host", ["instance_id", "hostname", "slots", "gpus"])
-
+Host = collections.namedtuple("Host", ["instance_id", "hostname", "slots", "gpus", "hw_info"])
+HWInfo = collections.namedtuple("HWInfo", ["memory"])
 UpdateEvent = collections.namedtuple("UpdateEvent", ["action", "message", "host"])
 
 
@@ -269,6 +269,7 @@ def _process_compute_ready_event(sqs_config_region, sqs_config_proxy, message_at
     # from instance and CloudFormation could be out-of-sync
     instance_properties = get_instance_properties(sqs_config_region, sqs_config_proxy, instance_type)
     gpus = instance_properties["gpus"]
+    memory = instance_properties["memory"]
     slots = message_attrs.get("Slots")
     hostname = message_attrs.get("LocalHostname").split(".")[0]
     _retry_on_request_limit_exceeded(lambda: table.put_item(Item={"instanceId": instance_id, "hostname": hostname}))
@@ -288,7 +289,7 @@ def _process_instance_terminate_event(message_attrs, message, table, queue):
 
     if item.get("Item") is not None:
         hostname = item.get("Item").get("hostname")
-        return UpdateEvent("REMOVE", message, Host(instance_id, hostname, None, None))
+        return UpdateEvent("REMOVE", message, Host(instance_id, hostname, None, None, HWInfo(None)))
     else:
         log.error("Instance %s not found in the database.", instance_id)
         _requeue_message(queue, message)

--- a/tests/common/schedulers/test_sge_commands.py
+++ b/tests/common/schedulers/test_sge_commands.py
@@ -20,7 +20,7 @@ from common.schedulers.sge_commands import (
     get_jobs_info,
     get_pending_jobs_info,
 )
-from sqswatcher.sqswatcher import Host, HWInfo
+from sqswatcher.sqswatcher import Host
 from tests.common import read_text
 
 
@@ -278,9 +278,9 @@ def test_qconf_commands(qconf_output, command, expected_succeeded_hosts, mocker)
         "common.schedulers.sge_commands.check_sge_command_output", return_value=qconf_output, autospec=True
     )
     hosts = [
-        Host("id", "ip-10-0-0-157", 1, 0, HWInfo(1)),
-        Host("id", "ip-10-0-0-155", 1, 0, HWInfo(1)),
-        Host("id", "ip-10-0-0", 1, 0, HWInfo(1)),
+        Host("id", "ip-10-0-0-157", 1, 0, 1, 1, 1, 1),
+        Host("id", "ip-10-0-0-155", 1, 0, 1, 1, 1, 1),
+        Host("id", "ip-10-0-0", 1, 0, 1, 1, 1, 1),
     ]
     succeeded_hosts = exec_qconf_command(hosts, QCONF_COMMANDS[command])
 

--- a/tests/common/schedulers/test_sge_commands.py
+++ b/tests/common/schedulers/test_sge_commands.py
@@ -20,7 +20,7 @@ from common.schedulers.sge_commands import (
     get_jobs_info,
     get_pending_jobs_info,
 )
-from sqswatcher.sqswatcher import Host
+from sqswatcher.sqswatcher import Host, HWInfo
 from tests.common import read_text
 
 
@@ -277,7 +277,11 @@ def test_qconf_commands(qconf_output, command, expected_succeeded_hosts, mocker)
     mock = mocker.patch(
         "common.schedulers.sge_commands.check_sge_command_output", return_value=qconf_output, autospec=True
     )
-    hosts = [Host("id", "ip-10-0-0-157", 1, 0), Host("id", "ip-10-0-0-155", 1, 0), Host("id", "ip-10-0-0", 1, 0)]
+    hosts = [
+        Host("id", "ip-10-0-0-157", 1, 0, HWInfo(1)),
+        Host("id", "ip-10-0-0-155", 1, 0, HWInfo(1)),
+        Host("id", "ip-10-0-0", 1, 0, HWInfo(1)),
+    ]
     succeeded_hosts = exec_qconf_command(hosts, QCONF_COMMANDS[command])
 
     mock.assert_called_with(

--- a/tests/sqswatcher/test_slurm.py
+++ b/tests/sqswatcher/test_slurm.py
@@ -12,7 +12,7 @@ import pytest
 
 from assertpy import assert_that
 from sqswatcher.plugins.slurm import _update_gres_node_lists, _update_node_lists
-from sqswatcher.sqswatcher import Host, UpdateEvent
+from sqswatcher.sqswatcher import Host, HWInfo, UpdateEvent
 
 
 # Input: existing gres_node_list, events to be processed.
@@ -23,9 +23,9 @@ from sqswatcher.sqswatcher import Host, UpdateEvent
         (
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n"],
             [
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
             ],
             [
                 "NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n",
@@ -35,8 +35,8 @@ from sqswatcher.sqswatcher import Host, UpdateEvent
         (
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n"],
             [
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, HWInfo(1))),
             ],
             [],
         ),
@@ -44,8 +44,8 @@ from sqswatcher.sqswatcher import Host, UpdateEvent
             # GPU files should be updated after remove/add sequence
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-1]\n"],
             [
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
             ],
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n"],
         ),
@@ -64,16 +64,16 @@ def test_update_gres_node_lists(gres_node_list, events, expected_result, mocker)
     "gpu_node_list, events, expected_result",
     [
         (
-            ["NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 RealMemory=1 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"],
             [
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
             ],
             (
                 [
-                    "NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n",
-                    "NodeName=ip-10-0-000-222 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-111 RealMemory=1 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-222 RealMemory=1 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n",
                 ],
                 # Note nodes_to_restart list is expected to be repetitive because we want to restart with every ADD
                 ["ip-10-0-000-111", "ip-10-0-000-222", "ip-10-0-000-111"],
@@ -82,19 +82,19 @@ def test_update_gres_node_lists(gres_node_list, events, expected_result, mocker)
         (
             ["NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"],
             [
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, HWInfo(1))),
             ],
             ([], []),
         ),
         (
             # CPU/GPU information should be updated after remove/add sequence
-            ["NodeName=ip-10-0-000-111 CPUs=8 Gres=gpu:tesla:1 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 RealMemory=10 CPUs=8 Gres=gpu:tesla:1 State=UNKNOWN\n"],
             [
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, HWInfo(1))),
             ],
-            (["NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"], ["ip-10-0-000-111"]),
+            (["NodeName=ip-10-0-000-111 RealMemory=1 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"], ["ip-10-0-000-111"]),
         ),
     ],
     ids=["repetitive_add", "remove_nonexisting_node", "reusing_nodename"],
@@ -111,16 +111,16 @@ def test_gpu_update_node_lists(gpu_node_list, events, expected_result, mocker):
     "node_list, events, expected_result",
     [
         (
-            ["NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 RealMemory=1 CPUs=32 State=UNKNOWN\n"],
             [
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, HWInfo(1))),
             ],
             (
                 [
-                    "NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n",
-                    "NodeName=ip-10-0-000-222 CPUs=32 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-111 RealMemory=1 CPUs=32 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-222 RealMemory=1 CPUs=32 State=UNKNOWN\n",
                 ],
                 # Note nodes_to_restart list is expected to be repetitive because we want to restart with every ADD
                 ["ip-10-0-000-111", "ip-10-0-000-222", "ip-10-0-000-111"],
@@ -129,19 +129,19 @@ def test_gpu_update_node_lists(gpu_node_list, events, expected_result, mocker):
         (
             ["NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n"],
             [
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0)),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, HWInfo(1))),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0, HWInfo(1))),
             ],
             ([], []),
         ),
         (
             # CPU information should be updated after remove/add sequence
-            ["NodeName=ip-10-0-000-111 CPUs=8 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 RealMemory=10 CPUs=8 State=UNKNOWN\n"],
             [
-                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
-                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
+                UpdateEvent("REMOVE", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, HWInfo(1))),
+                UpdateEvent("ADD", "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, HWInfo(1))),
             ],
-            (["NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n"], ["ip-10-0-000-111"]),
+            (["NodeName=ip-10-0-000-111 RealMemory=1 CPUs=32 State=UNKNOWN\n"], ["ip-10-0-000-111"]),
         ),
     ],
     ids=["repetitive_add", "remove_nonexisting_node", "reusing_nodename"],


### PR DESCRIPTION
* Modified get_instance_properties in utils.py to retrieve memory from instances.json
* Modified sqswatcher.py to include extended hardware info in "Add" events
* Modified slurm plugin to write hardware info to nodes
* Not adding hardware info to dummy nodes because scaling should be based on slots/GPUs not the hardware info.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
