### PR TITLE
specify endpoint url for SQS to support PrivateLink

### DIFF
--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -123,7 +123,9 @@ def _get_sqs_queue(region, queue_name, proxy_config):
     :return: the Queue object
     """
     log.debug("Getting SQS queue '%s'", queue_name)
-    sqs = boto3.resource("sqs", region_name=region, config=proxy_config, endpoint_url="https://sqs." + region + ".amazonaws.com")
+    sqs = boto3.resource(
+        "sqs", region_name=region, config=proxy_config, endpoint_url="https://sqs." + region + ".amazonaws.com"
+    )
     try:
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         log.debug("SQS queue is %s", queue)

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -123,7 +123,7 @@ def _get_sqs_queue(region, queue_name, proxy_config):
     :return: the Queue object
     """
     log.debug("Getting SQS queue '%s'", queue_name)
-    sqs = boto3.resource("sqs", region_name=region, config=proxy_config)
+    sqs = boto3.resource("sqs", region_name=region, config=proxy_config, endpoint_url="https://sqs."+region+".amazonaws.com")
     try:
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         log.debug("SQS queue is %s", queue)

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -123,7 +123,9 @@ def _get_sqs_queue(region, queue_name, proxy_config):
     :return: the Queue object
     """
     log.debug("Getting SQS queue '%s'", queue_name)
-    endpoint_url = "https://sts.{0}.{1}".format(region, "amazonaws.com.cn" if region.startswith("cn-") else "amazonaws.com")
+    endpoint_url = "https://sts.{0}.{1}".format(
+        region, "amazonaws.com.cn" if region.startswith("cn-") else "amazonaws.com"
+    )
     sqs = boto3.resource(
         "sqs", region_name=region, config=proxy_config, endpoint_url=endpoint_url
     )

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -126,9 +126,7 @@ def _get_sqs_queue(region, queue_name, proxy_config):
     endpoint_url = "https://sts.{0}.{1}".format(
         region, "amazonaws.com.cn" if region.startswith("cn-") else "amazonaws.com"
     )
-    sqs = boto3.resource(
-        "sqs", region_name=region, config=proxy_config, endpoint_url=endpoint_url
-    )
+    sqs = boto3.resource("sqs", region_name=region, config=proxy_config, endpoint_url=endpoint_url)
     try:
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         log.debug("SQS queue is %s", queue)

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -123,7 +123,7 @@ def _get_sqs_queue(region, queue_name, proxy_config):
     :return: the Queue object
     """
     log.debug("Getting SQS queue '%s'", queue_name)
-    sqs = boto3.resource("sqs", region_name=region, config=proxy_config, endpoint_url="https://sqs."+region+".amazonaws.com")
+    sqs = boto3.resource("sqs", region_name=region, config=proxy_config, endpoint_url="https://sqs." + region + ".amazonaws.com")
     try:
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         log.debug("SQS queue is %s", queue)

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -123,8 +123,9 @@ def _get_sqs_queue(region, queue_name, proxy_config):
     :return: the Queue object
     """
     log.debug("Getting SQS queue '%s'", queue_name)
+    endpoint_url = "https://sts.{0}.{1}".format(region, "amazonaws.com.cn" if region.startswith("cn-") else "amazonaws.com")
     sqs = boto3.resource(
-        "sqs", region_name=region, config=proxy_config, endpoint_url="https://sqs." + region + ".amazonaws.com"
+        "sqs", region_name=region, config=proxy_config, endpoint_url=endpoint_url
     )
     try:
         queue = sqs.get_queue_by_name(QueueName=queue_name)


### PR DESCRIPTION
*Description of changes:*
- specify endpoint on SQS in sqswatcher.py
  - In default, SQS command in Boto3 use legacy endpoint url (*region*.queue.amazonaws.com). It prevent using PrivateLink url (sqs.*region*.amazonaws.com). Therefore this fix specifies new endpoint url.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
