### PR TITLE
Make ParallelCluster services more portable

### DIFF
--- a/config/jobwatcher.service
+++ b/config/jobwatcher.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=AWS ParallelCluster Jobwatcher service
+After=network.target
+ConditionPathExists=/etc/jobwatcher.cfg
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/jobwatcher
+ExecReload=/bin/kill -HUP $MAINPID
+StandardError=syslog
+PIDFile=/var/run/jobwatcher.pid
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/config/nodewatcher.service
+++ b/config/nodewatcher.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=AWS ParallelCluster Nodewatcher service
+After=network.target
+ConditionPathExists=/etc/nodewatcher.cfg
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/nodewatcher
+ExecReload=/bin/kill -HUP $MAINPID
+StandardError=syslog
+PIDFile=/var/run/nodewatcher.pid
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/config/sqswatcher.service
+++ b/config/sqswatcher.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=AWS ParallelCluster Sqswatcher service
+After=network.target
+ConditionPathExists=/etc/sqswatcher.cfg
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/sqswatcher
+ExecReload=/bin/kill -HUP $MAINPID
+StandardError=syslog
+PIDFile=/var/run/sqswatcher.pid
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ console_scripts = [
     "jobwatcher = jobwatcher.jobwatcher:main",
 ]
 version = "2.5.1"
-requires = ["requests>=2.21.0", "boto3>=1.7.55", "retrying>=1.3.3", "configparser>=3.7.4", "paramiko>=2.4.2"]
+requires = ["requests>=2.20.0", "boto3>=1.7.55", "retrying>=1.3.3", "paramiko>=2.4.2"]
 
 setup(
     name="aws-parallelcluster-node",

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -51,7 +51,7 @@ def get_jobs_info(job_state_filter=None):
     :param job_state_filter: filter jobs by the given state
     :return: a list of SlurmJob objects representing the submitted jobs.
     """
-    command = "/opt/slurm/bin/squeue -r -O '{0}'".format(SQUEUE_FIELD_STRING)
+    command = "squeue -r -O '{0}'".format(SQUEUE_FIELD_STRING)
     if job_state_filter:
         command += " --states {0}".format(job_state_filter)
 
@@ -116,7 +116,7 @@ def _recompute_required_nodes_by_slots_reservation(pending_jobs, node_slots):
 
     For example, when submitting a job with: sbatch -c 3 -n 5 in a cluster with 4-slot nodes, the output of the squeue
     command is:
-        /opt/slurm/bin/squeue -r -o '%i|%t|%D|%C|%c|%r'
+        squeue -r -o '%i|%t|%D|%C|%c|%r'
         JOBID|ST|NODES|CPUS|MIN_CPUS|REASON
         91|PD|4|15|3|Nodes required for job are DOWN, DRAINED or reserved for jobs in higher priority partitions
 

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -206,7 +206,13 @@ def _read_cfnconfig():
     :return: a dictionary containing the configuration parameters
     """
     cfnconfig_params = {}
-    cfnconfig_file = "/opt/parallelcluster/cfnconfig"
+    cfnconfig_file_locations = ["/opt/parallelcluster/cfnconfig", "/etc/parallelcluster/cfnconfig"]
+    cfnconfig_file = None
+    for fl in cfnconfig_file_locations:
+        if os.path.exists(fl):
+            cfnconfig_file = fl
+    if not cfnconfig_file:
+        raise CriticalError("Could not find cfnconfig file.")
     log.info("Reading %s", cfnconfig_file)
     with open(cfnconfig_file) as f:
         for kvp in f:

--- a/src/jobwatcher/plugins/slurm.py
+++ b/src/jobwatcher/plugins/slurm.py
@@ -45,7 +45,7 @@ def get_required_nodes(instance_properties, max_size):
 
 # get nodes reserved by running jobs
 def get_busy_nodes():
-    command = "/opt/slurm/bin/sinfo -h -o '%D %t'"
+    command = "sinfo -h -o '%D %t'"
     # Sample output:
     # 2 mix
     # 4 alloc

--- a/src/nodewatcher/plugins/slurm.py
+++ b/src/nodewatcher/plugins/slurm.py
@@ -89,14 +89,7 @@ def is_node_down():
         # Output format:
         # down*
         hostname = socket.get_hostname()
-        command = [
-            "sinfo",
-            "--noheader",
-            "-o",
-            "%T",
-            "-n",
-            hostname
-        ]
+        command = ["sinfo", "--noheader", "-o", "%T", "-n", hostname]
         output = check_command_output(command).strip()
         log.info("Node is in state: '{0}'".format(output))
         if output and all(state not in output for state in ["down", "drained", "fail"]):

--- a/src/sqswatcher/plugins/sge.py
+++ b/src/sqswatcher/plugins/sge.py
@@ -98,5 +98,5 @@ def update_cluster(max_cluster_size, cluster_user, update_events, instance_prope
     return failed, succeeded
 
 
-def init():
+def init(scheduler_conf_dir=None):
     pass

--- a/src/sqswatcher/plugins/torque.py
+++ b/src/sqswatcher/plugins/torque.py
@@ -51,7 +51,7 @@ def update_cluster(max_cluster_size, cluster_user, update_events, instance_prope
     return failed, succeeded
 
 
-def init():
+def init(scheduler_conf_dir=None):
     if hasattr(init, "wakeup_scheduler_worker_thread") and init.wakeup_scheduler_worker_thread.is_alive():
         return
     init.wakeup_scheduler_worker_thread = threading.Thread(target=_wakeup_scheduler_worker)

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -112,14 +112,14 @@ def _get_config():
     )
     return SQSWatcherConfig(
         region,
-	scheduler,
-	scheduler_conf_dir,
-	sqsqueue,
-	table_name,
-	cluster_user,
-	proxy_config,
-	stack_name,
-	max_processed_messages
+        scheduler,
+        scheduler_conf_dir,
+        sqsqueue,
+        table_name,
+        cluster_user,
+        proxy_config,
+        stack_name,
+        max_processed_messages,
     )
 
 

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -51,6 +51,7 @@ SQSWatcherConfig = collections.namedtuple(
     [
         "region",
         "scheduler",
+        "scheduler_conf_dir",
         "sqsqueue",
         "table_name",
         "cluster_user",
@@ -82,6 +83,7 @@ def _get_config():
 
     region = config.get("sqswatcher", "region")
     scheduler = config.get("sqswatcher", "scheduler")
+    scheduler_conf_dir = config.get("sqswatcher", "scheduler_conf_dir", fallback=None)
     sqsqueue = config.get("sqswatcher", "sqsqueue")
     table_name = config.get("sqswatcher", "table_name")
     cluster_user = config.get("sqswatcher", "cluster_user")
@@ -96,10 +98,11 @@ def _get_config():
         proxy_config = Config(proxies={"https": _proxy})
 
     log.info(
-        "Configured parameters: region=%s scheduler=%s sqsqueue=%s table_name=%s cluster_user=%s "
-        "proxy=%s stack_name=%s max_processed_messages=%s",
+        "Configured parameters: region=%s scheduler=%s scheduler_conf_dir=%s sqsqueue=%s table_name=%s "
+        "cluster_user=%s proxy=%s stack_name=%s max_processed_messages=%s",
         region,
         scheduler,
+        scheduler_conf_dir,
         sqsqueue,
         table_name,
         cluster_user,
@@ -108,7 +111,15 @@ def _get_config():
         max_processed_messages,
     )
     return SQSWatcherConfig(
-        region, scheduler, sqsqueue, table_name, cluster_user, proxy_config, stack_name, max_processed_messages
+        region,
+	scheduler,
+	scheduler_conf_dir,
+	sqsqueue,
+	table_name,
+	cluster_user,
+	proxy_config,
+	stack_name,
+	max_processed_messages
     )
 
 
@@ -359,7 +370,7 @@ def _poll_queue(sqs_config, queue, table, asg_name):
     :param table: DB table resource object
     """
     scheduler_module = load_module("sqswatcher.plugins." + sqs_config.scheduler)
-    scheduler_module.init()
+    scheduler_module.init(sqs_config.scheduler_conf_dir)
 
     max_cluster_size = None
     instance_type = None

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -163,7 +163,7 @@ def test_get_jobs_info(squeue_mocked_response, expected_output, test_datadir, mo
     jobs = get_jobs_info(job_state_filter="PD,R")
 
     mock.assert_called_with(
-        "/opt/slurm/bin/squeue -r -O 'jobid:200,statecompact:200,numnodes:200,numcpus:200,numtasks:200,"
+        "squeue -r -O 'jobid:200,statecompact:200,numnodes:200,numcpus:200,numtasks:200,"
         "cpus-per-task:200,mincpus:200,reason:200,tres-per-job:200,tres-per-task:200,tres-per-node:200,"
         "cpus-per-tres:200' --states PD,R"
     )


### PR DESCRIPTION
*Description of changes:*

This patch is intended to make ParallelCluster services work on other platforms, not just systems created by the chef bootstrap mechanism.

Mostly this means removing hard-coded paths and being more flexible about config file locations. I've also added systemd unit files and relaxed the requirements a little bit to allow the package to be installed on SLES 15 SP1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
