### PR TITLE
Nodewatcher optimizations

### DIFF
--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -42,9 +42,9 @@ log = logging.getLogger(__name__)
 DATA_DIR = "/var/run/nodewatcher/"
 IDLETIME_FILE = DATA_DIR + "node_idletime.json"
 # Timeout used when nodewatcher starts. The node might not be attached to scheduler yet.
-INITIAL_TERMINATE_TIMEOUT = minutes(3)
+INITIAL_TERMINATE_TIMEOUT = minutes(5)
 # Timeout used at every iteration of nodewatcher loop.
-TERMINATE_TIMEOUT = minutes(1)
+TERMINATE_TIMEOUT = minutes(5)
 LOOP_TIME = 60
 
 NodewatcherConfig = collections.namedtuple(

--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -66,10 +66,11 @@ def _reconfigure_nodes():
 
 def _read_node_list(config_file):
     nodes = []
-    with open(config_file) as slurm_config:
-        for line in slurm_config:
-            if line.startswith("NodeName") and "dummy-compute" not in line:
-                nodes.append(line)
+    if os.path.exists(config_file):
+        with open(config_file) as slurm_config:
+            for line in slurm_config:
+                if line.startswith("NodeName") and "dummy-compute" not in line:
+                    nodes.append(line)
     return nodes
 
 


### PR DESCRIPTION
- Timeout for terminating failing nodes have been increased. This is to allow some extra margin to recover since the scheduler might be unresponsive when under heavy load
  - A node that cannot attach to the scheduler is terminated after 5 minutes (it was 3 before)
  - A node that is failing after being attached is terminated after 5 minutes (it was 1 before)

- Fix a bug that was triggered when the COMPUTE_READY event and the INSTANCE_TERMINATE one for the same instance were processed in the same batch. This was caused by the fact that when parsing the INSTANCE_TERMINATE event the record was not present in dynamodb yet.

- slurm: check if nodes file exists when reading dummy-nodes

- Reduce the amount of calls to ASG api to prevent Throttling. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
