### PR TITLE
Implement Cluster Management Daemon, clustermgtd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ console_scripts = [
     "jobwatcher = jobwatcher.jobwatcher:main",
     "slurm_resume = slurm_plugin.resume:main",
     "slurm_suspend = slurm_plugin.suspend:main",
+    "clustermgtd = slurm_plugin.clustermgtd:main",
 ]
 version = "2.8.0"
 requires = ["boto3>=1.7.55", "retrying>=1.3.3", "paramiko>=2.4.2"]

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -111,7 +111,7 @@ class SlurmNode:
         return "{class_name}({attrs})".format(class_name=self.__class__.__name__, attrs=attrs)
 
     def __str__(self):
-        return f"{self.name}"
+        return f"{self.name}({self.nodeaddr})"
 
 
 def update_nodes(nodes, nodeaddrs=None, nodehostnames=None, state=None, reason=None, raise_on_error=True):

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -18,7 +18,7 @@ import pwd
 import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 import boto3
@@ -373,6 +373,11 @@ def sleep_remaining_loop_time(total_loop_time, loop_start_time=None):
     end_time = datetime.now()
     if not loop_start_time:
         loop_start_time = end_time
+    # Localize datetime objects to UTC if not previously localized
+    if not end_time.tzinfo:
+        end_time = end_time.replace(tzinfo=timezone.utc)
+    if not loop_start_time.tzinfo:
+        loop_start_time = loop_start_time.replace(tzinfo=timezone.utc)
     time_delta = (end_time - loop_start_time).total_seconds()
     if time_delta < total_loop_time:
         time.sleep(total_loop_time - time_delta)

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -373,7 +373,11 @@ def sleep_remaining_loop_time(total_loop_time, loop_start_time=None):
     end_time = datetime.now()
     if not loop_start_time:
         loop_start_time = end_time
-    # Localize datetime objects to UTC if not previously localized
+    # Always try to localize datetime objects to UTC if not previously localized
+    # For example, datetime in tradition daemons are not localized(sqswatcher, jobwatcher, ...)
+    # Daemons in HIT integration are required to use localized datetime
+    # This operation DOES NOT convert datetime from 1 timezone into UTC
+    # It simply replaces the timezone info if datetime is not localized
     if not end_time.tzinfo:
         end_time = end_time.replace(tzinfo=timezone.utc)
     if not loop_start_time.tzinfo:

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -243,6 +243,16 @@ class ClusterManager:
             timestamp_file.write(f"{self.current_time}")
 
     @staticmethod
+    @retry(stop_max_attempt_number=3, wait_fixed=1000)
+    def _get_node_info_with_retry(nodes):
+        return get_nodes_info(nodes, command_timeout=5)
+
+    @staticmethod
+    @retry(stop_max_attempt_number=3, wait_fixed=1000)
+    def _get_partition_info_with_retry():
+        return get_partition_info(command_timeout=5)
+
+    @staticmethod
     def _get_node_info_from_partition():
         """
         Retrieve node belonging in UP/INACTIVE partitions.
@@ -252,9 +262,9 @@ class ClusterManager:
         try:
             inactive_nodes = []
             active_nodes = []
-            partitions = get_partition_info()
+            partitions = ClusterManager._get_partition_info_with_retry()
             for part in partitions:
-                nodes = get_nodes_info(part.nodes)
+                nodes = ClusterManager._get_node_info_with_retry(part.nodes)
                 if "INACTIVE" in part.state:
                     inactive_nodes.extend(nodes)
                 else:

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1,0 +1,552 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+from datetime import datetime, timezone
+from enum import Enum
+from logging.config import fileConfig
+
+from botocore.config import Config
+from configparser import ConfigParser
+from retrying import retry
+
+from common.schedulers.slurm_commands import (
+    get_nodes_info,
+    get_partition_info,
+    set_nodes_down,
+    set_nodes_down_and_power_save,
+    set_nodes_drain,
+)
+from common.time_utils import seconds
+from common.utils import sleep_remaining_loop_time
+from slurm_plugin.common import CONFIG_FILE_DIR, EC2_INSTANCE_HEALTHY_STATUSES, InstanceManager
+
+LOOP_TIME = 30
+log = logging.getLogger(__name__)
+
+
+class ClustermgtdConfig:
+    DEFAULTS = {
+        # Basic configs
+        "max_retry": 5,
+        "loop_time": LOOP_TIME,
+        "proxy": "NONE",
+        "logging_config": os.path.join(
+            os.path.dirname(__file__), "logging", "parallelcluster_clustermgtd_logging.conf"
+        ),
+        # Launch configs
+        "launch_max_batch_size": 100,
+        "update_node_address": True,
+        # Terminate configs
+        "terminate_max_batch_size": 1000,
+        # Timeout to wait for node initialization, should be the same as ResumeTimeout
+        "node_replacement_timeout": 600,
+        "terminate_drain_nodes": True,
+        "terminate_down_nodes": True,
+        "orphaned_instance_timeout": 180,
+        # Health check configs
+        "disable_ec2_health_check": False,
+        "disable_scheduled_event_health_check": False,
+        "disable_all_cluster_management": False,
+        "health_check_timeout": 180,
+    }
+
+    def __init__(self, config_file_path):
+        self._get_config(config_file_path)
+
+    def __repr__(self):
+        attrs = ", ".join(["{key}={value}".format(key=key, value=repr(value)) for key, value in self.__dict__.items()])
+        return "{class_name}({attrs})".format(class_name=self.__class__.__name__, attrs=attrs)
+
+    def _get_basic_config(self, config):
+        """Get basic config options."""
+        self.region = config.get("clustermgtd", "region")
+        self.cluster_name = config.get("clustermgtd", "cluster_name")
+        # Configure boto3 to retry 5 times by default
+        self._boto3_config = {"retries": {"max_attempts": self.DEFAULTS.get("max_retry"), "mode": "standard"}}
+        self.loop_time = config.getint("clustermgtd", "loop_time", fallback=self.DEFAULTS.get("loop_time"))
+        self.disable_all_cluster_management = config.getboolean(
+            "clustermgtd",
+            "disable_all_cluster_management",
+            fallback=self.DEFAULTS.get("disable_all_cluster_management"),
+        )
+        self.heartbeat_file_path = config.get("clustermgtd", "heartbeat_file_path")
+
+        proxy = config.get("clustermgtd", "proxy", fallback=self.DEFAULTS.get("proxy"))
+        if proxy != "NONE":
+            self._boto3_config["proxies"] = {"https": proxy}
+        self.boto3_config = Config(**self._boto3_config)
+        self.logging_config = config.get("clustermgtd", "logging_config", fallback=self.DEFAULTS.get("logging_config"))
+
+    def _get_launch_config(self, config):
+        """Get config options related to launching instances."""
+        self.launch_max_batch_size = config.getint(
+            "clustermgtd", "launch_max_batch_size", fallback=self.DEFAULTS.get("launch_max_batch_size")
+        )
+        self.update_node_address = config.getboolean(
+            "clustermgtd", "update_node_address", fallback=self.DEFAULTS.get("update_node_address")
+        )
+
+    def _get_health_check_config(self, config):
+        self.disable_ec2_health_check = config.getboolean(
+            "clustermgtd", "disable_ec2_health_check", fallback=self.DEFAULTS.get("disable_ec2_health_check")
+        )
+        self.disable_scheduled_event_health_check = config.getboolean(
+            "clustermgtd",
+            "disable_scheduled_event_health_check",
+            fallback=self.DEFAULTS.get("disable_scheduled_event_health_check"),
+        )
+        self.health_check_timeout = config.getint(
+            "clustermgtd", "health_check_timeout", fallback=self.DEFAULTS.get("health_check_timeout")
+        )
+        self.disable_all_health_checks = config.getboolean(
+            "clustermgtd",
+            "disable_all_health_checks",
+            fallback=(self.disable_ec2_health_check and self.disable_scheduled_event_health_check),
+        )
+
+    def _get_terminate_config(self, config):
+        """Get config option related to instance termination and node replacement."""
+        self.terminate_max_batch_size = config.getint(
+            "clustermgtd", "terminate_max_batch_size", fallback=self.DEFAULTS.get("terminate_max_batch_size")
+        )
+        self.node_replacement_timeout = config.getint(
+            "clustermgtd", "node_replacement_timeout", fallback=self.DEFAULTS.get("node_replacement_timeout")
+        )
+        self.terminate_drain_nodes = config.getboolean(
+            "clustermgtd", "terminate_drain_nodes", fallback=self.DEFAULTS.get("terminate_drain_nodes")
+        )
+        self.terminate_down_nodes = config.getboolean(
+            "clustermgtd", "terminate_down_nodes", fallback=self.DEFAULTS.get("terminate_down_nodes")
+        )
+        self.orphaned_instance_timeout = config.getint(
+            "clustermgtd", "orphaned_instance_timeout", fallback=self.DEFAULTS.get("orphaned_instance_timeout")
+        )
+
+    def _get_config(self, config_file_path):
+        """Get clustermgtd configuration."""
+        log.info("Reading %s", config_file_path)
+        config = ConfigParser()
+        try:
+            config.read_file(open(config_file_path, "r"))
+        except IOError:
+            log.error(f"Cannot read cluster manager configuration file: {config_file_path}")
+            raise
+
+        # Get config settings
+        self._get_basic_config(config)
+        self._get_health_check_config(config)
+        self._get_launch_config(config)
+        self._get_terminate_config(config)
+
+        # Initialize instance manager class that will be used to launch/terminate instance
+        self.instance_manager = InstanceManager(self.region, self.cluster_name, self.boto3_config)
+        # Log configuration
+        log.info(self.__repr__())
+
+
+class ClusterManager:
+    """Class for all cluster management related actions."""
+
+    class HealthCheckTypes(Enum):
+        """Enum for health check types."""
+
+        scheduled_event = "scheduled_events_check"
+        ec2_health = "ec2_health_check"
+
+        def __str__(self):
+            return self.value
+
+    def __init__(self):
+        self.replacing_nodes = set()
+
+    def _set_replacing_nodes(self, node_list):
+        """Setter function used for testing purposes only."""
+        self.replacing_nodes = set(node_list)
+
+    def set_current_time(self, current_time):
+        self.current_time = current_time
+
+    def set_sync_config(self, sync_config):
+        self.sync_config = sync_config
+
+    def manage_cluster(self, sync_config, current_time):
+        """Manage cluster by syncing scheduler states with EC2 states and performing node maintenance actions."""
+        # Initialization
+        self.set_sync_config(sync_config)
+        self.set_current_time(current_time)
+        self._write_timestamp_to_file()
+        if sync_config.disable_all_cluster_management:
+            log.info("All cluster management actions currently disabled.")
+            return
+        # Get node states for nodes in inactive and active partitions
+        active_nodes, inactive_nodes = ClusterManager._get_node_info_from_partition()
+        # Handle inactive partition and terminate backing instances
+        if inactive_nodes:
+            self._clean_up_inactive_partition(inactive_nodes)
+        # Get all instances in EC2
+        cluster_instances = self._get_ec2_states()
+        log.info("Current cluster instances in EC2: %s", cluster_instances)
+        # Clean up orphaned instances and skip all other operations if no active node
+        if not active_nodes:
+            self._terminate_orphaned_instances(cluster_instances, ips_used_by_slurm=[])
+            log.info("No active node in scheduler, skipping all other maintenance operation")
+            return
+        log.info("Current active slurm nodes in scheduler: %s", active_nodes)
+        # Initialize mapping data structures
+        slurm_nodes_ip_phonebook = {node.nodeaddr: node for node in active_nodes}
+        # Perform health check actions
+        if not sync_config.disable_all_health_checks:
+            self._perform_health_check_actions(cluster_instances, slurm_nodes_ip_phonebook)
+        # Maintain slurm nodes
+        self._maintain_nodes(cluster_instances, active_nodes)
+        # Clean up orphaned instances
+        self._terminate_orphaned_instances(cluster_instances, ips_used_by_slurm=list(slurm_nodes_ip_phonebook.keys()))
+
+    def _write_timestamp_to_file(self):
+        """Write timestamp into shared file so compute nodes can determine if head node is online."""
+        with open(self.sync_config.heartbeat_file_path, "w") as timestamp_file:
+            timestamp_file.write(f"{self.current_time}")
+
+    @staticmethod
+    def _get_node_info_from_partition():
+        """
+        Retrieve node belonging in UP/INACTIVE partitions.
+
+        Return list of nodes in active parition, list of nodes in in active partition
+        """
+        inactive_nodes = []
+        active_nodes = []
+        partitions = get_partition_info()
+        for part in partitions:
+            nodes = get_nodes_info(part.nodes)
+            if "INACTIVE" in part.state:
+                inactive_nodes.extend(nodes)
+            else:
+                active_nodes.extend(nodes)
+
+        return active_nodes, inactive_nodes
+
+    def _clean_up_inactive_partition(self, inactive_nodes):
+        """
+        Terminate all other instances associated with nodes directly through EC2.
+
+        This operation will not update node states, nodes will retain their states
+        Nodes will be placed into down* by slurm after SlurmdTimeout
+        If dynamic, nodes will be power_saved after SuspendTime
+        """
+        log.info("Clean up instances associated with nodes in INACTIVE partitions: %s", inactive_nodes)
+        self.sync_config.instance_manager.terminate_associated_instances(
+            inactive_nodes, terminate_batch_size=self.sync_config.terminate_max_batch_size
+        )
+
+    def _get_ec2_states(self):
+        """Get EC2 instance states by describe_instances API."""
+        return self.sync_config.instance_manager.get_cluster_instances(include_master=False, alive_states_only=True)
+
+    def _perform_health_check_actions(self, cluster_instances, slurm_nodes_ip_phonebook):
+        """Run health check actions."""
+        instances_id_phonebook = {instance.id: instance for instance in cluster_instances}
+        # Get instance health states
+        instance_health_states = self.sync_config.instance_manager.get_instance_health_states(
+            list(instances_id_phonebook.keys())
+        )
+        # Perform EC2 health check actions
+        if not self.sync_config.disable_ec2_health_check:
+            self._handle_health_check(
+                instance_health_states,
+                instances_id_phonebook,
+                slurm_nodes_ip_phonebook,
+                health_check_type=ClusterManager.HealthCheckTypes.ec2_health,
+            )
+        # Perform scheduled event actions
+        if not self.sync_config.disable_scheduled_event_health_check:
+            self._handle_health_check(
+                instance_health_states,
+                instances_id_phonebook,
+                slurm_nodes_ip_phonebook,
+                health_check_type=ClusterManager.HealthCheckTypes.scheduled_event,
+            )
+
+    def _fail_ec2_health_check(self, instance_health_state):
+        """Check if instance is failing any EC2 health check for more than health_check_timeout."""
+        try:
+            if (
+                # Check instance status
+                instance_health_state.instance_status.get("Status") not in EC2_INSTANCE_HEALTHY_STATUSES
+                and ClusterManager._time_is_up(
+                    instance_health_state.instance_status.get("Details")[0].get("ImpairedSince"),
+                    self.current_time,
+                    self.sync_config.health_check_timeout,
+                )
+            ) or (
+                # Check system status
+                instance_health_state.system_status.get("Status") not in EC2_INSTANCE_HEALTHY_STATUSES
+                and ClusterManager._time_is_up(
+                    instance_health_state.instance_status.get("Details")[0].get("ImpairedSince"),
+                    self.current_time,
+                    self.sync_config.health_check_timeout,
+                )
+            ):
+                return True
+        except Exception as e:
+            log.warning("Error when parsing instance health status %s, with exception: %s", instance_health_state, e)
+            return True
+
+        return False
+
+    def _fail_scheduled_events_check(self, instance_health_state):
+        """Check if instance has EC2 scheduled maintenance event."""
+        if instance_health_state.scheduled_events:
+            return True
+        return False
+
+    def _handle_health_check(
+        self, instance_health_states, instances_id_phonebook, slurm_nodes_ip_phonebook, health_check_type
+    ):
+        """
+        Perform health check action for all types of supported health checks.
+
+        Place nodes failing health check into DRAIN, so they can be maintained when possible
+        """
+        health_check_functions = {
+            ClusterManager.HealthCheckTypes.scheduled_event: self._fail_scheduled_events_check,
+            ClusterManager.HealthCheckTypes.ec2_health: self._fail_ec2_health_check,
+        }
+        # Check if health check type is supported
+        if health_check_type not in health_check_functions:
+            log.error("Unable to perform action for unsupported health check type: %s", health_check_type)
+            return
+        log.info("Performing actions for health check type: %s", health_check_type)
+        nodes_failing_health_check = []
+        for instance in instance_health_states:
+            # Pick corresponding health check function
+            is_instance_unhealthy = health_check_functions.get(health_check_type)
+            if is_instance_unhealthy(instance_health_state=instance):
+                unhealthy_node = slurm_nodes_ip_phonebook.get(instances_id_phonebook.get(instance.id).private_ip)
+                if unhealthy_node:
+                    log.warning(
+                        "Node %s(%s) is associated with instance %s that is failing %s. EC2 health state: %s",
+                        unhealthy_node.name,
+                        unhealthy_node.nodeaddr,
+                        instance.id,
+                        health_check_type,
+                        instance,
+                    )
+                    nodes_failing_health_check.append(unhealthy_node.name)
+        if nodes_failing_health_check:
+            # Place unhealthy node into drain, this operation is idempotent
+            set_nodes_drain(nodes_failing_health_check, reason=f"Node failing {health_check_type}")
+
+    def _update_replacing_nodes(self, slurm_nodes):
+        """Update self.replacing_nodes by removing nodes that finished replacement and is up."""
+        for node in slurm_nodes:
+            if node.is_up():
+                self.replacing_nodes.discard(node.name)
+
+    def _find_unhealthy_slurm_nodes(self, slurm_nodes, instances_ip_phonebook):
+        """Check and return slurm nodes with unhealthy scheduler state, grouping by node type (static/dynamic)."""
+        unhealthy_static_nodes = []
+        unhealthy_dynamic_nodes = []
+        for node in slurm_nodes:
+            if not self._is_node_healthy(node, instances_ip_phonebook):
+                if node.is_static_node():
+                    unhealthy_static_nodes.append(node)
+                else:
+                    unhealthy_dynamic_nodes.append(node)
+
+        return unhealthy_dynamic_nodes, unhealthy_static_nodes
+
+    def _is_node_being_replaced(self, node, instances_ip_phonebook):
+        """Check if a node is currently being replaced and within node_replacement_timeout."""
+        backing_instance = instances_ip_phonebook.get(node.nodeaddr)
+        if (
+            backing_instance
+            and node.name in self.replacing_nodes
+            and not ClusterManager._time_is_up(
+                backing_instance.launch_time, self.current_time, grace_time=self.sync_config.node_replacement_timeout
+            )
+        ):
+            return True
+        return False
+
+    @staticmethod
+    def _is_node_addr_valid(node, instance_ips_in_cluster):
+        """Check if a slurm node's addr setting is considered valid."""
+        # Check if static node has a backing instance
+        if node.is_static_node():
+            if not node.is_nodeaddr_set():
+                log.warning("Node state check: static node without nodeaddr set node %s", node.name)
+                return False
+        # Check if backing instance is still in EC2
+        if node.is_nodeaddr_set():
+            if node.nodeaddr not in instance_ips_in_cluster:
+                log.warning("Node state check: no corresponding instance in EC2 for node %s", node.name)
+                return False
+        return True
+
+    def _is_node_state_healthy(self, node, instances_ip_phonebook):
+        """Check if a slurm node's scheduler state is considered healthy."""
+        # Check to see if node is in DRAINED, ignoring any node currently being replaced
+        if node.is_drained() and self.sync_config.terminate_drain_nodes:
+            if self._is_node_being_replaced(node, instances_ip_phonebook):
+                log.info("Node state check: node %s in DRAINED but is currently being replaced, ignoring", node.name)
+                return True
+            else:
+                log.warning("Node state check: node %s in DRAINED, replacing node", node.name)
+                return False
+        # Check to see if node is in DOWN, ignoring any node currently being replaced
+        if node.is_down() and self.sync_config.terminate_down_nodes:
+            if self._is_node_being_replaced(node, instances_ip_phonebook):
+                log.info("Node state check: node %s in DOWN but is currently being replaced, ignoring.", node.name)
+                return True
+            else:
+                log.warning("Node state check: node %s in DOWN, replacing node", node.name)
+                return False
+        return True
+
+    def _is_node_healthy(self, node, instances_ip_phonebook):
+        """Check if a slurm node is considered healthy."""
+        return ClusterManager._is_node_addr_valid(
+            node, instance_ips_in_cluster=list(instances_ip_phonebook.keys())
+        ) and self._is_node_state_healthy(node, instances_ip_phonebook)
+
+    @staticmethod
+    def _handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes):
+        """
+        Maintain any unhealthy dynamic node.
+
+        Setting node to down will let slurm requeue jobs allocated to node.
+        Setting node to power_down will terminate backing instance and reset dynamic node for future use.
+        """
+        log.info("Setting unhealthy dynamic nodes to down and power_down: %s", unhealthy_dynamic_nodes)
+        set_nodes_down_and_power_save(
+            [node.name for node in unhealthy_dynamic_nodes], reason="Schduler health check failed"
+        )
+
+    def _handle_unhealthy_static_nodes(self, unhealthy_static_nodes):
+        """
+        Maintain any unhealthy static node.
+
+        Set node to down, terminate backing instance, and launch new instance for static node.
+        """
+        log.info(
+            "Setting following unhealthy static nodes to DOWN and terminating associated instances: %s",
+            unhealthy_static_nodes,
+        )
+        node_list = [node.name for node in unhealthy_static_nodes]
+        try:
+            # Set nodes into down state so jobs can be requeued immediately
+            set_nodes_down(node_list, reason="Static node maintenance: unhealthy node is being replaced")
+        except Exception as e:
+            logging.error(
+                "Error setting unhealthy static nodes into down state, continuing with instance replacement: %s", e,
+            )
+        self.sync_config.instance_manager.terminate_associated_instances(
+            unhealthy_static_nodes, terminate_batch_size=self.sync_config.terminate_max_batch_size
+        )
+        log.info("Launching new instances for unhealthy static nodes: %s", unhealthy_static_nodes)
+        self.sync_config.instance_manager.add_instances_for_nodes(
+            node_list, self.sync_config.launch_max_batch_size, self.sync_config.update_node_address
+        )
+        # Add node to list of nodes being replaced
+        self.replacing_nodes |= set(node_list)
+        log.info("After node maintenance, following nodes are currently in replacement: %s", self.replacing_nodes)
+
+    def _maintain_nodes(self, cluster_instances, slurm_nodes):
+        """
+        Call functions to maintain unhealthy nodes.
+
+        This function needs to handle the case that 2 slurm nodes have the same IP/nodeaddr.
+        Hence the a list of nodes is passed in and slurm node dict with IP/nodeaddr as key should be avoided.
+        """
+        self._update_replacing_nodes(slurm_nodes)
+        log.info("Following nodes are currently in replacement: %s", self.replacing_nodes)
+        instances_ip_phonebook = {instance.private_ip: instance for instance in cluster_instances}
+        unhealthy_dynamic_nodes, unhealthy_static_nodes = self._find_unhealthy_slurm_nodes(
+            slurm_nodes, instances_ip_phonebook
+        )
+        log.info(
+            "Found the following unhealthy static nodes: %s\nFound the following unhealthy dynamic nodes: %s",
+            unhealthy_static_nodes,
+            unhealthy_dynamic_nodes,
+        )
+        if unhealthy_dynamic_nodes:
+            ClusterManager._handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes)
+        if unhealthy_static_nodes:
+            self._handle_unhealthy_static_nodes(unhealthy_static_nodes)
+
+    def _terminate_orphaned_instances(self, cluster_instances, ips_used_by_slurm):
+        """Terminate instance not associated with any node and running longer than orphaned_instance_timeout."""
+        instances_to_terminate = []
+        for instance in cluster_instances:
+            if instance.private_ip not in ips_used_by_slurm and ClusterManager._time_is_up(
+                instance.launch_time, self.current_time, self.sync_config.orphaned_instance_timeout
+            ):
+                instances_to_terminate.append(instance.id)
+        log.info("Terminating the following orphaned instances: %s", instances_to_terminate)
+        if instances_to_terminate:
+            self.sync_config.instance_manager.delete_instances(
+                instances_to_terminate, terminate_batch_size=self.sync_config.terminate_max_batch_size
+            )
+
+    @staticmethod
+    def _time_is_up(initial_time, current_time, grace_time):
+        """Check if timeout is exceeded."""
+        # Localize datetime objects to UTC if not previously localized
+        # All timestamps used in this function should be already localized
+        # Assume timestamp was taken from UTC is there is no localization info
+        if not initial_time.tzinfo:
+            log.warning("Timestamp %s is not localized. Please double check that this is expected, localizing to UTC.")
+            initial_time = initial_time.replace(tzinfo=timezone.utc)
+        if not current_time.tzinfo:
+            log.warning("Timestamp %s is not localized. Please double check that this is expected, localizing to UTC")
+            current_time = current_time.replace(tzinfo=timezone.utc)
+        time_diff = (current_time - initial_time).total_seconds()
+        return time_diff >= grace_time
+
+
+def _run_clustermgtd():
+    """Run clustermgtd actions."""
+    cluster_manager = ClusterManager()
+    while True:
+        # Get loop start time
+        start_time = datetime.now(tz=timezone.utc)
+        # Get program config
+        sync_config = ClustermgtdConfig(os.path.join(CONFIG_FILE_DIR, "parallelcluster_clustermgtd.conf"))
+        # Configure root logger
+        try:
+            fileConfig(sync_config.logging_config, disable_existing_loggers=False)
+        except Exception as e:
+            log.warning(
+                "Unable to configure logging from %s, using default logging settings.\nException: %s",
+                sync_config.logging_config,
+                e,
+            )
+        # Manage cluster
+        cluster_manager.manage_cluster(sync_config, start_time)
+        sleep_remaining_loop_time(sync_config.loop_time, start_time)
+
+
+@retry(wait_fixed=seconds(LOOP_TIME))
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
+    log.info("ClusterManager Startup")
+    try:
+        _run_clustermgtd()
+    except Exception as e:
+        log.exception("An unexpected error occurred: %s", e)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -46,7 +46,12 @@ log = logging.getLogger(__name__)
 
 
 def log_exception(
-    logger, action_desc, catch_exception=Exception, raise_on_error=True, exception_to_raise=None,
+    logger,
+    action_desc,
+    log_level=logging.ERROR,
+    catch_exception=Exception,
+    raise_on_error=True,
+    exception_to_raise=None,
 ):
     def _log_exception(function):
         @functools.wraps(function)
@@ -54,7 +59,7 @@ def log_exception(
             try:
                 return function(*args, **kwargs)
             except catch_exception as e:
-                logger.exception("Failed when %s with exception %s", action_desc, e)
+                logger.log(log_level, "Failed when %s with exception %s", action_desc, e)
                 if raise_on_error:
                     if exception_to_raise:
                         raise exception_to_raise

--- a/src/slurm_plugin/logging/parallelcluster_clustermgtd_logging.conf
+++ b/src/slurm_plugin/logging/parallelcluster_clustermgtd_logging.conf
@@ -1,0 +1,21 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=streamHandler
+
+[formatters]
+keys=defaultFormatter
+
+[logger_root]
+level=INFO
+handlers=streamHandler
+
+[formatter_defaultFormatter]
+format=%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s
+
+[handler_streamHandler]
+class=StreamHandler
+level=INFO
+formatter=defaultFormatter
+args=(sys.stdout,)

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -1052,6 +1052,7 @@ def test_slurm_node_is_nodeaddr_set(node, expected_output):
         (SlurmNode("nodename", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), True),
         (SlurmNode("nodename", "nodeip", "nodehostname", "IDLE+CLOUD"), False),
         (SlurmNode("nodename", "nodeip", "nodehostname", "DOWN+CLOUD"), False),
+        (SlurmNode("nodename", "nodeip", "nodehostname", "COMPLETING+DRAIN"), True),
     ],
 )
 def test_slurm_node_has_job(node, expected_output):

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -971,8 +971,8 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
             None,
             False,
             [
-                call("/opt/slurm/bin/scontrol update nodename=node-1", raise_on_error=False),
-                call("/opt/slurm/bin/scontrol update nodename=node-2,node-3", raise_on_error=False),
+                call("/opt/slurm/bin/scontrol update nodename=node-1", raise_on_error=False, timeout=5),
+                call("/opt/slurm/bin/scontrol update nodename=node-2,node-3", raise_on_error=False, timeout=5),
             ],
         ),
         (
@@ -984,10 +984,12 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                 call(
                     "/opt/slurm/bin/scontrol update state=power_down nodename=node-1 nodehostname=hostname-1",
                     raise_on_error=True,
+                    timeout=5,
                 ),
                 call(
                     "/opt/slurm/bin/scontrol update state=power_down nodename=node-2,node-3 nodeaddr=addr-2,addr-3",
                     raise_on_error=True,
+                    timeout=5,
                 ),
             ],
         ),
@@ -1003,6 +1005,7 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                         + " nodename=node-1 nodehostname=hostname-1"
                     ),
                     raise_on_error=True,
+                    timeout=5,
                 ),
                 call(
                     (
@@ -1010,6 +1013,7 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                         + " nodename=node-[3-6] nodeaddr=addr-[3-6] nodehostname=hostname-[3-6]"
                     ),
                     raise_on_error=True,
+                    timeout=5,
                 ),
             ],
         ),

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -173,8 +173,8 @@ def test_set_sync_config(initialize_instance_manager, mocker):
 def test_get_node_info_from_partition(
     partitions, get_nodes_side_effect, expected_inactive_nodes, expected_active_nodes, mocker
 ):
-    mocker.patch("slurm_plugin.clustermgtd.get_partition_info", return_value=partitions, autospec=True)
-    mocker.patch("slurm_plugin.clustermgtd.get_nodes_info", side_effect=get_nodes_side_effect, autospec=True)
+    mocker.patch("slurm_plugin.clustermgtd.ClusterManager._get_partition_info_with_retry", return_value=partitions)
+    mocker.patch("slurm_plugin.clustermgtd.ClusterManager._get_node_info_with_retry", side_effect=get_nodes_side_effect)
     cluster_manager = ClusterManager()
     active_nodes, inactive_nodes = cluster_manager._get_node_info_from_partition()
     assert_that(active_nodes).is_equal_to(expected_active_nodes)

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1,0 +1,892 @@
+import os
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+from assertpy import assert_that
+
+import slurm_plugin
+from common.schedulers.slurm_commands import SlurmNode, SlurmPartition
+from slurm_plugin.clustermgtd import ClusterManager, ClustermgtdConfig
+from slurm_plugin.common import EC2Instance, EC2InstanceHealthState, InstanceManager
+
+
+@pytest.mark.parametrize(
+    ("config_file", "expected_attributes"),
+    [
+        (
+            "default.conf",
+            {
+                # basic configs
+                "cluster_name": "hit",
+                "region": "us-east-2",
+                "_boto3_config": {"retries": {"max_attempts": 5, "mode": "standard"}},
+                "loop_time": 30,
+                "disable_all_cluster_management": False,
+                "heartbeat_file_path": "/home/ec2-user/clustermgtd_heartbeat",
+                "logging_config": os.path.join(
+                    os.path.dirname(slurm_plugin.__file__), "logging", "parallelcluster_clustermgtd_logging.conf"
+                ),
+                # launch configs
+                "update_node_address": True,
+                "launch_max_batch_size": 100,
+                # terminate configs
+                "terminate_max_batch_size": 1000,
+                "node_replacement_timeout": 600,
+                "terminate_drain_nodes": True,
+                "terminate_down_nodes": True,
+                "orphaned_instance_timeout": 180,
+                # health check configs
+                "disable_ec2_health_check": False,
+                "disable_scheduled_event_health_check": False,
+                "disable_all_health_checks": False,
+                "health_check_timeout": 180,
+            },
+        ),
+        (
+            "all_options.conf",
+            {
+                # basic configs
+                "cluster_name": "hit",
+                "region": "us-east-1",
+                "_boto3_config": {
+                    "retries": {"max_attempts": 5, "mode": "standard"},
+                    "proxies": {"https": "https://fake.proxy"},
+                },
+                "loop_time": 60,
+                "disable_all_cluster_management": True,
+                "heartbeat_file_path": "/home/ubuntu/clustermgtd_heartbeat",
+                "logging_config": "/my/logging/config",
+                # launch configs
+                "update_node_address": False,
+                "launch_max_batch_size": 1,
+                # terminate configs
+                "terminate_max_batch_size": 500,
+                "node_replacement_timeout": 10,
+                "terminate_drain_nodes": False,
+                "terminate_down_nodes": False,
+                "orphaned_instance_timeout": 60,
+                # health check configs
+                "disable_ec2_health_check": True,
+                "disable_scheduled_event_health_check": True,
+                "disable_all_health_checks": False,
+                "health_check_timeout": 10,
+            },
+        ),
+        (
+            "health_check.conf",
+            {
+                # basic configs
+                "cluster_name": "hit",
+                "region": "us-east-1",
+                "_boto3_config": {
+                    "retries": {"max_attempts": 5, "mode": "standard"},
+                    "proxies": {"https": "https://fake.proxy"},
+                },
+                "loop_time": 60,
+                "disable_all_cluster_management": True,
+                "heartbeat_file_path": "/home/ubuntu/clustermgtd_heartbeat",
+                "logging_config": "/my/logging/config",
+                # launch configs
+                "update_node_address": False,
+                "launch_max_batch_size": 1,
+                # terminate configs
+                "terminate_max_batch_size": 500,
+                "node_replacement_timeout": 10,
+                "terminate_drain_nodes": False,
+                "terminate_down_nodes": False,
+                "orphaned_instance_timeout": 60,
+                # health check configs
+                "disable_ec2_health_check": True,
+                "disable_scheduled_event_health_check": True,
+                "disable_all_health_checks": True,
+                "health_check_timeout": 10,
+            },
+        ),
+    ],
+    ids=["default", "all_options", "health_check"],
+)
+def test_clustermgtd_config(config_file, expected_attributes, test_datadir):
+    sync_config = ClustermgtdConfig(test_datadir / config_file)
+    for key in expected_attributes:
+        assert_that(sync_config.__dict__.get(key)).is_equal_to(expected_attributes.get(key))
+
+
+@pytest.mark.parametrize(
+    "partitions, get_nodes_side_effect, expected_inactive_nodes, expected_active_nodes",
+    [
+        (
+            [
+                SlurmPartition("partition1", "placeholder_nodes", "UP"),
+                SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
+                SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
+            ],
+            [
+                [
+                    SlurmNode("node1", "nodeaddr", "nodeaddr", "DOWN"),
+                    SlurmNode("node2", "nodeaddr", "nodeaddr", "IDLE"),
+                ],
+                [
+                    SlurmNode("node3", "nodeaddr", "nodeaddr", "IDLE"),
+                    SlurmNode("node4", "nodeaddr", "nodeaddr", "IDLE"),
+                ],
+                [SlurmNode("node5", "nodeaddr", "nodeaddr", "DRAIN")],
+            ],
+            [SlurmNode("node3", "nodeaddr", "nodeaddr", "IDLE"), SlurmNode("node4", "nodeaddr", "nodeaddr", "IDLE")],
+            [
+                SlurmNode("node1", "nodeaddr", "nodeaddr", "DOWN"),
+                SlurmNode("node2", "nodeaddr", "nodeaddr", "IDLE"),
+                SlurmNode("node5", "nodeaddr", "nodeaddr", "DRAIN"),
+            ],
+        ),
+    ],
+    ids=["mixed"],
+)
+def test_get_node_info_from_partition(
+    partitions, get_nodes_side_effect, expected_inactive_nodes, expected_active_nodes, mocker
+):
+    mocker.patch("slurm_plugin.clustermgtd.get_partition_info", return_value=partitions, autospec=True)
+    mocker.patch("slurm_plugin.clustermgtd.get_nodes_info", side_effect=get_nodes_side_effect, autospec=True)
+    cluster_manager = ClusterManager()
+    active_nodes, inactive_nodes = cluster_manager._get_node_info_from_partition()
+    assert_that(active_nodes).is_equal_to(expected_active_nodes)
+    assert_that(inactive_nodes).is_equal_to(expected_inactive_nodes)
+
+
+def test_clean_up_inactive_parititon():
+    # Test setup
+    inactive_nodes = ["some inactive nodes"]
+    mock_sync_config = SimpleNamespace(
+        terminate_max_batch_size=4, instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+    )
+    cluster_manager = ClusterManager()
+    cluster_manager.set_sync_config(mock_sync_config)
+    cluster_manager.sync_config.instance_manager.terminate_associated_instances = MagicMock()
+    cluster_manager._clean_up_inactive_partition(inactive_nodes)
+    cluster_manager.sync_config.instance_manager.terminate_associated_instances.assert_called_with(
+        ["some inactive nodes"], terminate_batch_size=4
+    )
+
+
+def test_get_ec2_states():
+    # Test setup
+    cluster_manager = ClusterManager()
+    mock_sync_config = SimpleNamespace(instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),)
+    cluster_manager.set_sync_config(mock_sync_config)
+    cluster_manager.sync_config.instance_manager.get_cluster_instances = MagicMock()
+    # Run test
+    cluster_manager._get_ec2_states()
+    # Assert calls
+    cluster_manager.sync_config.instance_manager.get_cluster_instances.assert_called_with(
+        include_master=False, alive_states_only=True
+    )
+
+
+@pytest.mark.parametrize(
+    "disable_ec2_health_check, disable_scheduled_event_health_check, expected_handle_health_check_calls",
+    [
+        (
+            False,
+            False,
+            [
+                call(
+                    ["some_instance_health_states"],
+                    {
+                        "id-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                        "id-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+                    },
+                    {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"},
+                    health_check_type=ClusterManager.HealthCheckTypes.ec2_health,
+                ),
+                call(
+                    ["some_instance_health_states"],
+                    {
+                        "id-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                        "id-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+                    },
+                    {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"},
+                    health_check_type=ClusterManager.HealthCheckTypes.scheduled_event,
+                ),
+            ],
+        ),
+        (
+            True,
+            False,
+            [
+                call(
+                    ["some_instance_health_states"],
+                    {
+                        "id-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                        "id-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+                    },
+                    {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"},
+                    health_check_type=ClusterManager.HealthCheckTypes.scheduled_event,
+                )
+            ],
+        ),
+        (True, True, []),
+        (
+            False,
+            True,
+            [
+                call(
+                    ["some_instance_health_states"],
+                    {
+                        "id-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                        "id-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+                    },
+                    {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"},
+                    health_check_type=ClusterManager.HealthCheckTypes.ec2_health,
+                )
+            ],
+        ),
+    ],
+)
+def test_perform_health_check_actions(
+    disable_ec2_health_check, disable_scheduled_event_health_check, expected_handle_health_check_calls
+):
+    mock_instance_health_states = ["some_instance_health_states"]
+    mock_cluster_instances = [
+        EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+        EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+    ]
+    slurm_nodes_ip_phonebook = {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"}
+    mock_sync_config = SimpleNamespace(
+        disable_ec2_health_check=disable_ec2_health_check,
+        disable_scheduled_event_health_check=disable_scheduled_event_health_check,
+        instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+    )
+    # Mock functions
+    cluster_manager = ClusterManager()
+    cluster_manager.set_sync_config(mock_sync_config)
+    cluster_manager.sync_config.instance_manager.get_instance_health_states = MagicMock(
+        return_value=mock_instance_health_states
+    )
+    cluster_manager._handle_health_check = MagicMock()
+    # Run test
+    cluster_manager._perform_health_check_actions(mock_cluster_instances, slurm_nodes_ip_phonebook)
+    # Check function calls
+    if expected_handle_health_check_calls:
+        cluster_manager._handle_health_check.assert_has_calls(expected_handle_health_check_calls)
+    else:
+        cluster_manager._handle_health_check.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "instance_health_state, current_time, expected_result",
+    [
+        (
+            EC2InstanceHealthState(
+                "id-12345",
+                "running",
+                {"Details": [{}], "Status": "ok"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "ok"},
+                None,
+            ),
+            datetime(2020, 1, 1, 0, 0, 30),
+            False,
+        ),
+        (
+            EC2InstanceHealthState(
+                "id-12345",
+                "stopped",
+                {"Details": [{}], "Status": "initializing"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "initializing"},
+                None,
+            ),
+            datetime(2020, 1, 1, 0, 0, 30),
+            False,
+        ),
+        (
+            EC2InstanceHealthState(
+                "id-12345",
+                "stopped",
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "not-applicable"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "not-applicable"},
+                None,
+            ),
+            datetime(2020, 1, 1, 0, 0, 30),
+            False,
+        ),
+        (
+            EC2InstanceHealthState(
+                "id-12345",
+                "stopped",
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "insufficient-data"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "not-applicable"},
+                None,
+            ),
+            datetime(2020, 1, 1, 0, 0, 30),
+            True,
+        ),
+        (
+            EC2InstanceHealthState(
+                "id-12345",
+                "stopped",
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "initializing"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "impaired"},
+                None,
+            ),
+            datetime(2020, 1, 1, 0, 0, 30),
+            True,
+        ),
+        (
+            EC2InstanceHealthState(
+                "id-12345",
+                "stopped",
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "initializing"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "impaired"},
+                None,
+            ),
+            datetime(2020, 1, 1, 0, 0, 29),
+            False,
+        ),
+    ],
+    ids=["ok", "initializing", "not-applicable", "insufficient-data", "impaired", "timeout"],
+)
+def test_fail_ec2_health_check(instance_health_state, current_time, expected_result):
+    mock_sync_config = SimpleNamespace(health_check_timeout=30)
+    cluster_manager = ClusterManager()
+    cluster_manager.set_current_time(current_time)
+    cluster_manager.set_sync_config(mock_sync_config)
+    assert_that(cluster_manager._fail_ec2_health_check(instance_health_state)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "instance_health_state, current_time, expected_result",
+    [
+        (
+            EC2InstanceHealthState(
+                "id-12345", "running", {"Details": [{}], "Status": "ok"}, {"Details": [{}], "Status": "ok"}, [],
+            ),
+            datetime(2020, 1, 1, 0, 0, 30),
+            False,
+        ),
+        (
+            EC2InstanceHealthState(
+                "id-12345",
+                "running",
+                {"Details": [{}], "Status": "ok"},
+                {"Details": [{}], "Status": "ok"},
+                [{"InstanceEventId": "someid"}],
+            ),
+            datetime(2020, 1, 1, 0, 0, 29),
+            True,
+        ),
+    ],
+    ids=["no_event", "has_event"],
+)
+def test_fail_scheduled_events_health_check(instance_health_state, current_time, expected_result):
+    mock_sync_config = SimpleNamespace(health_check_timeout=30)
+    cluster_manager = ClusterManager()
+    cluster_manager.set_current_time(current_time)
+    cluster_manager.set_sync_config(mock_sync_config)
+    assert_that(cluster_manager._fail_scheduled_events_check(instance_health_state)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "health_check_type, mock_fail_ec2_side_effect, mock_fail_scheduled_events_side_effect, expected_failed_nodes",
+    [
+        (ClusterManager.HealthCheckTypes.scheduled_event, [True, False], [False, True], ["nodename-2"]),
+        (ClusterManager.HealthCheckTypes.ec2_health, [True, False], [False, True], ["nodename-1"]),
+        (ClusterManager.HealthCheckTypes.ec2_health, [False, False], [False, True], []),
+    ],
+    ids=["scheduled_event", "ec2_health", "all_healthy"],
+)
+def test_handle_health_check(
+    health_check_type, mock_fail_ec2_side_effect, mock_fail_scheduled_events_side_effect, expected_failed_nodes, mocker
+):
+    placeholder_states = [
+        EC2InstanceHealthState("id-1", "some_state", "some_status", "some_status", "some_event"),
+        EC2InstanceHealthState("id-2", "some_state", "some_status", "some_status", "some_event"),
+    ]
+    instances_id_phonebook = {
+        "id-1": EC2Instance("id-1", "ip-1", "host-1", "some_launch_time"),
+        "id-2": EC2Instance("id-2", "ip-2", "host-2", "some_launch_time"),
+    }
+    slurm_nodes_ip_phonebook = {
+        "ip-1": SlurmNode("nodename-1", "ip-1", "host-1", "some_states"),
+        "ip-2": SlurmNode("nodename-2", "ip-2", "host-2", "some_states"),
+    }
+    cluster_manager = ClusterManager()
+    cluster_manager._fail_ec2_health_check = MagicMock(side_effect=mock_fail_ec2_side_effect)
+    cluster_manager._fail_scheduled_events_check = MagicMock(side_effect=mock_fail_scheduled_events_side_effect)
+    drain_node_mock = mocker.patch("slurm_plugin.clustermgtd.set_nodes_drain", autospec=True)
+    cluster_manager._handle_health_check(
+        placeholder_states, instances_id_phonebook, slurm_nodes_ip_phonebook, health_check_type
+    )
+    if expected_failed_nodes:
+        drain_node_mock.assert_called_with(expected_failed_nodes, reason=f"Node failing {health_check_type}")
+    else:
+        drain_node_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "current_replacing_nodes, slurm_nodes, expected_replacing_nodes",
+    [
+        (
+            {"node-1", "node-2"},
+            [
+                SlurmNode("node-1", "ip", "hostname", "IDLE+CLOUD"),
+                SlurmNode("node-2", "ip", "hostname", "DOWN+CLOUD"),
+                SlurmNode("node-3", "ip", "hostname", "IDLE+CLOUD"),
+            ],
+            {"node-2"},
+        )
+    ],
+    ids=["mixed"],
+)
+def test_update_replacing_nodes(current_replacing_nodes, slurm_nodes, expected_replacing_nodes):
+    cluster_manager = ClusterManager()
+    cluster_manager._set_replacing_nodes(current_replacing_nodes)
+    cluster_manager._update_replacing_nodes(slurm_nodes)
+    assert_that(cluster_manager.replacing_nodes).is_equal_to(expected_replacing_nodes)
+
+
+@pytest.mark.parametrize(
+    "current_replacing_nodes, node, instances_ip_phonebook, current_time, expected_result",
+    [
+        (
+            set(),
+            SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"),
+            {"ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0))},
+            datetime(2020, 1, 1, 0, 0, 29),
+            False,
+        ),
+        ({"node-1"}, SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"), {}, datetime(2020, 1, 1, 0, 0, 29), False,),
+        (
+            {"node-1"},
+            SlurmNode("node-1", "ip-1", "hostname", "DOWN+CLOUD"),
+            {"ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0))},
+            datetime(2020, 1, 1, 0, 0, 29),
+            True,
+        ),
+        (
+            {"node-1"},
+            SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"),
+            {"ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0))},
+            datetime(2020, 1, 1, 0, 0, 30),
+            False,
+        ),
+    ],
+    ids=["not_in_replacement", "no-backing-instance", "in_replacement", "timeout"],
+)
+def test_is_node_being_replaced(current_replacing_nodes, node, instances_ip_phonebook, current_time, expected_result):
+    mock_sync_config = SimpleNamespace(node_replacement_timeout=30)
+    cluster_manager = ClusterManager()
+    cluster_manager.set_sync_config(mock_sync_config)
+    cluster_manager.set_current_time(current_time)
+    cluster_manager._set_replacing_nodes(current_replacing_nodes)
+    assert_that(cluster_manager._is_node_being_replaced(node, instances_ip_phonebook)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "node, instances_ips_in_cluster, expected_result",
+    [
+        (SlurmNode("node-static-c5.xlarge-1", "node-static-c5.xlarge-1", "hostname", "IDLE+CLOUD"), ["ip-1"], False,),
+        (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), ["ip-2"], False,),
+        (
+            SlurmNode("node-dynamic-c5.xlarge-1", "node-dynamic-c5.xlarge-1", "hostname", "IDLE+CLOUD+POWER"),
+            ["ip-2"],
+            True,
+        ),
+        (SlurmNode("node-dynamic-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-2"], False,),
+        (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-1"], True,),
+    ],
+    ids=["static_addr_not_set", "static_no_backing", "dynamic_power_save", "dynamic_no_backing", "static_valid"],
+)
+def test_is_node_addr_valid(node, instances_ips_in_cluster, expected_result):
+    assert_that(ClusterManager._is_node_addr_valid(node, instances_ips_in_cluster)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "node, mock_sync_config, mock_is_node_being_replaced, expected_result",
+    [
+        (
+            SlurmNode("node-1", "some_ip", "hostname", "MIXED+CLOUD"),
+            SimpleNamespace(terminate_drain_nodes=True, terminate_down_nodes=True),
+            None,
+            True,
+        ),
+        (
+            SlurmNode("node-1", "some_ip", "hostname", "IDLE+CLOUD+DRAIN"),
+            SimpleNamespace(terminate_drain_nodes=True, terminate_down_nodes=True),
+            False,
+            False,
+        ),
+        (
+            SlurmNode("node-1", "some_ip", "hostname", "IDLE+CLOUD+DRAIN"),
+            SimpleNamespace(terminate_drain_nodes=True, terminate_down_nodes=True),
+            True,
+            True,
+        ),
+        (
+            SlurmNode("node-1", "some_ip", "hostname", "IDLE+CLOUD+DRAIN"),
+            SimpleNamespace(terminate_drain_nodes=False, terminate_down_nodes=True),
+            False,
+            True,
+        ),
+        (
+            SlurmNode("node-1", "some_ip", "hostname", "DOWN+CLOUD"),
+            SimpleNamespace(terminate_drain_nodes=True, terminate_down_nodes=True),
+            False,
+            False,
+        ),
+        (
+            SlurmNode("node-1", "some_ip", "hostname", "DOWN+CLOUD"),
+            SimpleNamespace(terminate_drain_nodes=True, terminate_down_nodes=True),
+            True,
+            True,
+        ),
+        (
+            SlurmNode("node-1", "some_ip", "hostname", "DOWN+CLOUD"),
+            SimpleNamespace(terminate_drain_nodes=True, terminate_down_nodes=False),
+            False,
+            True,
+        ),
+    ],
+    ids=[
+        "healthy_node",
+        "drained_not_in_replacement",
+        "drained_in_replacement",
+        "drain_not_term",
+        "down_not_in_replacement",
+        "down_in_replacement",
+        "down_not_term",
+    ],
+)
+def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replaced, expected_result):
+    cluster_manager = ClusterManager()
+    cluster_manager.set_sync_config(mock_sync_config)
+    cluster_manager._is_node_being_replaced = MagicMock(return_value=mock_is_node_being_replaced)
+    assert_that(
+        cluster_manager._is_node_state_healthy(node, instances_ip_phonebook={"placeholder phonebook"})
+    ).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "node, instances_ip_phonebook, instance_ips_in_cluster",
+    [
+        (
+            SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            },
+            ["ip-1", "ip-2"],
+        )
+    ],
+    ids=["basic"],
+)
+def test_is_node_healthy(node, instances_ip_phonebook, instance_ips_in_cluster):
+    cluster_manager = ClusterManager()
+    cluster_manager._is_node_state_healthy = MagicMock()
+    ClusterManager._is_node_addr_valid = MagicMock()
+    cluster_manager._is_node_healthy(node, instances_ip_phonebook)
+    cluster_manager._is_node_state_healthy.assert_called_with(node, instances_ip_phonebook)
+    ClusterManager._is_node_addr_valid.assert_called_with(node, instance_ips_in_cluster=instance_ips_in_cluster)
+
+
+@pytest.mark.parametrize(
+    "unhealthy_dynamic_nodes, expected_power_save_node_list",
+    [
+        (
+            [
+                SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"),
+                SlurmNode("node-2", "ip-1", "hostname", "IDLE+CLOUD"),
+            ],
+            ["node-1", "node-2"],
+        )
+    ],
+    ids=["basic"],
+)
+def test_handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes, expected_power_save_node_list, mocker):
+    power_save_mock = mocker.patch(
+        "slurm_plugin.clustermgtd.set_nodes_down_and_power_save", return_value=None, autospec=True
+    )
+    ClusterManager._handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes)
+    power_save_mock.assert_called_with(expected_power_save_node_list, reason="Schduler health check failed")
+
+
+@pytest.mark.parametrize(
+    "current_replacing_nodes, unhealthy_static_nodes, expected_replacing_nodes, applicable_node_list",
+    [
+        (
+            {"some_current_node"},
+            [
+                SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"),
+                SlurmNode("node-2", "ip-1", "hostname", "IDLE+CLOUD"),
+            ],
+            {"some_current_node", "node-1", "node-2"},
+            ["node-1", "node-2"],
+        )
+    ],
+    ids=["basic"],
+)
+def test_handle_unhealthy_static_nodes(
+    current_replacing_nodes, unhealthy_static_nodes, expected_replacing_nodes, applicable_node_list, mocker
+):
+    # Test setup
+    mock_sync_config = SimpleNamespace(
+        terminate_max_batch_size=1,
+        launch_max_batch_size=5,
+        update_node_address=False,
+        instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+    )
+    cluster_manager = ClusterManager()
+    cluster_manager.set_sync_config(mock_sync_config)
+    cluster_manager._set_replacing_nodes(current_replacing_nodes)
+    # Mock associated function
+    cluster_manager.sync_config.instance_manager.terminate_associated_instances = MagicMock()
+    cluster_manager.sync_config.instance_manager.add_instances_for_nodes = MagicMock()
+    update_mock = mocker.patch("slurm_plugin.clustermgtd.set_nodes_down", return_value=None, autospec=True)
+    # Run test
+    cluster_manager._handle_unhealthy_static_nodes(unhealthy_static_nodes)
+    # Assert calls
+    update_mock.assert_called_with(
+        applicable_node_list, reason="Static node maintenance: unhealthy node is being replaced"
+    )
+    cluster_manager.sync_config.instance_manager.terminate_associated_instances.assert_called_with(
+        unhealthy_static_nodes, terminate_batch_size=1
+    )
+    cluster_manager.sync_config.instance_manager.add_instances_for_nodes.assert_called_with(
+        applicable_node_list, 5, False
+    )
+    assert_that(cluster_manager.replacing_nodes).is_equal_to(expected_replacing_nodes)
+
+
+@pytest.mark.parametrize(
+    "cluster_instances, active_nodes, mock_unhealthy_nodes",
+    [
+        (
+            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [
+                SlurmNode("node-1", "ip-1", "hostname", "some_state"),
+                SlurmNode("node-2", "ip-2", "hostname", "some_state"),
+            ],
+            (["node-1"], ["node-2"]),
+        ),
+        (
+            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [
+                SlurmNode("node-1", "ip-1", "hostname", "some_state"),
+                SlurmNode("node-1-repetitive-ip", "ip-1", "hostname", "some_state"),
+                SlurmNode("node-2", "ip-2", "hostname", "some_state"),
+            ],
+            (["node-1", "node-1-repetitive-ip"], ["node-2"]),
+        ),
+    ],
+    ids=["basic", "repetitive_ip"],
+)
+def test_maintain_nodes(cluster_instances, active_nodes, mock_unhealthy_nodes):
+    # Mock functions
+    mock_instances_ip_phonebook = {instance.private_ip: instance for instance in cluster_instances}
+    cluster_manager = ClusterManager()
+    cluster_manager._update_replacing_nodes = MagicMock()
+    cluster_manager._find_unhealthy_slurm_nodes = MagicMock(return_value=mock_unhealthy_nodes)
+    ClusterManager._handle_unhealthy_dynamic_nodes = MagicMock()
+    cluster_manager._handle_unhealthy_static_nodes = MagicMock()
+    # Run test
+    cluster_manager._maintain_nodes(cluster_instances, active_nodes)
+    # Check function calls
+    cluster_manager._update_replacing_nodes.assert_called_with(active_nodes)
+    cluster_manager._find_unhealthy_slurm_nodes.assert_called_with(active_nodes, mock_instances_ip_phonebook)
+    ClusterManager._handle_unhealthy_dynamic_nodes(mock_unhealthy_nodes[0])
+    cluster_manager._handle_unhealthy_static_nodes(mock_unhealthy_nodes[1])
+
+
+@pytest.mark.parametrize(
+    "cluster_instances, instances_ip_phonebook, current_time, expected_instance_to_terminate",
+    [
+        (
+            [
+                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-2", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            ],
+            {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"},
+            datetime(2020, 1, 1, 0, 0, 30),
+            [],
+        ),
+        (
+            [
+                EC2Instance("id-3", "ip-3", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-2", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            ],
+            {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"},
+            datetime(2020, 1, 1, 0, 0, 30),
+            ["id-3"],
+        ),
+        (
+            [
+                EC2Instance("id-3", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-2", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            ],
+            {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"},
+            datetime(2020, 1, 1, 0, 0, 29),
+            [],
+        ),
+    ],
+    ids=["all_good", "orphaned", "orphaned_timeout"],
+)
+def test_terminate_orphaned_instances(
+    cluster_instances, instances_ip_phonebook, current_time, expected_instance_to_terminate
+):
+    # Mock functions
+    cluster_manager = ClusterManager()
+    mock_sync_config = SimpleNamespace(
+        orphaned_instance_timeout=30,
+        terminate_max_batch_size=4,
+        instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+    )
+    cluster_manager.set_sync_config(mock_sync_config)
+    cluster_manager.set_current_time(current_time)
+    cluster_manager.sync_config.instance_manager.delete_instances = MagicMock()
+    # Run test
+    cluster_manager._terminate_orphaned_instances(cluster_instances, instances_ip_phonebook)
+    # Check function calls
+    if expected_instance_to_terminate:
+        cluster_manager.sync_config.instance_manager.delete_instances.assert_called_with(
+            expected_instance_to_terminate, terminate_batch_size=4
+        )
+
+
+@pytest.mark.parametrize(
+    "initial_time, current_time, grace_time, expected_result",
+    [
+        (datetime(2020, 1, 1, 0, 0, 0), datetime(2020, 1, 1, 0, 0, 29), 30, False),
+        (datetime(2020, 1, 1, 0, 0, 0), datetime(2020, 1, 1, 0, 0, 30), 30, True),
+        (
+            datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            # local timezone is 1 hours ahead of UTC, so this time stamp is actually 30 mins before initial_time
+            datetime(2020, 1, 1, 0, 30, 0, tzinfo=timezone(timedelta(hours=1))),
+            30 * 60,
+            False,
+        ),
+        (
+            datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            # local timezone is 1 hours ahead of UTC, so this time stamp is actually 30 mins after initial_time
+            datetime(2020, 1, 1, 1, 30, 0, tzinfo=timezone(timedelta(hours=1))),
+            30 * 60,
+            True,
+        ),
+        (
+            datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            # local timezone is 1 hours behind of UTC, so this time stamp is actually 1.5 hrs after initial_time
+            datetime(2020, 1, 1, 0, 30, 0, tzinfo=timezone(-timedelta(hours=1))),
+            90 * 60,
+            True,
+        ),
+        (
+            datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            # local timezone is 1 hours behind of UTC, so this time stamp is actually 1 hrs after initial_time
+            datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone(-timedelta(hours=1))),
+            90 * 60,
+            False,
+        ),
+    ],
+)
+def test_time_is_up(initial_time, current_time, grace_time, expected_result):
+    assert_that(ClusterManager._time_is_up(initial_time, current_time, grace_time)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "disable_cluster_management, disable_health_check, mock_cluster_instances, mock_active_nodes, mock_inactive_nodes",
+    [
+        (
+            False,
+            False,
+            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [
+                SlurmNode("some_active_node1", "ip", "hostname", "some_state"),
+                SlurmNode("some_active_node2", "ip", "hostname", "some_state"),
+            ],
+            [],
+        ),
+        (
+            True,
+            False,
+            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [
+                SlurmNode("some_active_node1", "ip", "hostname", "some_state"),
+                SlurmNode("some_active_node2", "ip", "hostname", "some_state"),
+            ],
+            [],
+        ),
+        (
+            False,
+            True,
+            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [
+                SlurmNode("some_active_node1", "ip", "hostname", "some_state"),
+                SlurmNode("some_active_node2", "ip", "hostname", "some_state"),
+            ],
+            [],
+        ),
+        (
+            False,
+            True,
+            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [],
+            [
+                SlurmNode("some_inactive_node1", "ip", "hostname", "some_state"),
+                SlurmNode("some_inactive_node2", "ip", "hostname", "some_state"),
+            ],
+        ),
+        (False, True, [EC2Instance("id-1", "ip-1", "hostname", "launch_time")], [], [],),
+    ],
+    ids=["all_enabled", "disable_all", "disable_health_check", "no_active", "no_node"],
+)
+def test_manage_cluster(
+    disable_cluster_management, disable_health_check, mock_cluster_instances, mock_active_nodes, mock_inactive_nodes
+):
+    mock_sync_config = SimpleNamespace(
+        disable_all_cluster_management=disable_cluster_management, disable_all_health_checks=disable_health_check
+    )
+    slurm_nodes_ip_phonebook = {node.nodeaddr: node for node in mock_active_nodes}
+    current_time = datetime(2020, 1, 1, 0, 0, 0)
+    cluster_manager = ClusterManager()
+    # Set up function mocks
+    cluster_manager.set_sync_config = MagicMock()
+    cluster_manager.set_current_time = MagicMock()
+    cluster_manager._write_timestamp_to_file = MagicMock()
+    cluster_manager._perform_health_check_actions = MagicMock()
+    cluster_manager._clean_up_inactive_partition = MagicMock()
+    cluster_manager._terminate_orphaned_instances = MagicMock()
+    cluster_manager._maintain_nodes = MagicMock()
+    ClusterManager._get_node_info_from_partition = MagicMock()
+    cluster_manager._get_ec2_states = MagicMock()
+    ClusterManager._get_node_info_from_partition = MagicMock(return_value=(mock_active_nodes, mock_inactive_nodes))
+    cluster_manager._get_ec2_states = MagicMock(return_value=mock_cluster_instances)
+    # Run test
+    cluster_manager.manage_cluster(mock_sync_config, current_time)
+    # Assert function calls
+    cluster_manager.set_sync_config.assert_called_with(mock_sync_config)
+    cluster_manager.set_current_time.assert_called_with(current_time)
+    cluster_manager._write_timestamp_to_file.assert_called()
+    if disable_cluster_management:
+        cluster_manager._perform_health_check_actions.assert_not_called()
+        cluster_manager._clean_up_inactive_partition.assert_not_called()
+        cluster_manager._terminate_orphaned_instances.assert_not_called()
+        cluster_manager._maintain_nodes.assert_not_called()
+        ClusterManager._get_node_info_from_partition.assert_not_called()
+        cluster_manager._get_ec2_states.assert_not_called()
+        return
+    if mock_inactive_nodes:
+        cluster_manager._clean_up_inactive_partition.assert_called_with(mock_inactive_nodes)
+    cluster_manager._get_ec2_states.assert_called()
+    if not mock_active_nodes:
+        cluster_manager._terminate_orphaned_instances.assert_called_with(mock_cluster_instances, ips_used_by_slurm=[])
+        cluster_manager._perform_health_check_actions.assert_not_called()
+        cluster_manager._maintain_nodes.assert_not_called()
+        return
+    if disable_health_check:
+        cluster_manager._perform_health_check_actions.assert_not_called()
+    else:
+        cluster_manager._perform_health_check_actions.assert_called_with(
+            mock_cluster_instances, slurm_nodes_ip_phonebook
+        )
+    cluster_manager._maintain_nodes.assert_called_with(mock_cluster_instances, mock_active_nodes)
+    cluster_manager._terminate_orphaned_instances.assert_called_with(
+        mock_cluster_instances, ips_used_by_slurm=list(slurm_nodes_ip_phonebook.keys())
+    )

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call
+from unittest.mock import call
 
 import pytest
 from assertpy import assert_that
@@ -9,7 +9,21 @@ from assertpy import assert_that
 import slurm_plugin
 from common.schedulers.slurm_commands import SlurmNode, SlurmPartition
 from slurm_plugin.clustermgtd import ClusterManager, ClustermgtdConfig
-from slurm_plugin.common import EC2Instance, EC2InstanceHealthState, InstanceManager
+from slurm_plugin.common import (
+    EC2_HEALTH_STATUS_UNHEALTHY_STATES,
+    EC2_INSTANCE_ALIVE_STATES,
+    EC2_SCHEDULED_EVENT_CODES,
+    EC2Instance,
+    EC2InstanceHealthState,
+)
+from tests.common import MockedBoto3Request
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    # we need to set the region in the environment because the Boto3ClientFactory requires it.
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    return "slurm_plugin.common.boto3"
 
 
 @pytest.mark.parametrize(
@@ -113,6 +127,19 @@ def test_clustermgtd_config(config_file, expected_attributes, test_datadir):
         assert_that(sync_config.__dict__.get(key)).is_equal_to(expected_attributes.get(key))
 
 
+@pytest.mark.parametrize("initialize_instance_manager", [(False,), (True,)])
+def test_set_sync_config(initialize_instance_manager, mocker):
+    sync_config = SimpleNamespace(some_key_1="some_value_1", some_key_2="some_value_2")
+    cluster_manager = ClusterManager()
+    cluster_manager._initialize_instance_manager = mocker.MagicMock()
+    cluster_manager._set_sync_config(sync_config)
+    assert_that(cluster_manager.sync_config).is_equal_to(sync_config)
+    if initialize_instance_manager:
+        cluster_manager._initialize_instance_manager.assert_called_once()
+    else:
+        cluster_manager._initialize_instance_manager.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "partitions, get_nodes_side_effect, expected_inactive_nodes, expected_active_nodes",
     [
@@ -154,31 +181,33 @@ def test_get_node_info_from_partition(
     assert_that(inactive_nodes).is_equal_to(expected_inactive_nodes)
 
 
-def test_clean_up_inactive_parititon():
+def test_clean_up_inactive_parititon(mocker):
     # Test setup
     inactive_nodes = ["some inactive nodes"]
     mock_sync_config = SimpleNamespace(
-        terminate_max_batch_size=4, instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+        terminate_max_batch_size=4, region="us-east-2", cluster_name="hit-test", boto3_config="some config"
     )
     cluster_manager = ClusterManager()
-    cluster_manager.set_sync_config(mock_sync_config)
-    cluster_manager.sync_config.instance_manager.terminate_associated_instances = MagicMock()
+    cluster_manager._set_sync_config(mock_sync_config)
+    cluster_manager._initialize_instance_manager()
+    cluster_manager.instance_manager.terminate_associated_instances = mocker.MagicMock()
     cluster_manager._clean_up_inactive_partition(inactive_nodes)
-    cluster_manager.sync_config.instance_manager.terminate_associated_instances.assert_called_with(
+    cluster_manager.instance_manager.terminate_associated_instances.assert_called_with(
         ["some inactive nodes"], terminate_batch_size=4
     )
 
 
-def test_get_ec2_states():
+def test_get_ec2_instances(mocker):
     # Test setup
+    mock_sync_config = SimpleNamespace(region="us-east-2", cluster_name="hit-test", boto3_config="some config")
     cluster_manager = ClusterManager()
-    mock_sync_config = SimpleNamespace(instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),)
-    cluster_manager.set_sync_config(mock_sync_config)
-    cluster_manager.sync_config.instance_manager.get_cluster_instances = MagicMock()
+    cluster_manager._set_sync_config(mock_sync_config)
+    cluster_manager._initialize_instance_manager()
+    cluster_manager.instance_manager.get_cluster_instances = mocker.MagicMock()
     # Run test
-    cluster_manager._get_ec2_states()
+    cluster_manager._get_ec2_instances()
     # Assert calls
-    cluster_manager.sync_config.instance_manager.get_cluster_instances.assert_called_with(
+    cluster_manager.instance_manager.get_cluster_instances.assert_called_with(
         include_master=False, alive_states_only=True
     )
 
@@ -244,28 +273,31 @@ def test_get_ec2_states():
     ],
 )
 def test_perform_health_check_actions(
-    disable_ec2_health_check, disable_scheduled_event_health_check, expected_handle_health_check_calls
+    disable_ec2_health_check, disable_scheduled_event_health_check, expected_handle_health_check_calls, mocker
 ):
     mock_instance_health_states = ["some_instance_health_states"]
     mock_cluster_instances = [
         EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
         EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
     ]
-    slurm_nodes_ip_phonebook = {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"}
+    ip_to_slurm_node_map = {"ip-1": "some_slurm_node1", "ip-2": "some_slurm_node2"}
     mock_sync_config = SimpleNamespace(
         disable_ec2_health_check=disable_ec2_health_check,
         disable_scheduled_event_health_check=disable_scheduled_event_health_check,
-        instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+        region="us-east-2",
+        cluster_name="hit-test",
+        boto3_config="some config",
     )
     # Mock functions
     cluster_manager = ClusterManager()
-    cluster_manager.set_sync_config(mock_sync_config)
-    cluster_manager.sync_config.instance_manager.get_instance_health_states = MagicMock(
+    cluster_manager._set_sync_config(mock_sync_config)
+    cluster_manager._initialize_instance_manager()
+    cluster_manager.instance_manager.get_unhealthy_cluster_instance_status = mocker.MagicMock(
         return_value=mock_instance_health_states
     )
-    cluster_manager._handle_health_check = MagicMock()
+    cluster_manager._handle_health_check = mocker.MagicMock().patch()
     # Run test
-    cluster_manager._perform_health_check_actions(mock_cluster_instances, slurm_nodes_ip_phonebook)
+    cluster_manager._perform_health_check_actions(mock_cluster_instances, ip_to_slurm_node_map)
     # Check function calls
     if expected_handle_health_check_calls:
         cluster_manager._handle_health_check.assert_has_calls(expected_handle_health_check_calls)
@@ -314,17 +346,17 @@ def test_perform_health_check_actions(
                 "id-12345",
                 "stopped",
                 {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "insufficient-data"},
-                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "not-applicable"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "insufficient-data"},
                 None,
             ),
             datetime(2020, 1, 1, 0, 0, 30),
-            True,
+            False,
         ),
         (
             EC2InstanceHealthState(
                 "id-12345",
                 "stopped",
-                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "initializing"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 15)}], "Status": "initializing"},
                 {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "impaired"},
                 None,
             ),
@@ -335,7 +367,7 @@ def test_perform_health_check_actions(
             EC2InstanceHealthState(
                 "id-12345",
                 "stopped",
-                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "initializing"},
+                {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 15)}], "Status": "initializing"},
                 {"Details": [{"ImpairedSince": datetime(2020, 1, 1, 0, 0, 0)}], "Status": "impaired"},
                 None,
             ),
@@ -346,21 +378,18 @@ def test_perform_health_check_actions(
     ids=["ok", "initializing", "not-applicable", "insufficient-data", "impaired", "timeout"],
 )
 def test_fail_ec2_health_check(instance_health_state, current_time, expected_result):
-    mock_sync_config = SimpleNamespace(health_check_timeout=30)
-    cluster_manager = ClusterManager()
-    cluster_manager.set_current_time(current_time)
-    cluster_manager.set_sync_config(mock_sync_config)
-    assert_that(cluster_manager._fail_ec2_health_check(instance_health_state)).is_equal_to(expected_result)
+    assert_that(
+        ClusterManager._fail_ec2_health_check(instance_health_state, current_time, health_check_timeout=30)
+    ).is_equal_to(expected_result)
 
 
 @pytest.mark.parametrize(
-    "instance_health_state, current_time, expected_result",
+    "instance_health_state, expected_result",
     [
         (
             EC2InstanceHealthState(
                 "id-12345", "running", {"Details": [{}], "Status": "ok"}, {"Details": [{}], "Status": "ok"}, [],
             ),
-            datetime(2020, 1, 1, 0, 0, 30),
             False,
         ),
         (
@@ -371,18 +400,13 @@ def test_fail_ec2_health_check(instance_health_state, current_time, expected_res
                 {"Details": [{}], "Status": "ok"},
                 [{"InstanceEventId": "someid"}],
             ),
-            datetime(2020, 1, 1, 0, 0, 29),
             True,
         ),
     ],
     ids=["no_event", "has_event"],
 )
-def test_fail_scheduled_events_health_check(instance_health_state, current_time, expected_result):
-    mock_sync_config = SimpleNamespace(health_check_timeout=30)
-    cluster_manager = ClusterManager()
-    cluster_manager.set_current_time(current_time)
-    cluster_manager.set_sync_config(mock_sync_config)
-    assert_that(cluster_manager._fail_scheduled_events_check(instance_health_state)).is_equal_to(expected_result)
+def test_fail_scheduled_events_health_check(instance_health_state, expected_result):
+    assert_that(ClusterManager._fail_scheduled_events_check(instance_health_state)).is_equal_to(expected_result)
 
 
 @pytest.mark.parametrize(
@@ -397,25 +421,47 @@ def test_fail_scheduled_events_health_check(instance_health_state, current_time,
 def test_handle_health_check(
     health_check_type, mock_fail_ec2_side_effect, mock_fail_scheduled_events_side_effect, expected_failed_nodes, mocker
 ):
-    placeholder_states = [
-        EC2InstanceHealthState("id-1", "some_state", "some_status", "some_status", "some_event"),
-        EC2InstanceHealthState("id-2", "some_state", "some_status", "some_status", "some_event"),
-    ]
-    instances_id_phonebook = {
+    # Define variable that will be used for all tests
+    health_state_1 = EC2InstanceHealthState("id-1", "some_state", "some_status", "some_status", "some_event")
+    health_state_2 = EC2InstanceHealthState("id-2", "some_state", "some_status", "some_status", "some_event")
+    placeholder_states = [health_state_1, health_state_2]
+    id_to_instance_map = {
         "id-1": EC2Instance("id-1", "ip-1", "host-1", "some_launch_time"),
         "id-2": EC2Instance("id-2", "ip-2", "host-2", "some_launch_time"),
     }
-    slurm_nodes_ip_phonebook = {
+    ip_to_slurm_node_map = {
         "ip-1": SlurmNode("nodename-1", "ip-1", "host-1", "some_states"),
         "ip-2": SlurmNode("nodename-2", "ip-2", "host-2", "some_states"),
     }
-    cluster_manager = ClusterManager()
-    cluster_manager._fail_ec2_health_check = MagicMock(side_effect=mock_fail_ec2_side_effect)
-    cluster_manager._fail_scheduled_events_check = MagicMock(side_effect=mock_fail_scheduled_events_side_effect)
-    drain_node_mock = mocker.patch("slurm_plugin.clustermgtd.set_nodes_drain", autospec=True)
-    cluster_manager._handle_health_check(
-        placeholder_states, instances_id_phonebook, slurm_nodes_ip_phonebook, health_check_type
+    mock_ec2_health_check = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._fail_ec2_health_check", side_effect=mock_fail_ec2_side_effect,
     )
+    mock_scheduled_health_check = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._fail_scheduled_events_check",
+        side_effect=mock_fail_scheduled_events_side_effect,
+    )
+    # Setup mocking
+    cluster_manager = ClusterManager()
+    cluster_manager._set_current_time("some_current_time")
+    mock_sync_config = SimpleNamespace(health_check_timeout=10)
+    cluster_manager._set_sync_config(mock_sync_config, initialize_instance_manager=False)
+    drain_node_mock = mocker.patch("slurm_plugin.clustermgtd.set_nodes_drain", autospec=True)
+    # Run tests
+    cluster_manager._handle_health_check(
+        placeholder_states, id_to_instance_map, ip_to_slurm_node_map, health_check_type
+    )
+    # Assert on calls
+    if health_check_type == ClusterManager.HealthCheckTypes.scheduled_event:
+        mock_scheduled_health_check.assert_has_calls(
+            [call(instance_health_state=health_state_1), call(instance_health_state=health_state_2)]
+        )
+    else:
+        mock_ec2_health_check.assert_has_calls(
+            [
+                call(instance_health_state=health_state_1, current_time="some_current_time", health_check_timeout=10),
+                call(instance_health_state=health_state_2, current_time="some_current_time", health_check_timeout=10),
+            ]
+        )
     if expected_failed_nodes:
         drain_node_mock.assert_called_with(expected_failed_nodes, reason=f"Node failing {health_check_type}")
     else:
@@ -426,7 +472,7 @@ def test_handle_health_check(
     "current_replacing_nodes, slurm_nodes, expected_replacing_nodes",
     [
         (
-            {"node-1", "node-2"},
+            {"node-1", "node-2", "node-4"},
             [
                 SlurmNode("node-1", "ip", "hostname", "IDLE+CLOUD"),
                 SlurmNode("node-2", "ip", "hostname", "DOWN+CLOUD"),
@@ -437,15 +483,15 @@ def test_handle_health_check(
     ],
     ids=["mixed"],
 )
-def test_update_replacing_nodes(current_replacing_nodes, slurm_nodes, expected_replacing_nodes):
+def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes, expected_replacing_nodes):
     cluster_manager = ClusterManager()
-    cluster_manager._set_replacing_nodes(current_replacing_nodes)
-    cluster_manager._update_replacing_nodes(slurm_nodes)
-    assert_that(cluster_manager.replacing_nodes).is_equal_to(expected_replacing_nodes)
+    cluster_manager._set_static_nodes_in_replacement(current_replacing_nodes)
+    cluster_manager._update_static_nodes_in_replacement(slurm_nodes)
+    assert_that(cluster_manager.static_nodes_in_replacement).is_equal_to(expected_replacing_nodes)
 
 
 @pytest.mark.parametrize(
-    "current_replacing_nodes, node, instances_ip_phonebook, current_time, expected_result",
+    "current_replacing_nodes, node, private_ip_to_instance_map, current_time, expected_result",
     [
         (
             set(),
@@ -472,19 +518,32 @@ def test_update_replacing_nodes(current_replacing_nodes, slurm_nodes, expected_r
     ],
     ids=["not_in_replacement", "no-backing-instance", "in_replacement", "timeout"],
 )
-def test_is_node_being_replaced(current_replacing_nodes, node, instances_ip_phonebook, current_time, expected_result):
+def test_is_node_being_replaced(
+    current_replacing_nodes, node, private_ip_to_instance_map, current_time, expected_result
+):
     mock_sync_config = SimpleNamespace(node_replacement_timeout=30)
     cluster_manager = ClusterManager()
-    cluster_manager.set_sync_config(mock_sync_config)
-    cluster_manager.set_current_time(current_time)
-    cluster_manager._set_replacing_nodes(current_replacing_nodes)
-    assert_that(cluster_manager._is_node_being_replaced(node, instances_ip_phonebook)).is_equal_to(expected_result)
+    cluster_manager._set_sync_config(mock_sync_config, initialize_instance_manager=False)
+    cluster_manager._set_current_time(current_time)
+    cluster_manager._set_static_nodes_in_replacement(current_replacing_nodes)
+    assert_that(cluster_manager._is_node_being_replaced(node, private_ip_to_instance_map)).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
+    "node, expected_result",
+    [
+        (SlurmNode("node-static-c5.xlarge-1", "node-static-c5.xlarge-1", "hostname", "IDLE+CLOUD"), False),
+        (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), True),
+    ],
+    ids=["static_addr_not_set", "static_valid"],
+)
+def test_is_static_node_configuration_valid(node, expected_result):
+    assert_that(ClusterManager._is_static_node_configuration_valid(node)).is_equal_to(expected_result)
 
 
 @pytest.mark.parametrize(
     "node, instances_ips_in_cluster, expected_result",
     [
-        (SlurmNode("node-static-c5.xlarge-1", "node-static-c5.xlarge-1", "hostname", "IDLE+CLOUD"), ["ip-1"], False,),
         (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), ["ip-2"], False,),
         (
             SlurmNode("node-dynamic-c5.xlarge-1", "node-dynamic-c5.xlarge-1", "hostname", "IDLE+CLOUD+POWER"),
@@ -494,10 +553,10 @@ def test_is_node_being_replaced(current_replacing_nodes, node, instances_ip_phon
         (SlurmNode("node-dynamic-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-2"], False,),
         (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-1"], True,),
     ],
-    ids=["static_addr_not_set", "static_no_backing", "dynamic_power_save", "dynamic_no_backing", "static_valid"],
+    ids=["static_no_backing", "dynamic_power_save", "dynamic_no_backing", "static_valid"],
 )
-def test_is_node_addr_valid(node, instances_ips_in_cluster, expected_result):
-    assert_that(ClusterManager._is_node_addr_valid(node, instances_ips_in_cluster)).is_equal_to(expected_result)
+def test_is_backing_instance_valid(node, instances_ips_in_cluster, expected_result):
+    assert_that(ClusterManager._is_backing_instance_valid(node, instances_ips_in_cluster)).is_equal_to(expected_result)
 
 
 @pytest.mark.parametrize(
@@ -556,36 +615,71 @@ def test_is_node_addr_valid(node, instances_ips_in_cluster, expected_result):
         "down_not_term",
     ],
 )
-def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replaced, expected_result):
+def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replaced, expected_result, mocker):
     cluster_manager = ClusterManager()
-    cluster_manager.set_sync_config(mock_sync_config)
-    cluster_manager._is_node_being_replaced = MagicMock(return_value=mock_is_node_being_replaced)
+    cluster_manager._set_sync_config(mock_sync_config, initialize_instance_manager=False)
+    cluster_manager._is_node_being_replaced = mocker.MagicMock(return_value=mock_is_node_being_replaced)
     assert_that(
-        cluster_manager._is_node_state_healthy(node, instances_ip_phonebook={"placeholder phonebook"})
+        cluster_manager._is_node_state_healthy(node, private_ip_to_instance_map={"placeholder phonebook"})
     ).is_equal_to(expected_result)
 
 
 @pytest.mark.parametrize(
-    "node, instances_ip_phonebook, instance_ips_in_cluster",
+    "node, private_ip_to_instance_map, instance_ips_in_cluster, expected_result",
     [
         (
-            SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             },
             ["ip-1", "ip-2"],
-        )
+            True,
+        ),
+        (
+            SlurmNode("queue-static-c5.xlarge-1", "queue-static-c5.xlarge-1", "hostname", "IDLE+CLOUD"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            },
+            ["ip-1", "ip-2"],
+            False,
+        ),
+        (
+            SlurmNode("queue-dynamic-c5.xlarge-1", "queue-dynamic-c5.xlarge-1", "hostname", "IDLE+CLOUD"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            },
+            ["ip-1", "ip-2"],
+            True,
+        ),
+        (
+            SlurmNode("queue-dynamic-c5.xlarge-1", "ip-3", "hostname", "IDLE+CLOUD"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            },
+            ["ip-1", "ip-2"],
+            False,
+        ),
+        (
+            SlurmNode("queue-static-c5.xlarge-1", "ip-2", "hostname", "DOWN+CLOUD"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            },
+            ["ip-1", "ip-2"],
+            False,
+        ),
     ],
-    ids=["basic"],
+    ids=["basic", "static_nodeaddr_not_set", "dynamic_nodeaddr_not_set", "dynamic_unhealthy", "static_unhealthy"],
 )
-def test_is_node_healthy(node, instances_ip_phonebook, instance_ips_in_cluster):
+def test_is_node_healthy(node, private_ip_to_instance_map, instance_ips_in_cluster, expected_result, mocker):
+    mock_sync_config = SimpleNamespace(terminate_down_nodes=True)
     cluster_manager = ClusterManager()
-    cluster_manager._is_node_state_healthy = MagicMock()
-    ClusterManager._is_node_addr_valid = MagicMock()
-    cluster_manager._is_node_healthy(node, instances_ip_phonebook)
-    cluster_manager._is_node_state_healthy.assert_called_with(node, instances_ip_phonebook)
-    ClusterManager._is_node_addr_valid.assert_called_with(node, instance_ips_in_cluster=instance_ips_in_cluster)
+    cluster_manager._set_sync_config(mock_sync_config, initialize_instance_manager=False)
+    assert_that(cluster_manager._is_node_healthy(node, private_ip_to_instance_map)).is_equal_to(expected_result)
 
 
 @pytest.mark.parametrize(
@@ -610,50 +704,66 @@ def test_handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes, expected_power_
 
 
 @pytest.mark.parametrize(
-    "current_replacing_nodes, unhealthy_static_nodes, expected_replacing_nodes, applicable_node_list",
+    (
+        "current_replacing_nodes",
+        "unhealthy_static_nodes",
+        "private_ip_to_instance_map",
+        "expected_replacing_nodes",
+        "delete_instance_list",
+        "add_node_list",
+    ),
     [
         (
             {"some_current_node"},
             [
                 SlurmNode("node-1", "ip-1", "hostname", "IDLE+CLOUD"),
-                SlurmNode("node-2", "ip-1", "hostname", "IDLE+CLOUD"),
+                SlurmNode("node-2", "ip-2", "hostname", "IDLE+CLOUD"),
+                SlurmNode("node-3", "ip-3", "hostname", "IDLE+CLOUD"),
             ],
-            {"some_current_node", "node-1", "node-2"},
-            ["node-1", "node-2"],
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "some_launch_time"),
+            },
+            {"some_current_node", "node-1", "node-2", "node-3"},
+            ["id-1", "id-2"],
+            ["node-1", "node-2", "node-3"],
         )
     ],
     ids=["basic"],
 )
 def test_handle_unhealthy_static_nodes(
-    current_replacing_nodes, unhealthy_static_nodes, expected_replacing_nodes, applicable_node_list, mocker
+    current_replacing_nodes,
+    unhealthy_static_nodes,
+    private_ip_to_instance_map,
+    expected_replacing_nodes,
+    delete_instance_list,
+    add_node_list,
+    mocker,
 ):
     # Test setup
     mock_sync_config = SimpleNamespace(
         terminate_max_batch_size=1,
         launch_max_batch_size=5,
         update_node_address=False,
-        instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+        region="us-east-2",
+        cluster_name="hit-test",
+        boto3_config="some config",
     )
     cluster_manager = ClusterManager()
-    cluster_manager.set_sync_config(mock_sync_config)
-    cluster_manager._set_replacing_nodes(current_replacing_nodes)
+    cluster_manager._set_sync_config(mock_sync_config)
+    cluster_manager._initialize_instance_manager()
+    cluster_manager._set_static_nodes_in_replacement(current_replacing_nodes)
     # Mock associated function
-    cluster_manager.sync_config.instance_manager.terminate_associated_instances = MagicMock()
-    cluster_manager.sync_config.instance_manager.add_instances_for_nodes = MagicMock()
+    cluster_manager.instance_manager.delete_instances = mocker.MagicMock()
+    cluster_manager.instance_manager.add_instances_for_nodes = mocker.MagicMock()
     update_mock = mocker.patch("slurm_plugin.clustermgtd.set_nodes_down", return_value=None, autospec=True)
     # Run test
-    cluster_manager._handle_unhealthy_static_nodes(unhealthy_static_nodes)
+    cluster_manager._handle_unhealthy_static_nodes(unhealthy_static_nodes, private_ip_to_instance_map)
     # Assert calls
-    update_mock.assert_called_with(
-        applicable_node_list, reason="Static node maintenance: unhealthy node is being replaced"
-    )
-    cluster_manager.sync_config.instance_manager.terminate_associated_instances.assert_called_with(
-        unhealthy_static_nodes, terminate_batch_size=1
-    )
-    cluster_manager.sync_config.instance_manager.add_instances_for_nodes.assert_called_with(
-        applicable_node_list, 5, False
-    )
-    assert_that(cluster_manager.replacing_nodes).is_equal_to(expected_replacing_nodes)
+    update_mock.assert_called_with(add_node_list, reason="Static node maintenance: unhealthy node is being replaced")
+    cluster_manager.instance_manager.delete_instances.assert_called_with(delete_instance_list, terminate_batch_size=1)
+    cluster_manager.instance_manager.add_instances_for_nodes.assert_called_with(add_node_list, 5, False)
+    assert_that(cluster_manager.static_nodes_in_replacement).is_equal_to(expected_replacing_nodes)
 
 
 @pytest.mark.parametrize(
@@ -679,25 +789,29 @@ def test_handle_unhealthy_static_nodes(
     ],
     ids=["basic", "repetitive_ip"],
 )
-def test_maintain_nodes(cluster_instances, active_nodes, mock_unhealthy_nodes):
+def test_maintain_nodes(cluster_instances, active_nodes, mock_unhealthy_nodes, mocker):
     # Mock functions
-    mock_instances_ip_phonebook = {instance.private_ip: instance for instance in cluster_instances}
+    mock_private_ip_to_instance_map = {instance.private_ip: instance for instance in cluster_instances}
     cluster_manager = ClusterManager()
-    cluster_manager._update_replacing_nodes = MagicMock()
-    cluster_manager._find_unhealthy_slurm_nodes = MagicMock(return_value=mock_unhealthy_nodes)
-    ClusterManager._handle_unhealthy_dynamic_nodes = MagicMock()
-    cluster_manager._handle_unhealthy_static_nodes = MagicMock()
+    cluster_manager._update_static_nodes_in_replacement = mocker.MagicMock()
+    cluster_manager._find_unhealthy_slurm_nodes = mocker.MagicMock(return_value=mock_unhealthy_nodes)
+    mock_handle_unhealthy_dynamic_nodes = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._handle_unhealthy_dynamic_nodes"
+    )
+    cluster_manager._handle_unhealthy_static_nodes = mocker.MagicMock()
     # Run test
     cluster_manager._maintain_nodes(cluster_instances, active_nodes)
     # Check function calls
-    cluster_manager._update_replacing_nodes.assert_called_with(active_nodes)
-    cluster_manager._find_unhealthy_slurm_nodes.assert_called_with(active_nodes, mock_instances_ip_phonebook)
-    ClusterManager._handle_unhealthy_dynamic_nodes(mock_unhealthy_nodes[0])
-    cluster_manager._handle_unhealthy_static_nodes(mock_unhealthy_nodes[1])
+    cluster_manager._update_static_nodes_in_replacement.assert_called_with(active_nodes)
+    cluster_manager._find_unhealthy_slurm_nodes.assert_called_with(active_nodes, mock_private_ip_to_instance_map)
+    mock_handle_unhealthy_dynamic_nodes.assert_called_with(mock_unhealthy_nodes[0])
+    cluster_manager._handle_unhealthy_static_nodes.assert_called_with(
+        mock_unhealthy_nodes[1], mock_private_ip_to_instance_map
+    )
 
 
 @pytest.mark.parametrize(
-    "cluster_instances, instances_ip_phonebook, current_time, expected_instance_to_terminate",
+    "cluster_instances, private_ip_to_instance_map, current_time, expected_instance_to_terminate",
     [
         (
             [
@@ -730,23 +844,26 @@ def test_maintain_nodes(cluster_instances, active_nodes, mock_unhealthy_nodes):
     ids=["all_good", "orphaned", "orphaned_timeout"],
 )
 def test_terminate_orphaned_instances(
-    cluster_instances, instances_ip_phonebook, current_time, expected_instance_to_terminate
+    cluster_instances, private_ip_to_instance_map, current_time, expected_instance_to_terminate, mocker
 ):
     # Mock functions
     cluster_manager = ClusterManager()
     mock_sync_config = SimpleNamespace(
         orphaned_instance_timeout=30,
         terminate_max_batch_size=4,
-        instance_manager=InstanceManager("region", "cluster_name", "boto3_config"),
+        region="us-east-2",
+        cluster_name="hit-test",
+        boto3_config="some config",
     )
-    cluster_manager.set_sync_config(mock_sync_config)
-    cluster_manager.set_current_time(current_time)
-    cluster_manager.sync_config.instance_manager.delete_instances = MagicMock()
+    cluster_manager._set_sync_config(mock_sync_config)
+    cluster_manager._initialize_instance_manager()
+    cluster_manager._set_current_time(current_time)
+    cluster_manager.instance_manager.delete_instances = mocker.MagicMock()
     # Run test
-    cluster_manager._terminate_orphaned_instances(cluster_instances, instances_ip_phonebook)
+    cluster_manager._terminate_orphaned_instances(cluster_instances, private_ip_to_instance_map)
     # Check function calls
     if expected_instance_to_terminate:
-        cluster_manager.sync_config.instance_manager.delete_instances.assert_called_with(
+        cluster_manager.instance_manager.delete_instances.assert_called_with(
             expected_instance_to_terminate, terminate_batch_size=4
         )
 
@@ -838,43 +955,53 @@ def test_time_is_up(initial_time, current_time, grace_time, expected_result):
     ids=["all_enabled", "disable_all", "disable_health_check", "no_active", "no_node"],
 )
 def test_manage_cluster(
-    disable_cluster_management, disable_health_check, mock_cluster_instances, mock_active_nodes, mock_inactive_nodes
+    disable_cluster_management,
+    disable_health_check,
+    mock_cluster_instances,
+    mock_active_nodes,
+    mock_inactive_nodes,
+    mocker,
 ):
     mock_sync_config = SimpleNamespace(
-        disable_all_cluster_management=disable_cluster_management, disable_all_health_checks=disable_health_check
+        disable_all_cluster_management=disable_cluster_management,
+        disable_all_health_checks=disable_health_check,
+        region="us-east-2",
+        cluster_name="hit-test",
+        boto3_config="NONE",
     )
-    slurm_nodes_ip_phonebook = {node.nodeaddr: node for node in mock_active_nodes}
+    ip_to_slurm_node_map = {node.nodeaddr: node for node in mock_active_nodes}
     current_time = datetime(2020, 1, 1, 0, 0, 0)
     cluster_manager = ClusterManager()
     # Set up function mocks
-    cluster_manager.set_sync_config = MagicMock()
-    cluster_manager.set_current_time = MagicMock()
-    cluster_manager._write_timestamp_to_file = MagicMock()
-    cluster_manager._perform_health_check_actions = MagicMock()
-    cluster_manager._clean_up_inactive_partition = MagicMock()
-    cluster_manager._terminate_orphaned_instances = MagicMock()
-    cluster_manager._maintain_nodes = MagicMock()
-    ClusterManager._get_node_info_from_partition = MagicMock()
-    cluster_manager._get_ec2_states = MagicMock()
-    ClusterManager._get_node_info_from_partition = MagicMock(return_value=(mock_active_nodes, mock_inactive_nodes))
-    cluster_manager._get_ec2_states = MagicMock(return_value=mock_cluster_instances)
+    cluster_manager._initialize_instance_manager = mocker.MagicMock()
+    cluster_manager._set_current_time = mocker.MagicMock(side_effect=cluster_manager._set_current_time(current_time))
+    cluster_manager._write_timestamp_to_file = mocker.MagicMock().patch()
+    cluster_manager._perform_health_check_actions = mocker.MagicMock().patch()
+    cluster_manager._clean_up_inactive_partition = mocker.MagicMock().patch()
+    cluster_manager._terminate_orphaned_instances = mocker.MagicMock().patch()
+    cluster_manager._maintain_nodes = mocker.MagicMock().patch()
+    mock_get_node_info_from_partition = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._get_node_info_from_partition",
+        return_value=(mock_active_nodes, mock_inactive_nodes),
+    )
+    cluster_manager._get_ec2_instances = mocker.MagicMock(return_value=mock_cluster_instances)
     # Run test
-    cluster_manager.manage_cluster(mock_sync_config, current_time)
+    cluster_manager.manage_cluster(mock_sync_config)
     # Assert function calls
-    cluster_manager.set_sync_config.assert_called_with(mock_sync_config)
-    cluster_manager.set_current_time.assert_called_with(current_time)
-    cluster_manager._write_timestamp_to_file.assert_called()
+    cluster_manager._initialize_instance_manager.assert_called_once()
+    cluster_manager._set_current_time.assert_called_once()
+    cluster_manager._write_timestamp_to_file.assert_called_once()
     if disable_cluster_management:
         cluster_manager._perform_health_check_actions.assert_not_called()
         cluster_manager._clean_up_inactive_partition.assert_not_called()
         cluster_manager._terminate_orphaned_instances.assert_not_called()
         cluster_manager._maintain_nodes.assert_not_called()
-        ClusterManager._get_node_info_from_partition.assert_not_called()
-        cluster_manager._get_ec2_states.assert_not_called()
+        mock_get_node_info_from_partition.assert_not_called()
+        cluster_manager._get_ec2_instances.assert_not_called()
         return
     if mock_inactive_nodes:
         cluster_manager._clean_up_inactive_partition.assert_called_with(mock_inactive_nodes)
-    cluster_manager._get_ec2_states.assert_called()
+    cluster_manager._get_ec2_instances.assert_called_once()
     if not mock_active_nodes:
         cluster_manager._terminate_orphaned_instances.assert_called_with(mock_cluster_instances, ips_used_by_slurm=[])
         cluster_manager._perform_health_check_actions.assert_not_called()
@@ -883,10 +1010,407 @@ def test_manage_cluster(
     if disable_health_check:
         cluster_manager._perform_health_check_actions.assert_not_called()
     else:
-        cluster_manager._perform_health_check_actions.assert_called_with(
-            mock_cluster_instances, slurm_nodes_ip_phonebook
-        )
+        cluster_manager._perform_health_check_actions.assert_called_with(mock_cluster_instances, ip_to_slurm_node_map)
     cluster_manager._maintain_nodes.assert_called_with(mock_cluster_instances, mock_active_nodes)
     cluster_manager._terminate_orphaned_instances.assert_called_with(
-        mock_cluster_instances, ips_used_by_slurm=list(slurm_nodes_ip_phonebook.keys())
+        mock_cluster_instances, ips_used_by_slurm=list(ip_to_slurm_node_map.keys())
     )
+
+
+@pytest.mark.parametrize(
+    "config_file, mocked_active_nodes, mocked_inactive_nodes, mocked_boto3_request",
+    [
+        (
+            # basic: This is the most comprehensive case in manage_cluster with max number of boto3 calls
+            "default.conf",
+            [
+                SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+            ],
+            [
+                SlurmNode("queue-static-c5.xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+            ],
+            [
+                # _clean_up_inactive_partition/terminate_associated_instances: get instances from inactive node IPs
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-4",
+                                        "PrivateIpAddress": "ip-4",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "private-ip-address", "Values": ["ip-4", "ip-5"]},
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _clean_up_inactive_partition/terminate_associated_instances: delete inactive instances
+                MockedBoto3Request(
+                    method="terminate_instances",
+                    response={},
+                    expected_params={"InstanceIds": ["i-4"]},
+                    generate_error=False,
+                ),
+                # _get_ec2_instances: get all cluster instances by tags
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-1",
+                                        "PrivateIpAddress": "ip-1",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                    {
+                                        "InstanceId": "i-2",
+                                        "PrivateIpAddress": "ip-2",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                    {
+                                        "InstanceId": "i-3",
+                                        "PrivateIpAddress": "ip-3",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                    # Return an orphaned instance
+                                    {
+                                        "InstanceId": "i-999",
+                                        "PrivateIpAddress": "ip-999",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                ]
+                            }
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                            {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
+                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _perform_health_check_actions: get unhealthy instance status by instance status filter
+                MockedBoto3Request(
+                    method="describe_instance_status",
+                    response={"InstanceStatuses": []},
+                    expected_params={
+                        "Filters": [
+                            {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _perform_health_check_actions: get unhealthy instance status by system status filter
+                MockedBoto3Request(
+                    method="describe_instance_status",
+                    response={"InstanceStatuses": []},
+                    expected_params={
+                        "Filters": [
+                            {"Name": "system-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _perform_health_check_actions: get unhealthy instance status by schedule event filter
+                # Produce an error, cluster should be able to handle exception and move on
+                MockedBoto3Request(
+                    method="describe_instance_status",
+                    response={"InstanceStatuses": []},
+                    expected_params={"Filters": [{"Name": "event.code", "Values": EC2_SCHEDULED_EVENT_CODES}]},
+                    generate_error=True,
+                ),
+                # _maintain_nodes/delete_instances: terminate static down nodes
+                # dynamic down nodes are handled with suspend script, and its boto3 call should not be reflected here
+                MockedBoto3Request(
+                    method="terminate_instances",
+                    response={},
+                    expected_params={"InstanceIds": ["i-1"]},
+                    generate_error=False,
+                ),
+                # _terminate_orphaned_instances: terminate orphaned instances
+                MockedBoto3Request(
+                    method="terminate_instances",
+                    response={},
+                    expected_params={"InstanceIds": ["i-999"]},
+                    generate_error=False,
+                ),
+            ],
+        ),
+        (
+            # failures: All failure tolerant module will have an exception, but the program should not crash
+            "default.conf",
+            [
+                SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+            ],
+            [
+                SlurmNode("queue-static-c5.xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+            ],
+            [
+                # _clean_up_inactive_partition/terminate_associated_instances: get instances from inactive node IPs
+                # Not produce failure at this point, so next call is executed
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-4",
+                                        "PrivateIpAddress": "ip-4",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "private-ip-address", "Values": ["ip-4", "ip-5"]},
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _clean_up_inactive_partition/terminate_associated_instances: delete inactive instances
+                # Produce an error, cluster should be able to handle exception and move on
+                MockedBoto3Request(
+                    method="terminate_instances",
+                    response={},
+                    expected_params={"InstanceIds": ["i-4"]},
+                    generate_error=True,
+                ),
+                # _get_ec2_instances: get all cluster instances by tags
+                # Not producing failure here so logic after can be executed
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-1",
+                                        "PrivateIpAddress": "ip-1",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                    {
+                                        "InstanceId": "i-2",
+                                        "PrivateIpAddress": "ip-2",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                    {
+                                        "InstanceId": "i-3",
+                                        "PrivateIpAddress": "ip-3",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                    # Return an orphaned instance
+                                    {
+                                        "InstanceId": "i-999",
+                                        "PrivateIpAddress": "ip-999",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                ]
+                            }
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                            {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
+                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _perform_health_check_actions: get unhealthy instance status by instance status filter
+                MockedBoto3Request(
+                    method="describe_instance_status",
+                    response={
+                        "InstanceStatuses": [
+                            {
+                                "InstanceId": "i-1",
+                                "InstanceState": {"Name": "running"},
+                                "InstanceStatus": {"Status": "impaired"},
+                                "SystemStatus": {"Status": "ok"},
+                            },
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _perform_health_check_actions: get unhealthy instance status by system status filter
+                MockedBoto3Request(
+                    method="describe_instance_status",
+                    response={
+                        "InstanceStatuses": [
+                            {
+                                "InstanceId": "i-2",
+                                "InstanceState": {"Name": "pending"},
+                                "InstanceStatus": {"Status": "initializing"},
+                                "SystemStatus": {"Status": "impaired"},
+                                "Events": [{"InstanceEventId": "event-id-1"}],
+                            },
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "system-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _perform_health_check_actions: get unhealthy instance status by schedule event filter
+                # Produce an error, cluster should be able to handle exception and move on
+                MockedBoto3Request(
+                    method="describe_instance_status",
+                    response={},
+                    expected_params={"Filters": [{"Name": "event.code", "Values": EC2_SCHEDULED_EVENT_CODES}]},
+                    generate_error=True,
+                ),
+                # _maintain_nodes/delete_instances: terminate static down nodes
+                # dynamic down nodes are handled with suspend script, and its boto3 call should not be reflected here
+                # Produce an error, cluster should be able to handle exception and move on
+                MockedBoto3Request(
+                    method="terminate_instances",
+                    response={},
+                    expected_params={"InstanceIds": ["i-1"]},
+                    generate_error=True,
+                ),
+                # _terminate_orphaned_instances: terminate orphaned instances
+                # Produce an error, cluster should be able to handle exception and move on
+                MockedBoto3Request(
+                    method="terminate_instances",
+                    response={},
+                    expected_params={"InstanceIds": ["i-999"]},
+                    generate_error=True,
+                ),
+            ],
+        ),
+        (
+            # critical_failure_1: _get_ec2_instances will have an exception, but the program should not crash
+            "default.conf",
+            [
+                SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+            ],
+            [
+                SlurmNode("queue-static-c5.xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dynamic-c5.xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+            ],
+            [
+                # _clean_up_inactive_partition/terminate_associated_instances: get instances from inactive node IPs
+                # Not produce failure at this point, so next call is executed
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-4",
+                                        "PrivateIpAddress": "ip-4",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "private-ip-address", "Values": ["ip-4", "ip-5"]},
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                        ]
+                    },
+                    generate_error=False,
+                ),
+                # _clean_up_inactive_partition/terminate_associated_instances: delete inactive instances
+                # Produce an error, cluster should be able to handle exception and move on
+                MockedBoto3Request(
+                    method="terminate_instances",
+                    response={},
+                    expected_params={"InstanceIds": ["i-4"]},
+                    generate_error=True,
+                ),
+                # _get_ec2_instances: get all cluster instances by tags
+                # Produce an error, cluster should be able to handle exception and skip other actions
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={},
+                    expected_params={
+                        "Filters": [
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                            {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
+                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                        ]
+                    },
+                    generate_error=True,
+                ),
+            ],
+        ),
+        (
+            # critical_failure_2: _get_node_info_from_partition will have an exception, but the program should not crash
+            "default.conf",
+            Exception,
+            Exception,
+            [],
+        ),
+    ],
+    ids=["basic", "failures", "critical_failure_1", "critical_failure_2"],
+)
+def test_manage_cluster_boto3(
+    boto3_stubber, config_file, mocked_active_nodes, mocked_inactive_nodes, mocked_boto3_request, test_datadir, mocker
+):
+    # This test only patches I/O and boto3 calls to ensure that all boto3 calls are expected
+    mocker.patch("subprocess.run")
+    # patch boto3 call
+    boto3_stubber("ec2", mocked_boto3_request)
+    current_time = datetime(2020, 1, 2, 0, 0, 0)
+    cluster_manager = ClusterManager()
+    cluster_manager._set_current_time = mocker.MagicMock(side_effect=cluster_manager._set_current_time(current_time))
+    cluster_manager._write_timestamp_to_file = mocker.MagicMock().patch()
+    sync_config = ClustermgtdConfig(test_datadir / config_file)
+    if mocked_active_nodes is Exception or mocked_active_nodes is Exception:
+        mocker.patch(
+            "slurm_plugin.clustermgtd.ClusterManager._get_node_info_from_partition",
+            side_effect=ClusterManager.SchedulerUnavailable,
+        )
+    else:
+        mocker.patch(
+            "slurm_plugin.clustermgtd.ClusterManager._get_node_info_from_partition",
+            return_value=(mocked_active_nodes, mocked_inactive_nodes),
+        )
+    cluster_manager.manage_cluster(sync_config)

--- a/tests/slurm_plugin/test_clustermgtd/test_clustermgtd_config/all_options.conf
+++ b/tests/slurm_plugin/test_clustermgtd/test_clustermgtd_config/all_options.conf
@@ -1,0 +1,19 @@
+[clustermgtd]
+cluster_name = hit
+region = us-east-1
+heartbeat_file_path = /home/ubuntu/clustermgtd_heartbeat
+loop_time = 60
+disable_all_cluster_management = true
+proxy = https://fake.proxy
+logging_config = /my/logging/config
+update_node_address = false
+launch_max_batch_size = 1
+terminate_max_batch_size = 500
+node_replacement_timeout = 10
+terminate_drain_nodes = false
+terminate_down_nodes = false
+orphaned_instance_timeout = 60
+disable_ec2_health_check = True
+disable_scheduled_event_health_check = True
+disable_all_health_checks = False
+health_check_timeout = 10

--- a/tests/slurm_plugin/test_clustermgtd/test_clustermgtd_config/default.conf
+++ b/tests/slurm_plugin/test_clustermgtd/test_clustermgtd_config/default.conf
@@ -1,0 +1,4 @@
+[clustermgtd]
+cluster_name = hit
+region = us-east-2
+heartbeat_file_path = /home/ec2-user/clustermgtd_heartbeat

--- a/tests/slurm_plugin/test_clustermgtd/test_clustermgtd_config/health_check.conf
+++ b/tests/slurm_plugin/test_clustermgtd/test_clustermgtd_config/health_check.conf
@@ -1,0 +1,18 @@
+[clustermgtd]
+cluster_name = hit
+region = us-east-1
+heartbeat_file_path = /home/ubuntu/clustermgtd_heartbeat
+loop_time = 60
+disable_all_cluster_management = true
+proxy = https://fake.proxy
+logging_config = /my/logging/config
+update_node_address = false
+launch_max_batch_size = 1
+terminate_max_batch_size = 500
+node_replacement_timeout = 10
+terminate_drain_nodes = false
+terminate_down_nodes = false
+orphaned_instance_timeout = 60
+disable_ec2_health_check = True
+disable_scheduled_event_health_check = True
+health_check_timeout = 10

--- a/tests/slurm_plugin/test_clustermgtd/test_manage_cluster_boto3/default.conf
+++ b/tests/slurm_plugin/test_clustermgtd/test_manage_cluster_boto3/default.conf
@@ -1,0 +1,4 @@
+[clustermgtd]
+cluster_name = hit
+region = us-east-2
+heartbeat_file_path = /home/ec2-user/clustermgtd_heartbeat

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -505,8 +505,9 @@ def test_parse_requested_instances(node_list, expected_results, expected_failed_
 def test_delete_instances(boto3_stubber, instance_ids_to_name, batch_size, mocked_boto3_request, mocker):
     # patch boto3 call
     boto3_stubber("ec2", mocked_boto3_request)
+    mock_instance_manager = InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",)
     # run test
-    InstanceManager.delete_instances(instance_ids_to_name, "us-east-1", "some_boto_3_config", batch_size)
+    mock_instance_manager.delete_instances(instance_ids_to_name, batch_size)
 
 
 @pytest.mark.parametrize(

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -546,6 +546,7 @@ def test_delete_instances(boto3_stubber, instance_ids_to_name, batch_size, mocke
                             {"Name": "private-ip-address", "Values": ["ip.1", "ip.2", "ip.3"]},
                             {"Name": "tag:ClusterName", "Values": ["hit-test"]},
                         ],
+                        "MaxResults": 1000,
                     },
                 ),
             ],
@@ -579,6 +580,7 @@ def test_delete_instances(boto3_stubber, instance_ids_to_name, batch_size, mocke
                             {"Name": "private-ip-address", "Values": ["ip.1", "ip.2", "ip.3"]},
                             {"Name": "tag:ClusterName", "Values": ["hit-test"]},
                         ],
+                        "MaxResults": 1000,
                     },
                 ),
             ],
@@ -624,7 +626,8 @@ def test_get_instance_ids_to_nodename(slurm_nodes, mocked_boto3_request, expecte
                     expected_params={
                         "Filters": [
                             {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
-                        ]
+                        ],
+                        "MaxResults": 1000,
                     },
                     generate_error=False,
                 ),
@@ -643,7 +646,8 @@ def test_get_instance_ids_to_nodename(slurm_nodes, mocked_boto3_request, expecte
                     expected_params={
                         "Filters": [
                             {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
-                        ]
+                        ],
+                        "MaxResults": 1000,
                     },
                     generate_error=False,
                 ),
@@ -663,7 +667,8 @@ def test_get_instance_ids_to_nodename(slurm_nodes, mocked_boto3_request, expecte
                     expected_params={
                         "Filters": [
                             {"Name": "system-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
-                        ]
+                        ],
+                        "MaxResults": 1000,
                     },
                     generate_error=False,
                 ),
@@ -680,7 +685,10 @@ def test_get_instance_ids_to_nodename(slurm_nodes, mocked_boto3_request, expecte
                             },
                         ]
                     },
-                    expected_params={"Filters": [{"Name": "event.code", "Values": EC2_SCHEDULED_EVENT_CODES}]},
+                    expected_params={
+                        "Filters": [{"Name": "event.code", "Values": EC2_SCHEDULED_EVENT_CODES}],
+                        "MaxResults": 1000,
+                    },
                     generate_error=False,
                 ),
             ],
@@ -738,7 +746,8 @@ def get_unhealthy_cluster_instance_status(instance_ids, mocked_boto3_request, ex
                         {"Name": "tag:ClusterName", "Values": ["hit-test"]},
                         {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
                         {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
-                    ]
+                    ],
+                    "MaxResults": 1000,
                 },
                 generate_error=False,
             ),
@@ -757,7 +766,8 @@ def get_unhealthy_cluster_instance_status(instance_ids, mocked_boto3_request, ex
                         {"Name": "tag:ClusterName", "Values": ["hit-test"]},
                         {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
                         {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
-                    ]
+                    ],
+                    "MaxResults": 1000,
                 },
                 generate_error=False,
             ),
@@ -781,7 +791,7 @@ def get_unhealthy_cluster_instance_status(instance_ids, mocked_boto3_request, ex
                         }
                     ]
                 },
-                expected_params={"Filters": [{"Name": "tag:ClusterName", "Values": ["hit-test"]}]},
+                expected_params={"Filters": [{"Name": "tag:ClusterName", "Values": ["hit-test"]}], "MaxResults": 1000},
                 generate_error=False,
             ),
             [EC2Instance("i-1", "ip-1", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc))],


### PR DESCRIPTION
* Cluster management daemon is used to sync scheduler states with EC2 states, and has the following functionalities:
* Clean up INACTIVE partitions
* Maintain any node with unhealthy EC2 states
* Maintain any node with unhealthy scheduler states
* Clean up orphaned resources not included in scheduler configuration
* Add unit tests to cover newly added functionalities


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
