### PR TITLE
Back-port fixes to release-2.5 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+2.5.1
+-----
+
+**BUG FIXES**
+- Fix bug in sqswatcher that was causing the daemon to crash when more than 100 DynamoDB tables are present in the
+  cluster region.
+
+
 2.5.0
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ console_scripts = [
     "nodewatcher = nodewatcher.nodewatcher:main",
     "jobwatcher = jobwatcher.jobwatcher:main",
 ]
-version = "2.5.0"
+version = "2.5.1"
 requires = ["requests>=2.21.0", "boto3>=1.7.55", "retrying>=1.3.3", "configparser>=3.7.4", "paramiko>=2.4.2"]
 
 setup(

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -151,11 +151,8 @@ def _get_ddb_table(region, table_name, proxy_config):
     log.debug("Getting DynamoDB table '%s'", table_name)
     ddb_client = boto3.client("dynamodb", region_name=region, config=proxy_config)
     try:
-        tables = ddb_client.list_tables().get("TableNames")
-        if table_name not in tables:
-            error_msg = "Unable to find the DynamoDB table '{0}'".format(table_name)
-            log.critical(error_msg)
-            raise CriticalError(error_msg)
+        # Check that table exists
+        ddb_client.describe_table(TableName=table_name)
 
         ddb_resource = boto3.resource("dynamodb", region_name=region, config=proxy_config)
         table = ddb_resource.Table(table_name)


### PR DESCRIPTION
The following fixes have been back-ported:
- Fix "Unable to find the DynamoDB table" error in _get_ddb_table(): #190 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
