### PR TITLE
Handling EC2 Health Scheduled Events

### DIFF
--- a/src/common/schedulers/sge_commands.py
+++ b/src/common/schedulers/sge_commands.py
@@ -11,6 +11,7 @@
 import collections
 import logging
 import re
+import subprocess
 from xml.etree import ElementTree
 
 from common import sge
@@ -154,16 +155,22 @@ def install_sge_on_compute_nodes(hosts, cluster_user):
     return succeeded_hosts
 
 
-def lock_host(hostname):
+def lock_node(hostname):
     logging.info("Locking host %s", hostname)
     command = ["qmod", "-d", "all.q@{0}".format(hostname)]
-    run_sge_command(command)
+    try:
+        run_sge_command(command)
+    except subprocess.CalledProcessError:
+        logging.error("Error locking host %s", hostname)
 
 
-def unlock_host(hostname):
+def unlock_node(hostname):
     logging.info("Unlocking host %s", hostname)
     command = ["qmod", "-e", "all.q@{0}".format(hostname)]
-    run_sge_command(command)
+    try:
+        run_sge_command(command)
+    except subprocess.CalledProcessError:
+        logging.error("Error unlocking host %s", hostname)
 
 
 def _run_sge_command_for_multiple_hosts(hosts, command_template):

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -67,13 +67,9 @@ def get_node_state(hostname):
     # https://slurm.schedmd.com/sinfo.html#lbAG
     # Output format:
     # down*
-    try:
-        command = "/opt/slurm/bin/sinfo --noheader -o '%T' -n {}".format(hostname)
-        output = check_command_output(command).strip()
-        return output
-    except Exception as e:
-        logging.error("Failed when checking if node %s state with exception %s.", hostname, e)
-        raise
+    command = "/opt/slurm/bin/sinfo --noheader -o '%T' -n {}".format(hostname)
+    output = check_command_output(command).strip()
+    return output
 
 
 def get_pending_jobs_info(
@@ -301,7 +297,6 @@ def lock_node(hostname, reason=None):
         run_command(command)
     except subprocess.CalledProcessError:
         logging.error("Error locking host %s", hostname)
-        raise
 
 
 def unlock_node(hostname, reason=None):
@@ -318,7 +313,6 @@ def unlock_node(hostname, reason=None):
         run_command(command)
     except subprocess.CalledProcessError:
         logging.error("Error unlocking host %s", hostname)
-        raise
 
 
 class SlurmJob(ComparableObject):

--- a/src/common/schedulers/torque_commands.py
+++ b/src/common/schedulers/torque_commands.py
@@ -141,7 +141,6 @@ def lock_node(hostname, unlock=False, note=None):
         run_command(command)
     except subprocess.CalledProcessError:
         logging.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)
-        raise
 
 
 def update_cluster_limits(max_nodes, node_slots):

--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -277,6 +277,11 @@ def _init_idletime():
 
 
 def _lock_and_terminate(region, proxy_config, scheduler_module, hostname, instance_id):
+    # handle case that the instance is placed in lock by scheduled event and has job running
+    if _has_jobs(scheduler_module, hostname):
+        log.info("Instance has active jobs.")
+        return
+    # handle case that instance has no job running to begin with
     _lock_host(scheduler_module, hostname)
     if _has_jobs(scheduler_module, hostname):
         log.info("Instance has active jobs.")

--- a/src/nodewatcher/nodewatcher.py
+++ b/src/nodewatcher/nodewatcher.py
@@ -277,11 +277,6 @@ def _init_idletime():
 
 
 def _lock_and_terminate(region, proxy_config, scheduler_module, hostname, instance_id):
-    # handle case that the instance is placed in lock by scheduled event and has job running
-    if _has_jobs(scheduler_module, hostname):
-        log.info("Instance has active jobs.")
-        return
-    # handle case that instance has no job running to begin with
     _lock_host(scheduler_module, hostname)
     if _has_jobs(scheduler_module, hostname):
         log.info("Instance has active jobs.")

--- a/src/nodewatcher/plugins/sge.py
+++ b/src/nodewatcher/plugins/sge.py
@@ -11,7 +11,6 @@
 
 import logging
 import socket
-import subprocess
 
 from common.schedulers.sge_commands import (
     SGE_DISABLED_STATE,
@@ -20,9 +19,9 @@ from common.schedulers.sge_commands import (
     get_compute_nodes_info,
     get_jobs_info,
     get_pending_jobs_info,
+    lock_node,
+    unlock_node,
 )
-from common.schedulers.sge_commands import lock_host as sge_lock_host
-from common.schedulers.sge_commands import unlock_host
 from common.utils import check_command_output
 
 log = logging.getLogger(__name__)
@@ -59,13 +58,10 @@ def has_pending_jobs(instance_properties, max_size):
 
 
 def lock_host(hostname, unlock=False):
-    try:
-        if unlock:
-            unlock_host(hostname)
-        else:
-            sge_lock_host(hostname)
-    except subprocess.CalledProcessError:
-        log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)
+    if unlock:
+        unlock_node(hostname)
+    else:
+        lock_node(hostname)
 
 
 def is_node_down():

--- a/src/nodewatcher/plugins/sge.py
+++ b/src/nodewatcher/plugins/sge.py
@@ -91,6 +91,13 @@ def is_node_down():
         if all(error_state not in node.state for error_state in SGE_ERROR_STATES):
             # Consider the node down if it's in disabled state and there is no job running
             if SGE_DISABLED_STATE in node.state and not has_jobs(hostname):
+                log.warning(
+                    (
+                        "Considering node as down because there is no job running and node is in a disabled state. "
+                        "The node could have been put into this disabled state automatically by ParallelCluster "
+                        "in response to an EC2 scheduled maintenance event, or manually by the system administrator."
+                    )
+                )
                 return True
             return False
     except Exception as e:

--- a/src/nodewatcher/plugins/slurm.py
+++ b/src/nodewatcher/plugins/slurm.py
@@ -12,8 +12,14 @@
 import logging
 import subprocess
 
-from common.schedulers.slurm_commands import PENDING_RESOURCES_REASONS, get_pending_jobs_info
-from common.utils import check_command_output, run_command
+from common.schedulers.slurm_commands import (
+    PENDING_RESOURCES_REASONS,
+    SLURM_NODE_ERROR_STATES,
+    get_node_state,
+    get_pending_jobs_info,
+    lock_node,
+)
+from common.utils import check_command_output
 
 log = logging.getLogger(__name__)
 
@@ -54,43 +60,16 @@ def has_pending_jobs(instance_properties, max_size):
 
 
 def lock_host(hostname, unlock=False):
-    # hostname format: ip-10-0-0-114.eu-west-1.compute.internal
-    hostname = hostname.split(".")[0]
-    if unlock:
-        log.info("Unlocking host %s", hostname)
-        command = [
-            "/opt/slurm/bin/scontrol",
-            "update",
-            "NodeName={0}".format(hostname),
-            "State=RESUME",
-            'Reason="Unlocking"',
-        ]
-    else:
-        log.info("Locking host %s", hostname)
-        command = [
-            "/opt/slurm/bin/scontrol",
-            "update",
-            "NodeName={0}".format(hostname),
-            "State=DRAIN",
-            'Reason="Shutting down"',
-        ]
-    try:
-        run_command(command)
-    except subprocess.CalledProcessError:
-        log.error("Error %s host %s", "unlocking" if unlock else "locking", hostname)
+    lock_node(hostname, unlock=unlock)
 
 
 def is_node_down():
     """Check if node is down according to scheduler."""
     try:
-        # retrieves the state of a specific node
-        # https://slurm.schedmd.com/sinfo.html#lbAG
-        # Output format:
-        # down*
-        command = "/bin/bash -c \"/opt/slurm/bin/sinfo --noheader -o '%T' -n $(hostname)\""
-        output = check_command_output(command).strip()
+        hostname = check_command_output("hostname").strip()
+        output = get_node_state(hostname)
         log.info("Node is in state: '{0}'".format(output))
-        if output and all(state not in output for state in ["down", "drained", "fail"]):
+        if output and all(state not in output for state in SLURM_NODE_ERROR_STATES):
             return False
     except Exception as e:
         log.error("Failed when checking if node is down with exception %s. Reporting node as down.", e)

--- a/src/nodewatcher/plugins/torque.py
+++ b/src/nodewatcher/plugins/torque.py
@@ -70,6 +70,13 @@ def is_node_down():
                 # Consider the node down if it is in Disabled state placed by scheduled event
                 # and does not have job
                 if TORQUE_NODE_DISABLED_STATE in node.state and not has_jobs(hostname):
+                    log.warning(
+                        (
+                            "Considering node as down because there is no job running and node is in a disabled state. "
+                            "The node could have been put into this disabled state automatically by ParallelCluster in "
+                            "response to an EC2 scheduled maintenance event, or manually by the system administrator."
+                        )
+                    )
                     return True
                 return False
         else:

--- a/src/sqswatcher/plugins/sge.py
+++ b/src/sqswatcher/plugins/sge.py
@@ -120,26 +120,26 @@ def perform_health_actions(health_events):
             # to-do, ignore fail to lock message if node is not in scheduler
             if _is_node_locked(event.host.hostname):
                 log.error(
-                    "Instance {}/{} currently in disabled state 'd'. "
+                    "Instance %s/%s currently in disabled state 'd'. "
                     "Risk of lock being released by nodewatcher if locking the node because of scheduled event now. "
-                    "Marking event as failed to retry later.".format(event.host.instance_id, event.host.hostname)
+                    "Marking event as failed to retry later.",
+                    event.host.instance_id,
+                    event.host.hostname,
                 )
                 failed.append(event)
                 continue
             lock_host(event.host.hostname)
             if _is_node_locked:
                 succeeded.append(event)
-                log.info(
-                    "Successfully locked {} in response to scheduled maintainence event".format(event.host.hostname)
-                )
+                log.info("Successfully locked %s in response to scheduled maintainence event", event.host.hostname)
             else:
                 failed.append(event)
-                log.info("Failed to lock {} in response to scheduled maintainence event".format(event.host.hostname))
+                log.error("Failed to lock %s in response to scheduled maintainence event", event.host.hostname)
         except Exception as e:
             log.error(
-                "Encountered exception when locking {} because of a scheduled maintainence event: {}".format(
-                    event.host.hostname, e
-                )
+                "Encountered exception when locking %s because of a scheduled maintainence event: %s",
+                event.host.hostname,
+                e,
             )
             failed.append(event)
 

--- a/src/sqswatcher/plugins/sge.py
+++ b/src/sqswatcher/plugins/sge.py
@@ -9,13 +9,17 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import socket
 
 from common.schedulers.sge_commands import (
     QCONF_COMMANDS,
+    SGE_DISABLED_STATE,
     add_host_slots,
     add_hosts_to_group,
     exec_qconf_command,
+    get_compute_nodes_info,
     install_sge_on_compute_nodes,
+    lock_host,
     remove_hosts_from_group,
     remove_hosts_from_queue,
 )
@@ -94,6 +98,49 @@ def update_cluster(max_cluster_size, cluster_user, update_events, instance_prope
         if event.host.hostname in added_hosts or event.host.hostname in removed_hosts:
             succeeded.append(event)
         else:
+            failed.append(event)
+
+    return failed, succeeded
+
+
+def _is_node_locked(hostname):
+    node_info = get_compute_nodes_info(hostname_filter=hostname)
+    node = node_info.get(socket.getfqdn(hostname), node_info.get(hostname))
+    if SGE_DISABLED_STATE in node.state:
+        return True
+    return False
+
+
+def perform_health_actions(health_events):
+    """Update and write node lists( and gres_nodes if instance has GPU); restart relevant nodes."""
+    failed = []
+    succeeded = []
+    for event in health_events:
+        try:
+            # to-do, ignore fail to lock message if node is not in scheduler
+            if _is_node_locked(event.host.hostname):
+                log.error(
+                    "Instance {}/{} currently in disabled state 'd'. "
+                    "Risk of lock being released by nodewatcher if locking the node because of scheduled event now. "
+                    "Marking event as failed to retry later.".format(event.host.instance_id, event.host.hostname)
+                )
+                failed.append(event)
+                continue
+            lock_host(event.host.hostname)
+            if _is_node_locked:
+                succeeded.append(event)
+                log.info(
+                    "Successfully locked {} in response to scheduled maintainence event".format(event.host.hostname)
+                )
+            else:
+                failed.append(event)
+                log.info("Failed to lock {} in response to scheduled maintainence event".format(event.host.hostname))
+        except Exception as e:
+            log.error(
+                "Encountered exception when locking {} because of a scheduled maintainence event: {}".format(
+                    event.host.hostname, e
+                )
+            )
             failed.append(event)
 
     return failed, succeeded

--- a/src/sqswatcher/plugins/sge.py
+++ b/src/sqswatcher/plugins/sge.py
@@ -123,7 +123,7 @@ def perform_health_actions(health_events):
     for event in health_events:
         try:
             if _is_node_locked(event.host.hostname):
-                log.error(
+                log.warning(
                     "Instance %s/%s currently in disabled state 'd'. "
                     "Risk of lock being released by nodewatcher if locking the node because of scheduled event now. "
                     "Marking event as failed to retry later.",
@@ -141,7 +141,7 @@ def perform_health_actions(health_events):
                 log.error("Failed to lock %s in response to scheduled maintainence event", event.host.hostname)
         except Exception as e:
             log.error(
-                "Encountered exception when locking %s because of a scheduled maintainence event: %s",
+                "Encountered exception when responding to a scheduled maintainence event for %s: %s",
                 event.host.hostname,
                 e,
             )

--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -249,7 +249,7 @@ def perform_health_actions(health_events):
                 log.error("Failed to lock %s in response to scheduled maintainence event", event.host.hostname)
         except Exception as e:
             log.error(
-                "Encountered exception when locking %s because of a scheduled maintainence event: %s",
+                "Encountered exception when responding to a scheduled maintainence event for %s: %s",
                 event.host.hostname,
                 e,
             )

--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -88,7 +88,7 @@ def _write_node_list_to_file(generic_node_list, config_file_path):
     # Only log the updated node list if it's different from the previous version,
     # because it can get quite long.
     if not filecmp.cmp(config_file_path, abs_path, shallow=False):
-        log.info("Writing updated {0} with the following nodes: {1}".format(config_file_path, generic_node_list))
+        log.info("Writing updated %s with the following nodes: %s", config_file_path, generic_node_list)
 
     # Update permissions on new file
     os.chmod(abs_path, 0o744)
@@ -211,7 +211,7 @@ def update_cluster(max_cluster_size, cluster_user, update_events, instance_prope
 
 def _is_node_locked(hostname):
     node_state = get_node_state(hostname)
-    log.info("Node {} currently in state {}".format(hostname, node_state))
+    log.info("Node %s currently in state %s", hostname, node_state)
     for disable_state in SLURM_NODE_DISABLED_STATES:
         if disable_state in node_state:
             return True
@@ -226,28 +226,28 @@ def perform_health_actions(health_events):
         try:
             # to-do, ignore fail to lock message if node is not in scheduler
             if _is_node_locked(event.host.hostname):
-                log.error(
-                    "Instance {}/{} currently in disabled state 'draining/drained'. "
+                log.warning(
+                    "Instance %s/%s currently in disabled state 'draining/drained'. "
                     "Risk of lock being released by nodewatcher if locking the node because of scheduled event now. "
-                    "Marking event as failed to retry later.".format(event.host.instance_id, event.host.hostname)
+                    "Marking event as failed to retry later.",
+                    event.host.instance_id,
+                    event.host.hostname,
                 )
                 failed.append(event)
                 continue
-            reason = "DO_NOT_CHANGE_SQSWATCHER_SCHEDULED_EVENT_ACTION"
-            lock_node(event.host.hostname, unlock=False, note=reason)
+            reason = "Node requires replacement due to an EC2 scheduled maintenance event"
+            lock_node(event.host.hostname, reason=reason)
             if _is_node_locked(event.host.hostname):
                 succeeded.append(event)
-                log.info(
-                    "Successfully locked {} in response to scheduled maintainence event".format(event.host.hostname)
-                )
+                log.info("Successfully locked %s in response to scheduled maintainence event", event.host.hostname)
             else:
                 failed.append(event)
-                log.info("Failed to lock {} in response to scheduled maintainence event".format(event.host.hostname))
+                log.error("Failed to lock %s in response to scheduled maintainence event", event.host.hostname)
         except Exception as e:
             log.error(
-                "Encountered exception when locking {} because of a scheduled maintainence event: {}".format(
-                    event.host.hostname, e
-                )
+                "Encountered exception when locking %s because of a scheduled maintainence event: %s",
+                event.host.hostname,
+                e,
             )
             failed.append(event)
 

--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -210,11 +210,16 @@ def update_cluster(max_cluster_size, cluster_user, update_events, instance_prope
 
 
 def _is_node_locked(hostname):
-    node_state = get_node_state(hostname)
-    log.info("Node %s currently in state %s", hostname, node_state)
-    for disable_state in SLURM_NODE_DISABLED_STATES:
-        if disable_state in node_state:
-            return True
+    try:
+        node_state = get_node_state(hostname)
+        log.info("Node %s currently in state %s", hostname, node_state)
+        for disable_state in SLURM_NODE_DISABLED_STATES:
+            if disable_state in node_state:
+                return True
+    except Exception as e:
+        log.error(
+            "Failed when checking if node is locked with exception %s. Reporting node %s as unlocked.", e, hostname
+        )
     return False
 
 
@@ -224,7 +229,6 @@ def perform_health_actions(health_events):
     succeeded = []
     for event in health_events:
         try:
-            # to-do, ignore fail to lock message if node is not in scheduler
             if _is_node_locked(event.host.hostname):
                 log.warning(
                     "Instance %s/%s currently in disabled state 'draining/drained'. "

--- a/src/sqswatcher/plugins/torque.py
+++ b/src/sqswatcher/plugins/torque.py
@@ -71,30 +71,30 @@ def perform_health_actions(health_events):
             # to-do, ignore fail to lock message if node is not in scheduler
             if _is_node_locked(event.host.hostname):
                 log.error(
-                    "Instance {}/{} currently in disabled state 'offline'. "
+                    "Instance %s/%s currently in disabled state 'offline'. "
                     "Risk of lock being released by nodewatcher if locking the node because of scheduled event now. "
-                    "Marking event as failed to retry later.".format(event.host.instance_id, event.host.hostname)
+                    "Marking event as failed to retry later.",
+                    event.host.instance_id,
+                    event.host.hostname,
                 )
                 failed.append(event)
                 continue
 
-            note = "DO_NOT_CHANGE_SQSWATCHER_SCHEDULED_EVENT_ACTION"
+            note = "Node requires replacement due to an EC2 scheduled maintenance event"
             lock_node(hostname=event.host.hostname, unlock=False, note=note)
 
             if _is_node_locked:
                 succeeded.append(event)
-                log.info(
-                    "Successfully locked {} in response to scheduled maintainence event".format(event.host.hostname)
-                )
+                log.info("Successfully locked %s in response to scheduled maintainence event", event.host.hostname)
             else:
                 failed.append(event)
-                log.info("Failed to lock {} in response to scheduled maintainence event".format(event.host.hostname))
+                log.error("Failed to lock %s in response to scheduled maintainence event", event.host.hostname)
 
         except Exception as e:
             log.error(
-                "Encountered exception when locking {} because of a scheduled maintainence event: {}".format(
-                    event.host.hostname, e
-                )
+                "Encountered exception when locking %s because of a scheduled maintainence event: %s",
+                event.host.hostname,
+                e,
             )
             failed.append(event)
 

--- a/src/sqswatcher/plugins/torque.py
+++ b/src/sqswatcher/plugins/torque.py
@@ -74,7 +74,7 @@ def perform_health_actions(health_events):
     for event in health_events:
         try:
             if _is_node_locked(event.host.hostname):
-                log.error(
+                log.warning(
                     "Instance %s/%s currently in disabled state 'offline'. "
                     "Risk of lock being released by nodewatcher if locking the node because of scheduled event now. "
                     "Marking event as failed to retry later.",
@@ -96,7 +96,7 @@ def perform_health_actions(health_events):
 
         except Exception as e:
             log.error(
-                "Encountered exception when locking %s because of a scheduled maintainence event: %s",
+                "Encountered exception when responding to a scheduled maintainence event for %s: %s",
                 event.host.hostname,
                 e,
             )

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -26,9 +26,11 @@ from retrying import retry
 from common.ssh_keyscan import update_ssh_known_hosts
 from common.time_utils import seconds
 from common.utils import (
+    SUPPORTED_EVENTTYPE_FOR_QUEUETYPE,
     CriticalError,
     EventType,
     Host,
+    QueueType,
     UpdateEvent,
     get_asg_name,
     get_cluster_instance_info,
@@ -57,7 +59,7 @@ SQSWatcherConfig = collections.namedtuple(
         "region",
         "scheduler",
         "sqsqueue",
-        "healthsqsqueue",
+        "health_sqsqueue",
         "table_name",
         "cluster_user",
         "proxy_config",
@@ -86,8 +88,8 @@ def _get_config():
     region = config.get("sqswatcher", "region")
     scheduler = config.get("sqswatcher", "scheduler")
     sqsqueue = config.get("sqswatcher", "sqsqueue")
-    healthsqsqueue = config.get("sqswatcher", "healthsqsqueue")
-    disable_health_check = bool(config.get("sqswatcher", "disable_health_check", fallback=False))
+    health_sqsqueue = config.get("sqswatcher", "health_sqsqueue")
+    disable_health_check = config.getboolean("sqswatcher", "disable_health_check", fallback=False)
     table_name = config.get("sqswatcher", "table_name")
     cluster_user = config.get("sqswatcher", "cluster_user")
     stack_name = config.get("sqswatcher", "stack_name")
@@ -102,13 +104,12 @@ def _get_config():
 
     log.info(
         (
-            "Configured parameters: region={} scheduler={} sqsqueue={} healthqueue={} table_name={} cluster_user={} "
-            "proxy={} stack_name={} max_processed_messages={} disable_health_check={}"
-        ).format(
+            "Configured parameters: region=%s scheduler=%s sqsqueue=%s health_sqsqueue=%s table_name=%s "
+            "cluster_user=%s proxy=%s stack_name=%s max_processed_messages=%s disable_health_check=%s",
             region,
             scheduler,
             sqsqueue,
-            healthsqsqueue,
+            health_sqsqueue,
             table_name,
             cluster_user,
             _proxy,
@@ -121,7 +122,7 @@ def _get_config():
         region,
         scheduler,
         sqsqueue,
-        healthsqsqueue,
+        health_sqsqueue,
         table_name,
         cluster_user,
         proxy_config,
@@ -199,7 +200,7 @@ def _retry_on_request_limit_exceeded(func):
     return _retry()
 
 
-def _requeue_message(queue, message_body):
+def _requeue_message(queue, message):
     """
     Requeue the given message into the specified queue.
 
@@ -207,6 +208,11 @@ def _requeue_message(queue, message_body):
     :param message: the message to requeue
     """
     max_retries = 1
+    # CW event rule can only send messages to SQS with "" enclosing the message.
+    # However, when message is re-queued it is sent without ""
+    message_body = (
+        json.loads(json.loads(message.body)) if str(message.body).startswith('"') else json.loads(message.body)
+    )
     if "TTL" not in message_body:
         message_body["TTL"] = max_retries
     else:
@@ -224,9 +230,10 @@ def _requeue_message(queue, message_body):
 
 
 def _retrieve_all_sqs_messages(queue, max_processed_messages):
+    queue_name = queue.url.split("/")[-1]
+    log.info("Retrieving messages from SQS queue %s", queue_name)
     max_messages_per_call = 10
     messages = []
-    queue_name = queue.url.split("/")[-1]
     while len(messages) < max_processed_messages:
         # setting WaitTimeSeconds in order to use Amazon SQS Long Polling.
         # when not using Long Polling with a small queue you might not receive any message
@@ -241,22 +248,21 @@ def _retrieve_all_sqs_messages(queue, max_processed_messages):
             # looping until receive_messages returns at least 1 message
             break
 
-    log.info("Retrieved {} messages from SQS queue {}".format(len(messages), queue_name))
+    log.info("Retrieved %s messages from SQS queue %s", len(messages), queue_name)
 
     return messages
 
 
-def _parse_sqs_messages(sqs_config, messages, table, queue):
+def _resolve_events_hostname_collision(event_pool):
     update_events = OrderedDict()
-    parsed_events = _parse_messages_helper(messages, False, sqs_config, table, queue)
-    for event in itertools.chain(parsed_events["ADD"], parsed_events["REMOVE"]):
-        log.info("Processing {} event for instance {}".format(event.action, event.host))
+    for event in event_pool:
+        log.info("Processing %s event for instance %s", event.action, event.host)
         hostname = event.host.hostname
         if hostname in update_events:
             # events are looped in the order they are fetched and by iterating over REMOVE events after ADD events.
             # in case of collisions let's always remove the item that comes first in order to always favor REMOVE ops.
             log.info(
-                "Hostname collision. Discarding event {} in favour of event {}".format(update_events[hostname], event)
+                "Hostname collision. Discarding event %s in favour of event %s", update_events[hostname], event,
             )
             update_events[hostname].message.delete()
             del update_events[hostname]
@@ -265,31 +271,47 @@ def _parse_sqs_messages(sqs_config, messages, table, queue):
     return update_events.values()
 
 
-def _parse_health_messages(sqs_config, messages, health_queue):
-    health_update_events = OrderedDict()
-    instance_id_to_hostname = get_cluster_instance_info(sqs_config.stack_name, sqs_config.region, include_master=False)
-    parsed_events = _parse_messages_helper(messages, True, sqs_config, instance_id_to_hostname=instance_id_to_hostname)
-    for health_event in parsed_events["HEALTH"]:
-        log.info("Processing {} event for instance {}".format(health_event.action, health_event.host))
-        if health_event.host.instance_id in health_update_events:
-            # delete first to preserve messages order in dict
-            log.info(
-                "InstanceID collision. Discarding event {} in favour of event {}".format(
-                    health_update_events[health_event.host.instance_id], health_event,
-                )
-            )
-            health_update_events[health_event.host.instance_id].message.delete()
-            del health_update_events[health_event.host.instance_id]
-        health_update_events[health_event.host.instance_id] = health_event
-
-    return health_update_events.values()
+def _parse_sqs_messages(sqs_config, messages, table, queue):
+    parsed_events = _parse_messages_helper(
+        messages, sqs_config, queue_type=QueueType.instance, table=table, queue=queue
+    )
+    return _resolve_events_hostname_collision(
+        event_pool=itertools.chain(parsed_events[EventType.ADD], parsed_events[EventType.REMOVE])
+    )
 
 
-def _parse_messages_helper(messages, is_health_queue, sqs_config, table=None, queue=None, instance_id_to_hostname=None):
+def _parse_health_messages(sqs_config, messages, table, health_queue):
+    if messages:
+        instances_in_cluster = get_cluster_instance_info(
+            sqs_config.stack_name, sqs_config.region, sqs_config.proxy_config, include_master=False
+        )
+        parsed_events = _parse_messages_helper(
+            messages, sqs_config, queue_type=QueueType.health, table=table, instances_in_cluster=instances_in_cluster
+        )
+        return _resolve_events_hostname_collision(event_pool=parsed_events[EventType.HEALTH])
+    else:
+        return []
+
+
+def _parse_messages_helper(messages, sqs_config, queue_type, table=None, queue=None, instances_in_cluster=None):
     parsed_events = {
-        "ADD": [],
-        "REMOVE": [],
-        "HEALTH": [],
+        EventType.ADD: [],
+        EventType.REMOVE: [],
+        EventType.HEALTH: [],
+    }
+    event_name_to_processing_function = {
+        EventType.HEALTH: lambda: _process_scheduled_maintenance_event(
+            message_attrs, message, table, instances_in_cluster
+        ),
+        EventType.ADD: lambda: _process_compute_ready_event(
+            sqs_config.region, sqs_config.proxy_config, message_attrs, message, table
+        ),
+        EventType.REMOVE: lambda: _process_instance_terminate_event(message_attrs, message, table, queue),
+    }
+    event_name_to_event_type = {
+        "parallelcluster:EC2_SCHEDULED_EVENT": EventType.HEALTH,
+        "parallelcluster:COMPUTE_READY": EventType.ADD,
+        "autoscaling:EC2_INSTANCE_TERMINATE": EventType.REMOVE,
     }
     for message in messages:
         # CW event rule can only send messages to SQS with "" enclosing the message.
@@ -298,45 +320,34 @@ def _parse_messages_helper(messages, is_health_queue, sqs_config, table=None, qu
             json.loads(json.loads(message.body)) if str(message.body).startswith('"') else json.loads(message.body)
         )
         message_attrs = json.loads(message_text.get("Message"))
-        event_type = message_attrs.get("Event")
-
-        if not event_type:
+        event_name = message_attrs.get("Event")
+        if not event_name:
             log.warning("Unable to read message. Deleting.")
             message.delete()
             continue
-        if is_health_queue:
-            if event_type == "parallelcluster:EC2_SCHEDULED_EVENT":
-                # filter events for instances currently in ASG
-                instances_in_cluster = list(instance_id_to_hostname.keys())
-                instance_id = message_attrs.get("EC2InstanceId")
-                if instance_id in instances_in_cluster:
-                    hostname = instance_id_to_hostname[instance_id]
-                    parsed_events["HEALTH"].append(
-                        UpdateEvent("SCHEDULED_EVENT", message, Host(instance_id, hostname, None, None))
-                    )
-                    log.info("Relevant EC2 scheduled event for instance:{} in ASG.".format(instance_id))
-                else:
-                    log.info("Irrelevant EC2 scheduled event for instance:{}. Discarding message.".format(instance_id))
-                    message.delete()
-            else:
-                log.info("Unsupported event type {} for health queue. Discarding message.".format(event_type))
-                message.delete()
+        event_type = event_name_to_event_type.get(event_name, None)
+
+        if event_type in SUPPORTED_EVENTTYPE_FOR_QUEUETYPE[queue_type]:
+            event = event_name_to_processing_function.get(event_type)()
+            if event:
+                parsed_events[event_type].append(event)
         else:
-            if event_type == "parallelcluster:COMPUTE_READY":
-                add_event = _process_compute_ready_event(
-                    sqs_config.region, sqs_config.proxy_config, message_attrs, message, table
-                )
-                if add_event:
-                    parsed_events["ADD"].append(add_event)
-            elif event_type == "autoscaling:EC2_INSTANCE_TERMINATE":
-                remove_event = _process_instance_terminate_event(message_attrs, message, table, queue)
-                if remove_event:
-                    parsed_events["REMOVE"].append(remove_event)
-            else:
-                log.info("Unsupported event type {} for instance queue. Discarding message.".format(event_type))
-                message.delete()
+            log.info("Unsupported event type %s for %s queue. Discarding message.", event_type, queue_type)
+            message.delete()
 
     return parsed_events
+
+
+def _process_scheduled_maintenance_event(message_attrs, message, table, instances_in_cluster):
+    instance_id = message_attrs.get("EC2InstanceId")
+    if instance_id in instances_in_cluster:
+        hostname = _retrieve_hostname_from_ddb(instance_id, table)
+        log.info("Relevant EC2 scheduled event for instance:%s in ASG.", instance_id)
+        return UpdateEvent(EventType.HEALTH, message, Host(instance_id, hostname, None, None))
+    else:
+        log.info("Irrelevant EC2 scheduled event for instance:%s. Discarding message.", instance_id)
+        message.delete()
+        return None
 
 
 def _process_compute_ready_event(sqs_config_region, sqs_config_proxy, message_attrs, message, table):
@@ -355,47 +366,49 @@ def _process_compute_ready_event(sqs_config_region, sqs_config_proxy, message_at
 def _process_instance_terminate_event(message_attrs, message, table, queue):
     instance_id = message_attrs.get("EC2InstanceId")
     try:
-        item = _retry_on_request_limit_exceeded(
-            lambda: table.get_item(ConsistentRead=True, Key={"instanceId": instance_id})
-        )
+        hostname = _retrieve_hostname_from_ddb(instance_id, table)
     except Exception as e:
         log.error("Failed when retrieving instance data for instance %s from db with exception %s", instance_id, e)
         _requeue_message(queue, message)
         message.delete()
         return None
 
-    if item.get("Item") is not None:
-        hostname = item.get("Item").get("hostname")
+    if hostname:
         return UpdateEvent(EventType.REMOVE, message, Host(instance_id, hostname, None, None))
     else:
         log.error("Instance %s not found in the database.", instance_id)
-        _requeue_message(queue, json.loads(message.body))
+        _requeue_message(queue, message)
         message.delete()
         return None
 
 
+def _retrieve_hostname_from_ddb(instance_id, table):
+    item = _retry_on_request_limit_exceeded(
+        lambda: table.get_item(ConsistentRead=True, Key={"instanceId": instance_id})
+    )
+    if item.get("Item") is not None:
+        hostname = item.get("Item").get("hostname")
+        return hostname
+    else:
+        return None
+
+
 def _process_health_messages(
-    health_events, scheduler_module, sqs_config, health_queue, force_cluster_update,
+    health_events, scheduler_module, sqs_config, health_queue,
 ):
-    # Update the scheduler only when there are messages from the queue or
-    # tha ASG max size got updated.
-    if not health_events and not force_cluster_update:
+    # Update the scheduler only when there are health events
+    if not health_events:
         return
 
     failed_events, succeeded_events = perform_health_actions(scheduler_module, health_events)
 
     for event in succeeded_events:
-        log.info("Successfully processed event {} for instance {}".format(event.action, event.host))
+        log.info("Successfully processed event %s for instance %s", event.action, event.host)
         event.message.delete()
 
     for event in failed_events:
-        log.error("Failed when processing event {} for instance {}".format(event.action, event.host))
-        message_text = (
-            json.loads(json.loads(event.message.body))
-            if str(event.message.body).startswith('"')
-            else json.loads(event.message.body)
-        )
-        _requeue_message(health_queue, message_text)
+        log.error("Failed when processing event %s for instance %s", event.action, event.host)
+        _requeue_message(health_queue, event.message)
         event.message.delete()
 
 
@@ -487,11 +500,11 @@ def _process_instance_queue(
     )
 
 
-def _process_health_queue(sqs_config, health_queue, scheduler_module, force_cluster_update):
+def _process_health_queue(sqs_config, health_queue, scheduler_module, table):
     messages = _retrieve_all_sqs_messages(health_queue, sqs_config.max_processed_messages)
-    health_events = _parse_health_messages(sqs_config, messages, health_queue)
+    health_events = _parse_health_messages(sqs_config, messages, table, health_queue)
     _process_health_messages(
-        health_events, scheduler_module, sqs_config, health_queue, force_cluster_update,
+        health_events, scheduler_module, sqs_config, health_queue,
     )
 
 
@@ -544,7 +557,7 @@ def _poll_queue(sqs_config, instance_queue, health_queue, table, asg_name):
             force_cluster_update,
         )
         if not sqs_config.disable_health_check:
-            _process_health_queue(sqs_config, health_queue, scheduler_module, force_cluster_update)
+            _process_health_queue(sqs_config, health_queue, scheduler_module, table)
 
         sleep_remaining_loop_time(LOOP_TIME, start_time)
 
@@ -557,7 +570,7 @@ def main():
     try:
         config = _get_config()
         instance_queue = _get_sqs_queue(config.region, config.sqsqueue, config.proxy_config)
-        health_queue = _get_sqs_queue(config.region, config.healthsqsqueue, config.proxy_config)
+        health_queue = _get_sqs_queue(config.region, config.health_sqsqueue, config.proxy_config)
         table = _get_ddb_table(config.region, config.table_name, config.proxy_config)
         asg_name = get_asg_name(config.stack_name, config.region, config.proxy_config)
 

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -353,7 +353,7 @@ def _process_scheduled_maintenance_event(stack_name, region, proxy_config, messa
         )
         if instance_id in instances_in_cluster:
             hostname = _retrieve_hostname_from_ddb(instance_id, table)
-            log.info("Relevant EC2 scheduled event for instance:%s in ASG.", instance_id)
+            log.info("Relevant EC2 scheduled event for instance: %s.", instance_id)
             if hostname:
                 return UpdateEvent(EventType.HEALTH, message, Host(instance_id, hostname, None, None))
             else:

--- a/tests/nodewatcher/plugins/test_sge.py
+++ b/tests/nodewatcher/plugins/test_sge.py
@@ -16,7 +16,7 @@ from nodewatcher.plugins.sge import has_jobs, has_pending_jobs, is_node_down
 
 
 @pytest.mark.parametrize(
-    "hostname, compute_nodes_output, expected_result",
+    "hostname, compute_nodes_output, has_job_output, expected_result",
     [
         (
             "ip-10-0-0-166",
@@ -31,6 +31,7 @@ from nodewatcher.plugins.sge import has_jobs, has_pending_jobs, is_node_down
                 )
             },
             False,
+            False,
         ),
         (
             "ip-10-0-0-166",
@@ -40,8 +41,9 @@ from nodewatcher.plugins.sge import has_jobs, has_pending_jobs, is_node_down
                 )
             },
             False,
+            False,
         ),
-        ("ip-10-0-0-166", {}, True),
+        ("ip-10-0-0-166", {}, True, True),
         (
             "ip-10-0-0-166",
             {
@@ -55,12 +57,67 @@ from nodewatcher.plugins.sge import has_jobs, has_pending_jobs, is_node_down
                 )
             },
             True,
+            True,
         ),
-        ("ip-10-0-0-166", Exception, True),
+        ("ip-10-0-0-166", Exception, True, True),
+        (
+            "ip-10-0-0-166",
+            {
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="d",
+                    jobs=[],
+                )
+            },
+            True,
+            False,
+        ),
+        (
+            "ip-10-0-0-166",
+            {
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="d",
+                    jobs=[],
+                )
+            },
+            False,
+            True,
+        ),
+        (
+            "ip-10-0-0-166",
+            {
+                "ip-10-0-0-166.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-0-166.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=0,
+                    slots_reserved=0,
+                    state="du",
+                    jobs=[],
+                )
+            },
+            True,
+            True,
+        ),
     ],
-    ids=["healthy", "healthy_short", "not_attached", "error_state", "exception"],
+    ids=[
+        "healthy",
+        "healthy_short",
+        "not_attached",
+        "error_state",
+        "exception",
+        "locked_has_job",
+        "locked_no_job",
+        "locked_error",
+    ],
 )
-def test_terminate_if_down(hostname, compute_nodes_output, expected_result, mocker):
+def test_is_node_down(hostname, compute_nodes_output, has_job_output, expected_result, mocker):
     mocker.patch("nodewatcher.plugins.sge.check_command_output", return_value=hostname, autospec=True)
     mocker.patch(
         "nodewatcher.plugins.sge.socket.getfqdn", return_value=hostname + ".eu-west-1.compute.internal", autospec=True
@@ -71,6 +128,7 @@ def test_terminate_if_down(hostname, compute_nodes_output, expected_result, mock
         mock = mocker.patch(
             "nodewatcher.plugins.sge.get_compute_nodes_info", return_value=compute_nodes_output, autospec=True
         )
+    mocker.patch("nodewatcher.plugins.sge.has_jobs", return_value=has_job_output, autospec=True)
 
     assert_that(is_node_down()).is_equal_to(expected_result)
     mock.assert_called_with(hostname)

--- a/tests/nodewatcher/plugins/test_slurm.py
+++ b/tests/nodewatcher/plugins/test_slurm.py
@@ -68,10 +68,10 @@ def test_has_pending_jobs(pending_jobs, expected_result, mocker):
 @pytest.mark.parametrize(
     "hostname, get_node_state_output, expected_result",
     [
-        ("ip-10-0-0-166", "idle", False,),
+        ("ip-10-0-0-166", "idle#", False,),
         ("ip-10-0-0-166", "down", True,),
-        ("ip-10-0-0-166", "draining", False,),
-        ("ip-10-0-0-166", "drained", True,),
+        ("ip-10-0-0-166", "draining#", False,),
+        ("ip-10-0-0-166", "drained*", True,),
         ("ip-10-0-0-166", "unknown", False,),
         ("ip-10-0-0-166", Exception, True,),
     ],

--- a/tests/sqswatcher/plugins/test_sge.py
+++ b/tests/sqswatcher/plugins/test_sge.py
@@ -1,0 +1,81 @@
+import pytest
+
+from assertpy import assert_that
+from common.schedulers.sge_commands import SgeHost, SgeJob
+from sqswatcher.plugins.sge import _is_node_locked
+
+
+@pytest.mark.parametrize(
+    "hostname, get_compute_nodes_info_output, expected_result",
+    [
+        (
+            "ip-10-0-000-111",
+            {
+                "ip-10-0-000-111.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-000-111.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=3,
+                    slots_reserved=0,
+                    state="",
+                    jobs=[],
+                )
+            },
+            False,
+        ),
+        (
+            "ip-10-0-000-111",
+            {
+                "ip-10-0-000-111.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-000-111.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=3,
+                    slots_reserved=0,
+                    state="aux",
+                    jobs=[],
+                )
+            },
+            False,
+        ),
+        (
+            "ip-10-0-000-111",
+            {
+                "ip-10-0-000-111.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-000-111.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=3,
+                    slots_reserved=0,
+                    state="d",
+                    jobs=[],
+                )
+            },
+            True,
+        ),
+        (
+            "ip-10-0-000-111",
+            {
+                "ip-10-0-000-111.eu-west-1.compute.internal": SgeHost(
+                    name="ip-10-0-000-111.eu-west-1.compute.internal",
+                    slots_total=4,
+                    slots_used=3,
+                    slots_reserved=0,
+                    state="auxd",
+                    jobs=[
+                        SgeJob(number="89", slots=1, state="r", node_type="MASTER", array_index=None, hostname=None),
+                    ],
+                )
+            },
+            True,
+        ),
+    ],
+)
+def test_is_node_locked(hostname, get_compute_nodes_info_output, expected_result, mocker):
+    mocker.patch(
+        "sqswatcher.plugins.sge.socket.getfqdn",
+        return_value="{}.eu-west-1.compute.internal".format(hostname),
+        autospec=True,
+    )
+    mocker.patch(
+        "sqswatcher.plugins.sge.get_compute_nodes_info", return_value=get_compute_nodes_info_output, autospec=True
+    )
+
+    assert_that(_is_node_locked(hostname)).is_equal_to(expected_result)

--- a/tests/sqswatcher/plugins/test_sge.py
+++ b/tests/sqswatcher/plugins/test_sge.py
@@ -2,7 +2,8 @@ import pytest
 
 from assertpy import assert_that
 from common.schedulers.sge_commands import SgeHost, SgeJob
-from sqswatcher.plugins.sge import _is_node_locked
+from common.utils import EventType, Host, UpdateEvent
+from sqswatcher.plugins.sge import _is_node_locked, perform_health_actions
 
 
 @pytest.mark.parametrize(
@@ -66,6 +67,7 @@ from sqswatcher.plugins.sge import _is_node_locked
             },
             True,
         ),
+        ("ip-10-0-000-111", Exception, False,),
     ],
 )
 def test_is_node_locked(hostname, get_compute_nodes_info_output, expected_result, mocker):
@@ -74,8 +76,73 @@ def test_is_node_locked(hostname, get_compute_nodes_info_output, expected_result
         return_value="{}.eu-west-1.compute.internal".format(hostname),
         autospec=True,
     )
-    mocker.patch(
-        "sqswatcher.plugins.sge.get_compute_nodes_info", return_value=get_compute_nodes_info_output, autospec=True
-    )
+    if get_compute_nodes_info_output is Exception:
+        mocker.patch("sqswatcher.plugins.sge.get_compute_nodes_info", side_effect=Exception(), autospec=True)
+    else:
+        mocker.patch(
+            "sqswatcher.plugins.sge.get_compute_nodes_info", return_value=get_compute_nodes_info_output, autospec=True
+        )
 
     assert_that(_is_node_locked(hostname)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "events, lock_node_side_effect, is_node_locked_output, failed_events, succeeded_events",
+    [
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [False, True],
+            [],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [True, True],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            Exception,
+            [False, False],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            Exception,
+            [False, True],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [False, False],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+    ],
+    ids=[
+        "all_good",
+        "node_already_in_lock",
+        "exception_when_locking_node_unlocked",
+        "exception_when_locking_node_locked",
+        "no_exception_failed_to_lock",
+    ],
+)
+def test_perform_health_actions(
+    events, lock_node_side_effect, is_node_locked_output, failed_events, succeeded_events, mocker
+):
+    if lock_node_side_effect is Exception:
+        mocker.patch("sqswatcher.plugins.sge.lock_node", side_effect=Exception, autospec=True)
+    else:
+        mocker.patch("sqswatcher.plugins.sge.lock_node", autospec=True)
+    mocker.patch(
+        "sqswatcher.plugins.sge._is_node_locked", side_effect=is_node_locked_output, autospec=True,
+    )
+    failed, succeeded = perform_health_actions(events)
+    assert_that(failed_events).is_equal_to(failed)
+    assert_that(succeeded_events).is_equal_to(succeeded)

--- a/tests/sqswatcher/plugins/test_slurm.py
+++ b/tests/sqswatcher/plugins/test_slurm.py
@@ -12,7 +12,12 @@ import pytest
 
 from assertpy import assert_that
 from common.utils import EventType, Host, UpdateEvent
-from sqswatcher.plugins.slurm import _is_node_locked, _update_gres_node_lists, _update_node_lists
+from sqswatcher.plugins.slurm import (
+    _is_node_locked,
+    _update_gres_node_lists,
+    _update_node_lists,
+    perform_health_actions,
+)
 
 
 # Input: existing gres_node_list, events to be processed.
@@ -155,14 +160,80 @@ def test_update_node_lists(node_list, events, expected_result, mocker):
 @pytest.mark.parametrize(
     "hostname, get_node_state_output, expected_result",
     [
-        ("ip-10-0-000-111", "draining", True),
-        ("ip-10-0-000-111", "drained", True),
+        ("ip-10-0-000-111", "draining*", True),
+        ("ip-10-0-000-111", "drained#", True),
         ("ip-10-0-000-111", "idle", False),
         ("ip-10-0-000-111", "down", False),
         ("ip-10-0-000-111", "unknown", False),
+        ("ip-10-0-000-111", Exception, False),
     ],
 )
 def test_is_node_locked(hostname, get_node_state_output, expected_result, mocker):
-    mocker.patch("sqswatcher.plugins.slurm.get_node_state", return_value=get_node_state_output, autospec=True)
+    if get_node_state_output is Exception:
+        mocker.patch("sqswatcher.plugins.slurm.get_node_state", side_effect=Exception(), autospec=True)
+    else:
+        mocker.patch("sqswatcher.plugins.slurm.get_node_state", return_value=get_node_state_output, autospec=True)
 
     assert_that(_is_node_locked(hostname)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "events, lock_node_side_effect, is_node_locked_output, failed_events, succeeded_events",
+    [
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [False, True],
+            [],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [True, True],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            Exception,
+            [False, False],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            Exception,
+            [False, True],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [False, False],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+    ],
+    ids=[
+        "all_good",
+        "node_already_in_lock",
+        "exception_when_locking_node_unlocked",
+        "exception_when_locking_node_locked",
+        "no_exception_failed_to_lock",
+    ],
+)
+def test_perform_health_actions(
+    events, lock_node_side_effect, is_node_locked_output, failed_events, succeeded_events, mocker
+):
+    if lock_node_side_effect is Exception:
+        mocker.patch("sqswatcher.plugins.slurm.lock_node", side_effect=Exception, autospec=True)
+    else:
+        mocker.patch("sqswatcher.plugins.slurm.lock_node", autospec=True)
+    mocker.patch(
+        "sqswatcher.plugins.slurm._is_node_locked", side_effect=is_node_locked_output, autospec=True,
+    )
+    failed, succeeded = perform_health_actions(events)
+    assert_that(failed_events).is_equal_to(failed)
+    assert_that(succeeded_events).is_equal_to(succeeded)

--- a/tests/sqswatcher/plugins/test_torque.py
+++ b/tests/sqswatcher/plugins/test_torque.py
@@ -1,0 +1,51 @@
+import pytest
+
+from assertpy import assert_that
+from common.schedulers.torque_commands import TorqueHost
+from sqswatcher.plugins.torque import _is_node_locked
+
+
+@pytest.mark.parametrize(
+    "hostname, get_compute_nodes_info_output, expected_result",
+    [
+        (
+            "ip-10-0-1-242",
+            {"ip-10-0-1-242": TorqueHost(name="ip-10-0-1-242", slots=4, state=["free"], jobs=None, note="")},
+            False,
+        ),
+        (
+            "ip-10-0-1-242",
+            {"ip-10-0-1-242": TorqueHost(name="ip-10-0-1-242", slots=4, state=["job-exclusive"], jobs=None, note="")},
+            False,
+        ),
+        (
+            "ip-10-0-1-242",
+            {"ip-10-0-1-242": TorqueHost(name="ip-10-0-1-242", slots=4, state=["down"], jobs=None, note="")},
+            False,
+        ),
+        (
+            "ip-10-0-1-242",
+            {"ip-10-0-1-242": TorqueHost(name="ip-10-0-1-242", slots=4, state=["offline"], jobs=None, note="")},
+            True,
+        ),
+        (
+            "ip-10-0-1-242",
+            {
+                "ip-10-0-1-242": TorqueHost(
+                    name="ip-10-0-1-242",
+                    slots=4,
+                    state=["down,offline,free,job-exclusive"],
+                    jobs="1/136.ip-10-0-0-196.eu-west-1.compute.internal",
+                    note="",
+                ),
+            },
+            False,
+        ),
+    ],
+)
+def test_is_node_locked(hostname, get_compute_nodes_info_output, expected_result, mocker):
+    mocker.patch(
+        "sqswatcher.plugins.torque.get_compute_nodes_info", return_value=get_compute_nodes_info_output, autospec=True
+    )
+
+    assert_that(_is_node_locked(hostname)).is_equal_to(expected_result)

--- a/tests/sqswatcher/plugins/test_torque.py
+++ b/tests/sqswatcher/plugins/test_torque.py
@@ -2,7 +2,8 @@ import pytest
 
 from assertpy import assert_that
 from common.schedulers.torque_commands import TorqueHost
-from sqswatcher.plugins.torque import _is_node_locked
+from common.utils import EventType, Host, UpdateEvent
+from sqswatcher.plugins.torque import _is_node_locked, perform_health_actions
 
 
 @pytest.mark.parametrize(
@@ -41,11 +42,79 @@ from sqswatcher.plugins.torque import _is_node_locked
             },
             False,
         ),
+        ("ip-10-0-1-242", Exception, False,),
     ],
 )
 def test_is_node_locked(hostname, get_compute_nodes_info_output, expected_result, mocker):
-    mocker.patch(
-        "sqswatcher.plugins.torque.get_compute_nodes_info", return_value=get_compute_nodes_info_output, autospec=True
-    )
+    if get_compute_nodes_info_output is Exception:
+        mocker.patch("sqswatcher.plugins.torque.get_compute_nodes_info", side_effect=Exception(), autospec=True)
+    else:
+        mocker.patch(
+            "sqswatcher.plugins.torque.get_compute_nodes_info",
+            return_value=get_compute_nodes_info_output,
+            autospec=True,
+        )
 
     assert_that(_is_node_locked(hostname)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "events, lock_node_side_effect, is_node_locked_output, failed_events, succeeded_events",
+    [
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [False, True],
+            [],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [True, True],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            Exception,
+            [False, False],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            Exception,
+            [False, True],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+        (
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            None,
+            [False, False],
+            [UpdateEvent(EventType.HEALTH, None, Host("i-12345", "ip-10-0-000-111", None, None))],
+            [],
+        ),
+    ],
+    ids=[
+        "all_good",
+        "node_already_in_lock",
+        "exception_when_locking_node_unlocked",
+        "exception_when_locking_node_locked",
+        "no_exception_failed_to_lock",
+    ],
+)
+def test_perform_health_actions(
+    events, lock_node_side_effect, is_node_locked_output, failed_events, succeeded_events, mocker
+):
+    if lock_node_side_effect is Exception:
+        mocker.patch("sqswatcher.plugins.torque.lock_node", side_effect=Exception, autospec=True)
+    else:
+        mocker.patch("sqswatcher.plugins.torque.lock_node", autospec=True)
+    mocker.patch(
+        "sqswatcher.plugins.torque._is_node_locked", side_effect=is_node_locked_output, autospec=True,
+    )
+    failed, succeeded = perform_health_actions(events)
+    assert_that(failed_events).is_equal_to(failed)
+    assert_that(succeeded_events).is_equal_to(succeeded)


### PR DESCRIPTION
* Modified sqswatcher to retrieve and process messages from health queue. Lock instance if there is an EC2 health scheduled event, so that instance can be replaced by nodewatcher ASAP
* Modified nodewatcher to consider nodes that are locked and have no job as down nodes
* Modified unit tests to adapt to above modifications
* This feature can be turned off by specifying `disable_health_check = True` in `/etc/sqswatcher.cfg` and restarting sqswatcher

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
