### PR TITLE
Drop dependency on requests and configparser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - pip install tox-travis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-requests>=2.21.0
 boto3>=1.7.55
 retrying>=1.3.3
-configparser>=3.7.4
 paramiko>=2.4.2
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ console_scripts = [
     "jobwatcher = jobwatcher.jobwatcher:main",
 ]
 version = "2.5.1"
-requires = ["requests>=2.21.0", "boto3>=1.7.55", "retrying>=1.3.3", "configparser>=3.7.4", "paramiko>=2.4.2"]
+requires = ["boto3>=1.7.55", "retrying>=1.3.3", "paramiko>=2.4.2"]
 
 setup(
     name="aws-parallelcluster-node",

--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -20,6 +20,7 @@ import tarfile
 import time
 from contextlib import closing
 from datetime import datetime
+from urllib.request import urlopen
 
 import boto3
 from botocore.config import Config
@@ -27,7 +28,6 @@ from botocore.exceptions import ClientError
 from configparser import ConfigParser
 from retrying import RetryError, retry
 
-import requests
 from common.time_utils import minutes, seconds
 from common.utils import (
     CriticalError,
@@ -99,7 +99,7 @@ def _get_metadata(metadata_path):
     :return the metadata value.
     """
     try:
-        metadata_value = requests.get("http://169.254.169.254/latest/meta-data/{0}".format(metadata_path)).text
+        metadata_value = urlopen("http://169.254.169.254/latest/meta-data/{0}".format(metadata_path)).read().decode()
     except Exception as e:
         error_msg = "Unable to get {0} metadata. Failed with exception: {1}".format(metadata_path, e)
         log.critical(error_msg)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37}
+    py{35,36,37,38}
     code-linters
 
 # Default testenv. Used to run tests on all python versions.
@@ -9,7 +9,7 @@ passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_
 whitelist_externals =
     bash
 deps =
-    py{35,36,37}: -rtests/requirements.txt
+    -r tests/requirements.txt
 commands =
     bash ./tests/test.sh
     python -m unittest discover -s tests/jobwatcher -p "*tests.py"


### PR DESCRIPTION
- `configparser` is not needed since we are supporting python>=3.5
- `requests` replaced with native python library

This PR also enables travis tests for Python 3.6 and 3.7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
