### PR TITLE
Register new nodes in DynamoDB and Route53

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -278,7 +278,7 @@ def get_nodes_info(nodes, command_timeout=5):
     """
     Retrieve SlurmNode list from slurm nodelist notation.
 
-    Sample slurm nodelist notation: queue1-dynamic-c5.xlarge-[1-3],queue2-static-t2.micro-5.
+    Sample slurm nodelist notation: queue1-dynamic-c5_xlarge-[1-3],queue2-static-t2_micro-5.
     """
     show_node_info_command = (
         f'{SCONTROL} show nodes {nodes} | grep -oP "^NodeName=\\K(\\S+)| '

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -673,7 +673,7 @@ class ClusterManager:
                 node, instance_ips_in_cluster=list(private_ip_to_instance_map.keys())
             ) and self._is_node_state_healthy(node, private_ip_to_instance_map)
 
-    @log_exception(log, "maintaining unhealthy dynamic nodes", catch_exception=Exception, raise_on_error=False)
+    @log_exception(log, "maintaining unhealthy dynamic nodes", raise_on_error=False)
     def _handle_unhealthy_dynamic_nodes(self, unhealthy_dynamic_nodes, private_ip_to_instance_map):
         """
         Maintain any unhealthy dynamic node.
@@ -705,7 +705,7 @@ class ClusterManager:
 
         return list(backing_instances)
 
-    @log_exception(log, "maintaining unhealthy static nodes", catch_exception=Exception, raise_on_error=False)
+    @log_exception(log, "maintaining unhealthy static nodes", raise_on_error=False)
     def _handle_unhealthy_static_nodes(self, unhealthy_static_nodes, private_ip_to_instance_map):
         """
         Maintain any unhealthy static node.

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -53,6 +53,9 @@ class SlurmResumeConfig:
 
         self.region = config.get("slurm_resume", "region")
         self.cluster_name = config.get("slurm_resume", "cluster_name")
+        self.dynamodb_table = config.get("slurm_resume", "dynamodb_table")
+        self.hosted_zone = config.get("slurm_resume", "hosted_zone")
+        self.dns_domain = config.get("slurm_resume", "dns_domain")
         self.max_batch_size = config.getint(
             "slurm_resume", "max_batch_size", fallback=self.DEFAULTS.get("max_batch_size")
         )
@@ -99,7 +102,14 @@ def _resume(arg_nodes, resume_config):
     node_list = [node.name for node in get_nodes_info(arg_nodes)]
     log.debug("Retrieved nodelist: %s", node_list)
 
-    instance_manager = InstanceManager(resume_config.region, resume_config.cluster_name, resume_config.boto3_config)
+    instance_manager = InstanceManager(
+        resume_config.region,
+        resume_config.cluster_name,
+        resume_config.boto3_config,
+        resume_config.dynamodb_table,
+        resume_config.hosted_zone,
+        resume_config.dns_domain,
+    )
     instance_manager.add_instances_for_nodes(node_list, resume_config.max_batch_size, resume_config.update_node_address)
     success_nodes = [node for node in node_list if node not in instance_manager.failed_nodes]
     log.info("Successfully launched nodes %s", print_with_count(success_nodes))

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -721,26 +721,26 @@ def test_get_pending_jobs_info(
     [
         (
             (
-                "multiple-dynamic-c5.xlarge-1\n"
+                "multiple-dynamic-c5-xlarge-1\n"
                 "172.31.10.155\n"
                 "172-31-10-155\n"
                 "MIXED+CLOUD\n"
-                "multiple-dynamic-c5.xlarge-2\n"
+                "multiple-dynamic-c5-xlarge-2\n"
                 "172.31.7.218\n"
                 "172-31-7-218\n"
                 "IDLE+CLOUD+POWER\n"
-                "multiple-dynamic-c5.xlarge-3\n"
-                "multiple-dynamic-c5.xlarge-3\n"
-                "multiple-dynamic-c5.xlarge-3\n"
+                "multiple-dynamic-c5-xlarge-3\n"
+                "multiple-dynamic-c5-xlarge-3\n"
+                "multiple-dynamic-c5-xlarge-3\n"
                 "IDLE+CLOUD+POWER"
             ),
             [
-                SlurmNode("multiple-dynamic-c5.xlarge-1", "172.31.10.155", "172-31-10-155", "MIXED+CLOUD"),
-                SlurmNode("multiple-dynamic-c5.xlarge-2", "172.31.7.218", "172-31-7-218", "IDLE+CLOUD+POWER"),
+                SlurmNode("multiple-dynamic-c5-xlarge-1", "172.31.10.155", "172-31-10-155", "MIXED+CLOUD"),
+                SlurmNode("multiple-dynamic-c5-xlarge-2", "172.31.7.218", "172-31-7-218", "IDLE+CLOUD+POWER"),
                 SlurmNode(
-                    "multiple-dynamic-c5.xlarge-3",
-                    "multiple-dynamic-c5.xlarge-3",
-                    "multiple-dynamic-c5.xlarge-3",
+                    "multiple-dynamic-c5-xlarge-3",
+                    "multiple-dynamic-c5-xlarge-3",
+                    "multiple-dynamic-c5-xlarge-3",
                     "IDLE+CLOUD+POWER",
                 ),
             ],

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -297,7 +297,9 @@ def test_clean_up_inactive_parititon(
 @pytest.mark.usefixtures("initialize_compute_fleet_status_manager_mock")
 def test_get_ec2_instances(mocker):
     # Test setup
-    mock_sync_config = SimpleNamespace(region="us-east-2", cluster_name="hit-test", boto3_config="some config")
+    mock_sync_config = SimpleNamespace(
+        region="us-east-2", cluster_name="hit-test", boto3_config=botocore.config.Config()
+    )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._instance_manager.get_cluster_instances = mocker.MagicMock()
     # Run test
@@ -396,7 +398,7 @@ def test_perform_health_check_actions(
         disable_scheduled_event_health_check=disable_scheduled_event_health_check,
         region="us-east-2",
         cluster_name="hit-test",
-        boto3_config="some config",
+        boto3_config=botocore.config.Config(),
         dynamodb_table="table_name",
     )
     # Mock functions
@@ -642,8 +644,8 @@ def test_is_node_being_replaced(
 @pytest.mark.parametrize(
     "node, expected_result",
     [
-        (SlurmNode("node-static-c5.xlarge-1", "node-static-c5.xlarge-1", "hostname", "IDLE+CLOUD"), False),
-        (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), True),
+        (SlurmNode("node-static-c5-xlarge-1", "node-static-c5-xlarge-1", "hostname", "IDLE+CLOUD"), False),
+        (SlurmNode("node-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), True),
     ],
     ids=["static_addr_not_set", "static_valid"],
 )
@@ -654,14 +656,14 @@ def test_is_static_node_configuration_valid(node, expected_result):
 @pytest.mark.parametrize(
     "node, instances_ips_in_cluster, expected_result",
     [
-        (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), ["ip-2"], False,),
+        (SlurmNode("node-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), ["ip-2"], False,),
         (
-            SlurmNode("node-dynamic-c5.xlarge-1", "node-dynamic-c5.xlarge-1", "hostname", "IDLE+CLOUD+POWER"),
+            SlurmNode("node-dynamic-c5-xlarge-1", "node-dynamic-c5-xlarge-1", "hostname", "IDLE+CLOUD+POWER"),
             ["ip-2"],
             True,
         ),
-        (SlurmNode("node-dynamic-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-2"], False,),
-        (SlurmNode("node-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-1"], True,),
+        (SlurmNode("node-dynamic-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-2"], False,),
+        (SlurmNode("node-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"), ["ip-1"], True,),
     ],
     ids=["static_no_backing", "dynamic_power_save", "dynamic_no_backing", "static_valid"],
 )
@@ -738,7 +740,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
     "node, private_ip_to_instance_map, instance_ips_in_cluster, expected_result",
     [
         (
-            SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -747,7 +749,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             True,
         ),
         (
-            SlurmNode("queue-static-c5.xlarge-1", "queue-static-c5.xlarge-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-static-c5-xlarge-1", "queue-static-c5-xlarge-1", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -756,7 +758,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             False,
         ),
         (
-            SlurmNode("queue-dynamic-c5.xlarge-1", "queue-dynamic-c5.xlarge-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-dynamic-c5-xlarge-1", "queue-dynamic-c5-xlarge-1", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -765,7 +767,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             True,
         ),
         (
-            SlurmNode("queue-dynamic-c5.xlarge-1", "ip-3", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-dynamic-c5-xlarge-1", "ip-3", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -774,7 +776,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             False,
         ),
         (
-            SlurmNode("queue-static-c5.xlarge-1", "ip-2", "hostname", "DOWN+CLOUD"),
+            SlurmNode("queue-static-c5-xlarge-1", "ip-2", "hostname", "DOWN+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -907,6 +909,8 @@ def test_handle_unhealthy_static_nodes(
     delete_instance_list,
     add_node_list,
     mocker,
+    caplog,
+    request,
 ):
     # Test setup
     mock_sync_config = SimpleNamespace(
@@ -915,10 +919,11 @@ def test_handle_unhealthy_static_nodes(
         update_node_address=True,
         region="us-east-2",
         cluster_name="hit-test",
-        boto3_config="some config",
+        boto3_config=botocore.config.Config(),
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._static_nodes_in_replacement = current_replacing_nodes
+
     # Mock associated function
     cluster_manager._instance_manager.delete_instances = mocker.MagicMock()
     cluster_manager._instance_manager._parse_requested_instances = mocker.MagicMock(
@@ -926,6 +931,8 @@ def test_handle_unhealthy_static_nodes(
     )
     cluster_manager._instance_manager._launch_ec2_instances = mocker.MagicMock(return_value=launched_instances)
     mocker.patch("slurm_plugin.common.update_nodes")
+    cluster_manager._instance_manager._store_assigned_hostnames = mocker.MagicMock()
+    cluster_manager._instance_manager._update_dns_hostnames = mocker.MagicMock()
     # Mock add_instances_for_nodes but still try to execute original code
     original_add_instances = cluster_manager._instance_manager.add_instances_for_nodes
     cluster_manager._instance_manager.add_instances_for_nodes = mocker.MagicMock(side_effect=original_add_instances)
@@ -941,6 +948,8 @@ def test_handle_unhealthy_static_nodes(
     else:
         cluster_manager._instance_manager.delete_instances.assert_not_called()
     cluster_manager._instance_manager.add_instances_for_nodes.assert_called_with(add_node_list, 5, True)
+    if "partial_launch" not in request.node.name:
+        assert_that(caplog.text).is_empty()
     assert_that(cluster_manager._static_nodes_in_replacement).is_equal_to(expected_replacing_nodes)
 
 
@@ -1057,7 +1066,7 @@ def test_terminate_orphaned_instances(
         terminate_max_batch_size=4,
         region="us-east-2",
         cluster_name="hit-test",
-        boto3_config="some config",
+        boto3_config=botocore.config.Config(),
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = current_time
@@ -1138,7 +1147,7 @@ def test_manage_cluster(
         disable_all_health_checks=disable_health_check,
         region="us-east-2",
         cluster_name="hit-test",
-        boto3_config="NONE",
+        boto3_config=botocore.config.Config(),
     )
     ip_to_slurm_node_map = {node.nodeaddr: node for node in mock_active_nodes}
     cluster_manager = ClusterManager(mock_sync_config)
@@ -1214,15 +1223,15 @@ def test_manage_cluster(
             "default.conf",
             [
                 # This node fail scheduler state check and corresponding instance will be terminated and replaced
-                SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+DRAIN"),
+                SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+DRAIN"),
                 # This node fail scheduler state check and node will be power_down
-                SlurmNode("queue-dynamic-c5.xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
                 # This node is good and should not be touched by clustermgtd
-                SlurmNode("queue-dynamic-c5.xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
             ],
             [
-                SlurmNode("queue-static-c5.xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
-                SlurmNode("queue-dynamic-c5.xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-static-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
             ],
             [
                 # _get_ec2_instances: get all cluster instances by tags
@@ -1368,13 +1377,13 @@ def test_manage_cluster(
             # failures: All failure tolerant module will have an exception, but the program should not crash
             "default.conf",
             [
-                SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5.xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5.xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
             ],
             [
-                SlurmNode("queue-static-c5.xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
-                SlurmNode("queue-dynamic-c5.xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-static-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
             ],
             [
                 # _get_ec2_instances: get all cluster instances by tags
@@ -1531,13 +1540,13 @@ def test_manage_cluster(
             # critical_failure_1: _get_ec2_instances will have an exception, but the program should not crash
             "default.conf",
             [
-                SlurmNode("queue-static-c5.xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5.xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5.xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
             ],
             [
-                SlurmNode("queue-static-c5.xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
-                SlurmNode("queue-dynamic-c5.xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-static-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dynamic-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
             ],
             [
                 # _get_ec2_instances: get all cluster instances by tags
@@ -1603,6 +1612,8 @@ def test_manage_cluster_boto3(
         mocker.patch.object(
             cluster_manager, "_get_node_info_from_partition", return_value=(mocked_active_nodes, mocked_inactive_nodes),
         )
+    cluster_manager._instance_manager._store_assigned_hostnames = mocker.MagicMock()
+    cluster_manager._instance_manager._update_dns_hostnames = mocker.MagicMock()
     cluster_manager.manage_cluster()
 
     assert_that(expected_error_messages).is_length(len(caplog.records))

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -10,10 +10,12 @@
 # limitations under the License.
 
 
+import logging
 import os
 from datetime import datetime, timedelta, timezone
 from unittest.mock import call
 
+import botocore
 import pytest
 from assertpy import assert_that
 
@@ -36,836 +38,1100 @@ def boto3_stubber_path():
     return "slurm_plugin.common.boto3"
 
 
-@pytest.mark.parametrize(
-    (
-        "instances_to_launch",
-        "instance_manager",
-        "launch_batch_size",
-        "update_node_address",
-        "mocked_boto3_request",
-        "expected_failed_nodes",
-        "expected_update_nodes_calls",
-    ),
-    [
-        # normal
+class TestInstanceManager:
+    class BatchWriterMock:
+        """Utility class to mock batch_writer."""
+
+        def __enter__(self, *args):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    @pytest.fixture
+    def instance_manager(self, mocker):
+        instance_manager = InstanceManager(
+            region="us-east-2",
+            cluster_name="hit",
+            boto3_config=botocore.config.Config(),
+            hosted_zone="hosted_zone",
+            dns_domain="dns.domain",
+        )
+        mocker.patch.object(instance_manager, "_table")
+        return instance_manager
+
+    @pytest.mark.parametrize(
         (
-            {
-                "queue1": {"c5.xlarge": ["queue1-static-c5.xlarge-2"], "c5.2xlarge": ["queue1-static-c5.2xlarge-1"]},
-                "queue2": {"c5.xlarge": ["queue2-static-c5.xlarge-1", "queue2-dynamic-c5.xlarge-1"]},
-            },
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            10,
-            True,
-            [
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-12345",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.1",
-                                "PrivateDnsName": "ip-1-0-0-1",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            }
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
-                    },
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-23456",
-                                "InstanceType": "c5.2xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.2",
-                                "PrivateDnsName": "ip-1-0-0-2",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            }
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
-                    },
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-34567",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.3",
-                                "PrivateDnsName": "ip-1-0-0-3",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            },
-                            {
-                                "InstanceId": "i-45678",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.4",
-                                "PrivateDnsName": "ip-1-0-0-4",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            },
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 2,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
-                    },
-                ),
-            ],
-            None,
-            [
-                call(
-                    ["queue1-static-c5.xlarge-2"],
-                    [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                ),
-                call(
-                    ["queue1-static-c5.2xlarge-1"],
-                    [EC2Instance("i-23456", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                ),
-                call(
-                    ["queue2-static-c5.xlarge-1", "queue2-dynamic-c5.xlarge-1"],
-                    [
-                        EC2Instance("i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                        EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                    ],
-                ),
-            ],
+            "instances_to_launch",
+            "launch_batch_size",
+            "update_node_address",
+            "mocked_boto3_request",
+            "expected_failed_nodes",
+            "expected_update_nodes_calls",
         ),
-        # client_error
-        (
-            {
-                "queue1": {"c5.xlarge": ["queue1-static-c5.xlarge-2"], "c5.2xlarge": ["queue1-static-c5.2xlarge-1"]},
-                "queue2": {"c5.xlarge": ["queue2-static-c5.xlarge-1", "queue2-dynamic-c5.xlarge-1"]},
-            },
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            10,
-            True,
-            [
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-12345",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.1",
-                                "PrivateDnsName": "ip-1-0-0-1",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            }
-                        ]
+        [
+            # normal
+            (
+                {
+                    "queue1": {
+                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
                     },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
-                    },
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={},
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
-                    },
-                    generate_error=True,
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-34567",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.3",
-                                "PrivateDnsName": "ip-1-0-0-3",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            },
-                            {
-                                "InstanceId": "i-45678",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.4",
-                                "PrivateDnsName": "ip-1-0-0-4",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            },
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 2,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
-                    },
-                ),
-            ],
-            ["queue1-static-c5.2xlarge-1"],
-            [
-                call(
-                    ["queue1-static-c5.xlarge-2"],
-                    [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                ),
-                call(
-                    ["queue2-static-c5.xlarge-1", "queue2-dynamic-c5.xlarge-1"],
-                    [
-                        EC2Instance("i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                        EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                    ],
-                ),
-            ],
-        ),
-        # no_update
-        (
-            {"queue1": {"c5.xlarge": ["queue1-static-c5.xlarge-2"]}},
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            10,
-            False,
-            [
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-12345",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.1",
-                                "PrivateDnsName": "ip-1-0-0-1",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            }
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
-                    },
-                ),
-            ],
-            None,
-            None,
-        ),
-        # batch_size1
-        (
-            {
-                "queue1": {"c5.xlarge": ["queue1-static-c5.xlarge-2"], "c5.2xlarge": ["queue1-static-c5.2xlarge-1"]},
-                "queue2": {
-                    "c5.xlarge": [
-                        "queue2-static-c5.xlarge-1",
-                        "queue2-static-c5.xlarge-2",
-                        "queue2-dynamic-c5.xlarge-1",
-                    ],
+                    "queue2": {"c5.xlarge": ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"]},
                 },
-            },
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            3,
-            True,
-            [
+                10,
+                True,
+                [
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-12345",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                    "PrivateDnsName": "ip-1-0-0-1",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
+                        },
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-23456",
+                                    "InstanceType": "c5.2xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.2",
+                                    "PrivateDnsName": "ip-1-0-0-2",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
+                        },
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-34567",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.3",
+                                    "PrivateDnsName": "ip-1-0-0-3",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                },
+                                {
+                                    "InstanceId": "i-45678",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.4",
+                                    "PrivateDnsName": "ip-1-0-0-4",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                },
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 2,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
+                        },
+                    ),
+                ],
+                None,
+                [
+                    call(
+                        ["queue1-static-c5-xlarge-2"],
+                        [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    ),
+                    call(
+                        ["queue1-static-c5-2xlarge-1"],
+                        [EC2Instance("i-23456", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    ),
+                    call(
+                        ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"],
+                        [
+                            EC2Instance(
+                                "i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            ),
+                            EC2Instance(
+                                "i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            # client_error
+            (
+                {
+                    "queue1": {
+                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
+                    },
+                    "queue2": {"c5.xlarge": ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"]},
+                },
+                10,
+                True,
+                [
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-12345",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                    "PrivateDnsName": "ip-1-0-0-1",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
+                        },
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={},
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
+                        },
+                        generate_error=True,
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-34567",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.3",
+                                    "PrivateDnsName": "ip-1-0-0-3",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                },
+                                {
+                                    "InstanceId": "i-45678",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.4",
+                                    "PrivateDnsName": "ip-1-0-0-4",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                },
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 2,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
+                        },
+                    ),
+                ],
+                ["queue1-static-c5-2xlarge-1"],
+                [
+                    call(
+                        ["queue1-static-c5-xlarge-2"],
+                        [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    ),
+                    call(
+                        ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"],
+                        [
+                            EC2Instance(
+                                "i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            ),
+                            EC2Instance(
+                                "i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            # no_update
+            (
+                {"queue1": {"c5.xlarge": ["queue1-static-c5-xlarge-2"]}},
+                10,
+                False,
+                [
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-12345",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                    "PrivateDnsName": "ip-1-0-0-1",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
+                        },
+                    ),
+                ],
+                None,
+                None,
+            ),
+            # batch_size1
+            (
+                {
+                    "queue1": {
+                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
+                    },
+                    "queue2": {
+                        "c5.xlarge": [
+                            "queue2-static-c5-xlarge-1",
+                            "queue2-static-c5-xlarge-2",
+                            "queue2-dynamic-c5-xlarge-1",
+                        ],
+                    },
+                },
+                3,
+                True,
+                [
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-12345",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                    "PrivateDnsName": "ip-1-0-0-1",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
+                        },
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={},
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
+                        },
+                        generate_error=True,
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={},
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 3,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
+                        },
+                        generate_error=True,
+                    ),
+                ],
+                [
+                    "queue1-static-c5-2xlarge-1",
+                    "queue2-static-c5-xlarge-1",
+                    "queue2-static-c5-xlarge-2",
+                    "queue2-dynamic-c5-xlarge-1",
+                ],
+                [
+                    call(
+                        ["queue1-static-c5-xlarge-2"],
+                        [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    )
+                ],
+            ),
+            # batch_size2
+            (
+                {
+                    "queue1": {
+                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
+                    },
+                    "queue2": {
+                        "c5.xlarge": [
+                            "queue2-static-c5-xlarge-1",
+                            "queue2-static-c5-xlarge-2",
+                            "queue2-dynamic-c5-xlarge-1",
+                        ],
+                    },
+                },
+                1,
+                True,
+                [
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-12345",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                    "PrivateDnsName": "ip-1-0-0-1",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
+                        },
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={},
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
+                        },
+                        generate_error=True,
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-34567",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.3",
+                                    "PrivateDnsName": "ip-1-0-0-3",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
+                        },
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={},
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
+                        },
+                        generate_error=True,
+                    ),
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-45678",
+                                    "InstanceType": "c5.xlarge",
+                                    "PrivateIpAddress": "ip.1.0.0.4",
+                                    "PrivateDnsName": "ip-1-0-0-4",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 1,
+                            "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
+                        },
+                    ),
+                ],
+                ["queue1-static-c5-2xlarge-1", "queue2-static-c5-xlarge-2"],
+                [
+                    call(
+                        ["queue1-static-c5-xlarge-2"],
+                        [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    ),
+                    call(
+                        ["queue2-static-c5-xlarge-1"],
+                        [EC2Instance("i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    ),
+                    call(
+                        ["queue2-dynamic-c5-xlarge-1"],
+                        [EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    ),
+                ],
+            ),
+            (
+                {
+                    "queue2": {
+                        "c5.xlarge": [
+                            "queue2-static-c5-xlarge-1",
+                            "queue2-static-c5-xlarge-2",
+                            "queue2-dynamic-c5-xlarge-1",
+                        ],
+                    },
+                },
+                10,
+                True,
+                # Simulate the case that only a part of the requested capacity is launched
                 MockedBoto3Request(
                     method="run_instances",
                     response={
                         "Instances": [
                             {
-                                "InstanceId": "i-12345",
+                                "InstanceId": "i-45678",
                                 "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.1",
-                                "PrivateDnsName": "ip-1-0-0-1",
+                                "PrivateIpAddress": "ip.1.0.0.4",
+                                "PrivateDnsName": "ip-1-0-0-4",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
                             }
                         ]
                     },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
-                    },
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={},
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
-                    },
-                    generate_error=True,
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={},
                     expected_params={
                         "MinCount": 1,
                         "MaxCount": 3,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
                     },
-                    generate_error=True,
                 ),
-            ],
-            [
-                "queue1-static-c5.2xlarge-1",
-                "queue2-static-c5.xlarge-1",
-                "queue2-static-c5.xlarge-2",
-                "queue2-dynamic-c5.xlarge-1",
-            ],
-            [
-                call(
-                    ["queue1-static-c5.xlarge-2"],
-                    [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                )
-            ],
-        ),
-        # batch_size2
-        (
-            {
-                "queue1": {"c5.xlarge": ["queue1-static-c5.xlarge-2"], "c5.2xlarge": ["queue1-static-c5.2xlarge-1"]},
-                "queue2": {
-                    "c5.xlarge": [
-                        "queue2-static-c5.xlarge-1",
-                        "queue2-static-c5.xlarge-2",
-                        "queue2-dynamic-c5.xlarge-1",
-                    ],
-                },
-            },
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            1,
-            True,
-            [
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-12345",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.1",
-                                "PrivateDnsName": "ip-1-0-0-1",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            }
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge"},
-                    },
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={},
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge"},
-                    },
-                    generate_error=True,
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-34567",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.3",
-                                "PrivateDnsName": "ip-1-0-0-3",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            }
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
-                    },
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={},
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
-                    },
-                    generate_error=True,
-                ),
-                MockedBoto3Request(
-                    method="run_instances",
-                    response={
-                        "Instances": [
-                            {
-                                "InstanceId": "i-45678",
-                                "InstanceType": "c5.xlarge",
-                                "PrivateIpAddress": "ip.1.0.0.4",
-                                "PrivateDnsName": "ip-1-0-0-4",
-                                "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            }
-                        ]
-                    },
-                    expected_params={
-                        "MinCount": 1,
-                        "MaxCount": 1,
-                        "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
-                    },
-                ),
-            ],
-            ["queue1-static-c5.2xlarge-1", "queue2-static-c5.xlarge-2"],
-            [
-                call(
-                    ["queue1-static-c5.xlarge-2"],
-                    [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                ),
-                call(
-                    ["queue2-static-c5.xlarge-1"],
-                    [EC2Instance("i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                ),
-                call(
-                    ["queue2-dynamic-c5.xlarge-1"],
-                    [EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                ),
-            ],
-        ),
-        (
-            {
-                "queue2": {
-                    "c5.xlarge": [
-                        "queue2-static-c5.xlarge-1",
-                        "queue2-static-c5.xlarge-2",
-                        "queue2-dynamic-c5.xlarge-1",
-                    ],
-                },
-            },
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            10,
-            True,
-            # Simulate the case that only a part of the requested capacity is launched
-            MockedBoto3Request(
-                method="run_instances",
-                response={
-                    "Instances": [
-                        {
-                            "InstanceId": "i-45678",
-                            "InstanceType": "c5.xlarge",
-                            "PrivateIpAddress": "ip.1.0.0.4",
-                            "PrivateDnsName": "ip-1-0-0-4",
-                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                        }
-                    ]
-                },
-                expected_params={
-                    "MinCount": 1,
-                    "MaxCount": 3,
-                    "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
-                },
+                ["queue2-static-c5-xlarge-2", "queue2-dynamic-c5-xlarge-1"],
+                [
+                    call(
+                        ["queue2-static-c5-xlarge-1", "queue2-static-c5-xlarge-2", "queue2-dynamic-c5-xlarge-1"],
+                        [EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                    )
+                ],
             ),
-            ["queue2-static-c5.xlarge-2", "queue2-dynamic-c5.xlarge-1"],
-            [
-                call(
-                    ["queue2-static-c5.xlarge-1", "queue2-static-c5.xlarge-2", "queue2-dynamic-c5.xlarge-1"],
-                    [EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-                )
-            ],
-        ),
-    ],
-    ids=["normal", "client_error", "no_update", "batch_size1", "batch_size2", "partial_launch"],
-)
-def test_add_instances(
-    boto3_stubber,
-    instances_to_launch,
-    instance_manager,
-    launch_batch_size,
-    update_node_address,
-    mocked_boto3_request,
-    expected_failed_nodes,
-    expected_update_nodes_calls,
-    mocker,
-):
-    mocker.patch("slurm_plugin.common.update_nodes")
-    # patch internal functions
-    # Mock _update_slurm_node_addrs but still allow original code to execute
-    original_update_func = instance_manager._update_slurm_node_addrs
-    instance_manager._update_slurm_node_addrs = mocker.MagicMock(side_effect=original_update_func)
-    instance_manager._parse_requested_instances = mocker.MagicMock(return_value=instances_to_launch)
-    # patch boto3 call
-    boto3_stubber("ec2", mocked_boto3_request)
-    # run test
-    instance_manager.add_instances_for_nodes(
-        node_list=["placeholder_node_list"],
-        launch_batch_size=launch_batch_size,
-        update_node_address=update_node_address,
+        ],
+        ids=["normal", "client_error", "no_update", "batch_size1", "batch_size2", "partial_launch"],
     )
-    if expected_update_nodes_calls:
-        instance_manager._update_slurm_node_addrs.assert_has_calls(expected_update_nodes_calls)
-    else:
-        instance_manager._update_slurm_node_addrs.assert_not_called()
-    if expected_failed_nodes:
-        assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
-    else:
-        assert_that(instance_manager.failed_nodes).is_empty()
+    def test_add_instances(
+        self,
+        boto3_stubber,
+        instances_to_launch,
+        launch_batch_size,
+        update_node_address,
+        mocked_boto3_request,
+        expected_failed_nodes,
+        expected_update_nodes_calls,
+        mocker,
+        instance_manager,
+    ):
+        mocker.patch("slurm_plugin.common.update_nodes")
+        # patch internal functions
+        instance_manager._store_assigned_hostnames = mocker.MagicMock()
+        instance_manager._update_dns_hostnames = mocker.MagicMock()
 
+        # Mock _update_slurm_node_addrs but still allow original code to execute
+        original_update_func = instance_manager._update_slurm_node_addrs
+        instance_manager._update_slurm_node_addrs = mocker.MagicMock(side_effect=original_update_func)
+        instance_manager._parse_requested_instances = mocker.MagicMock(return_value=instances_to_launch)
+        # patch boto3 call
+        boto3_stubber("ec2", mocked_boto3_request)
 
-@pytest.mark.parametrize(
-    "instance_manager, node_lists, launched_nodes, expected_update_nodes_call, expected_failed_nodes",
-    [
-        (
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            ["node-1"],
-            [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
-            call(["node-1"], nodeaddrs=["ip-1"], nodehostnames=["hostname-1"], raise_on_error=True),
-            [],
-        ),
-        (
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            ["node-1"],
-            [],
-            None,
-            ["node-1"],
-        ),
-        (
-            InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",),
-            ["node-1", "node-2", "node-3", "node-4"],
-            [
-                EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
-            ],
-            call(
-                ["node-1", "node-2"],
-                nodeaddrs=["ip-1", "ip-2"],
-                nodehostnames=["hostname-1", "hostname-2"],
-                raise_on_error=True,
-            ),
-            ["node-3", "node-4"],
-        ),
-    ],
-    ids=("all_launched", "nothing_launched", "partial_launched"),
-)
-def test_update_slurm_node_addrs(
-    instance_manager, node_lists, launched_nodes, expected_update_nodes_call, expected_failed_nodes, mocker
-):
-    mock_update_nodes = mocker.patch("slurm_plugin.common.update_nodes")
-    instance_manager._update_slurm_node_addrs(node_lists, launched_nodes)
-    if expected_update_nodes_call:
-        mock_update_nodes.assert_called_once()
-        mock_update_nodes.assert_has_calls([expected_update_nodes_call])
-    else:
-        mock_update_nodes.assert_not_called()
-    assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
-
-
-@pytest.mark.parametrize(
-    ("node_list", "expected_results", "expected_failed_nodes"),
-    [
-        (
-            [
-                "queue1-static-c5.xlarge-1",
-                "queue1-static-c5.xlarge-2",
-                "queue1-dynamic-c5.xlarge-201",
-                "queue2-static-g3.4xlarge-1",
-                "in-valid/queue.name-static-c5.xlarge-2",
-                "noBrackets-static-c5.xlarge-[1-2]",
-                "queue2-dynamic-g3.8xlarge-1",
-                "queue2-static-i3en.metal-2tb-1",
-                "queue2-static-i3en.metal_2tb-1",
-                "queue2-invalidnodetype-c5.xlarge-12",
-                "queuename-with-dash-and_underscore-static-i3en.metal-2tb-1",
-            ],
-            {
-                "queue1": {
-                    "c5.xlarge": [
-                        "queue1-static-c5.xlarge-1",
-                        "queue1-static-c5.xlarge-2",
-                        "queue1-dynamic-c5.xlarge-201",
-                    ]
-                },
-                "queue2": {
-                    "g3.4xlarge": ["queue2-static-g3.4xlarge-1"],
-                    "g3.8xlarge": ["queue2-dynamic-g3.8xlarge-1"],
-                    "i3en.metal-2tb": ["queue2-static-i3en.metal-2tb-1"],
-                },
-                "queuename-with-dash-and_underscore": {
-                    "i3en.metal-2tb": ["queuename-with-dash-and_underscore-static-i3en.metal-2tb-1"]
-                },
-            },
-            [
-                "in-valid/queue.name-static-c5.xlarge-2",
-                "noBrackets-static-c5.xlarge-[1-2]",
-                "queue2-static-i3en.metal_2tb-1",
-                "queue2-invalidnodetype-c5.xlarge-12",
-            ],
-        ),
-    ],
-)
-def test_parse_requested_instances(node_list, expected_results, expected_failed_nodes):
-    mock_instance_manager = InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",)
-    assert_that(mock_instance_manager._parse_requested_instances(node_list)).is_equal_to(expected_results)
-    assert_that(mock_instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
-
-
-@pytest.mark.parametrize(
-    ("instance_ids_to_name", "batch_size", "mocked_boto3_request"),
-    [
-        # normal
-        (
-            ["i-12345", "i-23456", "i-34567"],
-            10,
-            [
-                MockedBoto3Request(
-                    method="terminate_instances",
-                    response={},
-                    expected_params={"InstanceIds": ["i-12345", "i-23456", "i-34567"]},
-                ),
-            ],
-        ),
-        # ClientError
-        (
-            ["i-12345", "i-23456", "i-34567"],
-            1,
-            [
-                MockedBoto3Request(
-                    method="terminate_instances",
-                    response={},
-                    expected_params={"InstanceIds": ["i-12345"]},
-                    generate_error=True,
-                ),
-                MockedBoto3Request(
-                    method="terminate_instances",
-                    response={},
-                    expected_params={"InstanceIds": ["i-23456"]},
-                    generate_error=True,
-                ),
-                MockedBoto3Request(
-                    method="terminate_instances",
-                    response={},
-                    expected_params={"InstanceIds": ["i-34567"]},
-                    generate_error=True,
-                ),
-            ],
-        ),
-    ],
-    ids=["normal", "client_error"],
-)
-def test_delete_instances(boto3_stubber, instance_ids_to_name, batch_size, mocked_boto3_request, mocker):
-    # patch boto3 call
-    boto3_stubber("ec2", mocked_boto3_request)
-    mock_instance_manager = InstanceManager(region="us-east-2", cluster_name="hit", boto3_config="some_boto3_config",)
-    # run test
-    mock_instance_manager.delete_instances(instance_ids_to_name, batch_size)
-
-
-@pytest.mark.parametrize(
-    "instance_ids, mocked_boto3_request, expected_parsed_result",
-    [
-        (
-            ["i-1", "i-2"],
-            [
-                MockedBoto3Request(
-                    method="describe_instance_status",
-                    response={
-                        "InstanceStatuses": [
-                            {
-                                "InstanceId": "i-1",
-                                "InstanceState": {"Name": "running"},
-                                "InstanceStatus": {"Status": "impaired"},
-                                "SystemStatus": {"Status": "ok"},
-                            },
-                            {
-                                "InstanceId": "i-2",
-                                "InstanceState": {"Name": "pending"},
-                                "InstanceStatus": {"Status": "initializing"},
-                                "SystemStatus": {"Status": "impaired"},
-                                "Events": [{"InstanceEventId": "event-id-1"}],
-                            },
-                        ]
-                    },
-                    expected_params={
-                        "Filters": [
-                            {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
-                        ],
-                        "MaxResults": 1000,
-                    },
-                    generate_error=False,
-                ),
-                MockedBoto3Request(
-                    method="describe_instance_status",
-                    response={
-                        "InstanceStatuses": [
-                            {
-                                "InstanceId": "i-1",
-                                "InstanceState": {"Name": "running"},
-                                "InstanceStatus": {"Status": "impaired"},
-                                "SystemStatus": {"Status": "ok"},
-                            },
-                        ]
-                    },
-                    expected_params={
-                        "Filters": [
-                            {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
-                        ],
-                        "MaxResults": 1000,
-                    },
-                    generate_error=False,
-                ),
-                MockedBoto3Request(
-                    method="describe_instance_status",
-                    response={
-                        "InstanceStatuses": [
-                            {
-                                "InstanceId": "i-2",
-                                "InstanceState": {"Name": "pending"},
-                                "InstanceStatus": {"Status": "initializing"},
-                                "SystemStatus": {"Status": "impaired"},
-                                "Events": [{"InstanceEventId": "event-id-1"}],
-                            },
-                        ]
-                    },
-                    expected_params={
-                        "Filters": [
-                            {"Name": "system-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
-                        ],
-                        "MaxResults": 1000,
-                    },
-                    generate_error=False,
-                ),
-                MockedBoto3Request(
-                    method="describe_instance_status",
-                    response={
-                        "InstanceStatuses": [
-                            {
-                                "InstanceId": "i-2",
-                                "InstanceState": {"Name": "pending"},
-                                "InstanceStatus": {"Status": "initializing"},
-                                "SystemStatus": {"Status": "impaired"},
-                                "Events": [{"InstanceEventId": "event-id-1"}],
-                            },
-                        ]
-                    },
-                    expected_params={
-                        "Filters": [{"Name": "event.code", "Values": EC2_SCHEDULED_EVENT_CODES}],
-                        "MaxResults": 1000,
-                    },
-                    generate_error=False,
-                ),
-            ],
-            [
-                EC2InstanceHealthState("i-1", "running", {"Status": "ok"}, {"Status": "ok"}, None),
-                EC2InstanceHealthState(
-                    "i-2",
-                    "pending",
-                    {"Status": "initializing"},
-                    {"Status": "initializing"},
-                    [{"InstanceEventId": "event-id-1"}],
-                ),
-            ],
+        # run test
+        instance_manager.add_instances_for_nodes(
+            node_list=["placeholder_node_list"],
+            launch_batch_size=launch_batch_size,
+            update_node_address=update_node_address,
         )
-    ],
-)
-def get_unhealthy_cluster_instance_status(instance_ids, mocked_boto3_request, expected_parsed_result, boto3_stubber):
-    # patch boto3 call
-    boto3_stubber("ec2", mocked_boto3_request)
-    # run test
-    instance_manager = InstanceManager("us-east-1", "hit-test", "some_boto3_config")
-    result = instance_manager.get_unhealthy_cluster_instance_status(instance_ids)
-    assert_that(result).is_equal_to(expected_parsed_result)
+        if expected_update_nodes_calls:
+            instance_manager._update_slurm_node_addrs.assert_has_calls(expected_update_nodes_calls)
+        else:
+            instance_manager._update_slurm_node_addrs.assert_not_called()
+        if expected_failed_nodes:
+            assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
+        else:
+            assert_that(instance_manager.failed_nodes).is_empty()
 
+    @pytest.mark.parametrize(
+        "node_list, launched_nodes, expected_update_nodes_call, expected_failed_nodes",
+        [
+            (
+                ["node-1"],
+                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                call(["node-1"], nodeaddrs=["ip-1"]),
+                [],
+            ),
+            (["node-1"], [], None, ["node-1"],),
+            (
+                ["node-1", "node-2", "node-3", "node-4"],
+                [
+                    EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
+                    EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                ],
+                call(["node-1", "node-2"], nodeaddrs=["ip-1", "ip-2"]),
+                ["node-3", "node-4"],
+            ),
+        ],
+        ids=("all_launched", "nothing_launched", "partial_launched"),
+    )
+    def test_update_slurm_node_addrs(
+        self, node_list, launched_nodes, expected_update_nodes_call, expected_failed_nodes, instance_manager, mocker
+    ):
+        mock_update_nodes = mocker.patch("slurm_plugin.common.update_nodes")
 
-@pytest.mark.parametrize(
-    "mock_kwargs, mocked_boto3_request, expected_parsed_result",
-    [
-        (
-            {"include_master": False, "alive_states_only": True},
-            MockedBoto3Request(
-                method="describe_instances",
-                response={
-                    "Reservations": [
-                        {
-                            "Instances": [
+        instance_manager._update_slurm_node_addrs(node_list, launched_nodes)
+        if expected_update_nodes_call:
+            mock_update_nodes.assert_called_once()
+            mock_update_nodes.assert_has_calls([expected_update_nodes_call])
+        else:
+            mock_update_nodes.assert_not_called()
+        assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
+
+    @pytest.mark.parametrize(
+        "table_name, node_list, slurm_nodes, expected_put_item_calls, expected_message",
+        [
+            (
+                None,
+                ["node-1"],
+                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                None,
+                "Empty table name configuration parameter",
+            ),
+            ("table_name", ["node-1"], [], None, None,),
+            (
+                "table_name",
+                ["node-1"],
+                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [call(Item={"Id": "node-1", "InstanceId": "id-1"})],
+                None,
+            ),
+            (
+                "table_name",
+                ["node-1", "node-2"],
+                [
+                    EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
+                    EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                ],
+                [call(Item={"Id": "node-1", "InstanceId": "id-1"}), call(Item={"Id": "node-2", "InstanceId": "id-2"})],
+                None,
+            ),
+        ],
+        ids=("empty_table", "nothing_stored", "single_store", "multiple_store"),
+    )
+    def test_store_assigned_hostnames(
+        self, table_name, node_list, slurm_nodes, expected_put_item_calls, expected_message, mocker, instance_manager,
+    ):
+        # Mock other methods
+        instance_manager._update_dns_hostnames = mocker.MagicMock()
+        instance_manager._update_slurm_node_addrs = mocker.MagicMock()
+
+        # mock inputs
+        launched_nodes = node_list[: len(slurm_nodes)]
+        assigned_nodes = dict(zip(launched_nodes, slurm_nodes))
+
+        if not table_name:
+            instance_manager._table = None
+            with pytest.raises(Exception, match=expected_message):
+                instance_manager._store_assigned_hostnames(assigned_nodes)
+        else:
+            # mock batch_writer
+            batch_writer_mock = self.BatchWriterMock()
+            batch_writer_mock.put_item = mocker.MagicMock()
+            mocker.patch.object(instance_manager._table, "batch_writer", return_value=batch_writer_mock)
+
+            # call function and verify execution
+            instance_manager._store_assigned_hostnames(assigned_nodes)
+            if expected_put_item_calls:
+                batch_writer_mock.put_item.assert_has_calls(expected_put_item_calls)
+            else:
+                batch_writer_mock.put_item.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "hosted_zone, dns_domain, node_list, slurm_nodes, mocked_boto3_request, expected_message, expected_failure",
+        [
+            (
+                None,
+                "dns.domain",
+                ["node-1"],
+                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                None,
+                "Empty table name configuration parameter",
+                False,
+            ),
+            ("hosted_zone", None, ["node-1"], [], None, "Empty table name configuration parameter", False),
+            ("hosted_zone", "dns.domain", ["node-1"], [], None, None, False),
+            (
+                "hosted_zone",
+                "dns.domain",
+                ["node-1"],
+                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                MockedBoto3Request(
+                    method="change_resource_record_sets",
+                    response={
+                        "ChangeInfo": {
+                            "Id": "string",
+                            "Status": "PENDING",
+                            "SubmittedAt": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        }
+                    },
+                    expected_params={
+                        "HostedZoneId": "hosted_zone",
+                        "ChangeBatch": {
+                            "Changes": [
+                                {
+                                    "Action": "UPSERT",
+                                    "ResourceRecordSet": {
+                                        "Name": "node-1.dns.domain",
+                                        "ResourceRecords": [{"Value": "ip-1"}],
+                                        "Type": "A",
+                                        "TTL": 120,
+                                    },
+                                }
+                            ]
+                        },
+                    },
+                ),
+                None,
+                False,
+            ),
+            (
+                "hosted_zone",
+                "dns.domain",
+                ["node-1", "node-2"],
+                [
+                    EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
+                    EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                ],
+                [
+                    MockedBoto3Request(
+                        method="change_resource_record_sets",
+                        response={
+                            "ChangeInfo": {
+                                "Id": "string",
+                                "Status": "PENDING",
+                                "SubmittedAt": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            }
+                        },
+                        expected_params={
+                            "HostedZoneId": "hosted_zone",
+                            "ChangeBatch": {
+                                "Changes": [
+                                    {
+                                        "Action": "UPSERT",
+                                        "ResourceRecordSet": {
+                                            "Name": "node-1.dns.domain",
+                                            "ResourceRecords": [{"Value": "ip-1"}],
+                                            "Type": "A",
+                                            "TTL": 120,
+                                        },
+                                    },
+                                    {
+                                        "Action": "UPSERT",
+                                        "ResourceRecordSet": {
+                                            "Name": "node-2.dns.domain",
+                                            "ResourceRecords": [{"Value": "ip-2"}],
+                                            "Type": "A",
+                                            "TTL": 120,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    )
+                ],
+                None,
+                False,
+            ),
+            (
+                "hosted_zone",
+                "dns.domain",
+                ["node-1"],
+                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                MockedBoto3Request(
+                    method="change_resource_record_sets",
+                    response={},
+                    expected_params={
+                        "HostedZoneId": "hosted_zone",
+                        "ChangeBatch": {
+                            "Changes": [
+                                {
+                                    "Action": "UPSERT",
+                                    "ResourceRecordSet": {
+                                        "Name": "node-1.dns.domain",
+                                        "ResourceRecords": [{"Value": "ip-1"}],
+                                        "Type": "A",
+                                        "TTL": 120,
+                                    },
+                                }
+                            ]
+                        },
+                    },
+                    generate_error=True,
+                ),
+                None,
+                True,
+            ),
+        ],
+        ids=("no_hosted_zone", "no_domain_name", "nothing_stored", "single_store", "multiple_store", "client_error",),
+    )
+    def test_update_dns_hostnames(
+        self,
+        hosted_zone,
+        dns_domain,
+        node_list,
+        slurm_nodes,
+        mocked_boto3_request,
+        expected_message,
+        expected_failure,
+        mocker,
+        boto3_stubber,
+        instance_manager,
+        caplog,
+    ):
+        # Mock other methods
+        instance_manager._update_slurm_node_addrs = mocker.MagicMock()
+        instance_manager._store_assigned_hostnames = mocker.MagicMock()
+
+        if mocked_boto3_request:
+            boto3_stubber("route53", mocked_boto3_request)
+
+        # mock inputs
+        instance_manager._hosted_zone = hosted_zone
+        instance_manager._dns_domain = dns_domain
+        launched_nodes = node_list[: len(slurm_nodes)]
+        assigned_nodes = dict(zip(launched_nodes, slurm_nodes))
+        if expected_message:
+            with caplog.at_level(logging.INFO):
+                instance_manager._update_dns_hostnames(assigned_nodes)
+                assert_that(caplog.text).contains("Empty DNS domain name or hosted zone configuration parameter")
+        if expected_failure:
+            with pytest.raises(Exception, match="calling the ChangeResourceRecordSets"):
+                instance_manager._update_dns_hostnames(assigned_nodes)
+        else:
+            instance_manager._update_dns_hostnames(assigned_nodes)
+
+    @pytest.mark.parametrize(
+        ("nodename", "expected_queue", "expected_instance_type", "expected_failure"),
+        [
+            ("queue1-static-c5-xlarge-1", "queue1", "c5.xlarge", False),
+            ("queue-1-static-c5-xlarge-1", "queue-1", "c5.xlarge", False),
+            # ("queue1-static-i3en-metal-2tb-1", "queue1", "i3en.metal-2tb", False), not supported for now
+            ("queue1-static-u-6tb1-metal-1", "queue1", "u-6tb1.metal", False),
+            ("queue1-static-c5.xlarge-1", "queue1", "c5.xlarge", True),
+            ("queue_1-static-c5-xlarge-1", "queue_1", "c5.xlarge", True),
+        ],
+    )
+    def test_parse_nodename(self, nodename, expected_queue, expected_instance_type, expected_failure, instance_manager):
+        if expected_failure:
+            with pytest.raises(Exception):
+                instance_manager._parse_nodename(nodename)
+        else:
+            queue_name, instance_type = instance_manager._parse_nodename(nodename)
+            assert_that(expected_queue).is_equal_to(queue_name)
+            assert_that(expected_instance_type).is_equal_to(instance_type)
+
+    @pytest.mark.parametrize(
+        ("node_list", "expected_results", "expected_failed_nodes"),
+        [
+            (
+                [
+                    "queue1-static-c5-xlarge-1",
+                    "queue1-static-c5-xlarge-2",
+                    "queue1-dynamic-c5-xlarge-201",
+                    "queue2-static-g3-4xlarge-1",
+                    "in-valid/queue.name-static-c5-xlarge-2",
+                    "noBrackets-static-c5-xlarge-[1-2]",
+                    "queue2-dynamic-g3-8xlarge-1",
+                    "queue2-static-u-6tb1-metal-1",
+                    "queue2-invalidnodetype-c5-xlarge-12",
+                    "queuename-with-dash-and_underscore-static-i3en-metal-2tb-1",
+                ],
+                {
+                    "queue1": {
+                        "c5.xlarge": [
+                            "queue1-static-c5-xlarge-1",
+                            "queue1-static-c5-xlarge-2",
+                            "queue1-dynamic-c5-xlarge-201",
+                        ]
+                    },
+                    "queue2": {
+                        "g3.4xlarge": ["queue2-static-g3-4xlarge-1"],
+                        "g3.8xlarge": ["queue2-dynamic-g3-8xlarge-1"],
+                        "u-6tb1.metal": ["queue2-static-u-6tb1-metal-1"],
+                    },
+                },
+                [
+                    "in-valid/queue.name-static-c5-xlarge-2",
+                    "noBrackets-static-c5-xlarge-[1-2]",
+                    "queue2-invalidnodetype-c5-xlarge-12",
+                    "queuename-with-dash-and_underscore-static-i3en-metal-2tb-1",
+                ],
+            ),
+        ],
+    )
+    def test_parse_requested_instances(self, node_list, expected_results, expected_failed_nodes, instance_manager):
+        assert_that(instance_manager._parse_requested_instances(node_list)).is_equal_to(expected_results)
+        assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
+
+    @pytest.mark.parametrize(
+        ("instance_ids_to_name", "batch_size", "mocked_boto3_request"),
+        [
+            # normal
+            (
+                ["i-12345", "i-23456", "i-34567"],
+                10,
+                [
+                    MockedBoto3Request(
+                        method="terminate_instances",
+                        response={},
+                        expected_params={"InstanceIds": ["i-12345", "i-23456", "i-34567"]},
+                    ),
+                ],
+            ),
+            # ClientError
+            (
+                ["i-12345", "i-23456", "i-34567"],
+                1,
+                [
+                    MockedBoto3Request(
+                        method="terminate_instances",
+                        response={},
+                        expected_params={"InstanceIds": ["i-12345"]},
+                        generate_error=True,
+                    ),
+                    MockedBoto3Request(
+                        method="terminate_instances",
+                        response={},
+                        expected_params={"InstanceIds": ["i-23456"]},
+                        generate_error=True,
+                    ),
+                    MockedBoto3Request(
+                        method="terminate_instances",
+                        response={},
+                        expected_params={"InstanceIds": ["i-34567"]},
+                        generate_error=True,
+                    ),
+                ],
+            ),
+        ],
+        ids=["normal", "client_error"],
+    )
+    def test_delete_instances(
+        self, boto3_stubber, instance_ids_to_name, batch_size, mocked_boto3_request, instance_manager
+    ):
+        # patch boto3 call
+        boto3_stubber("ec2", mocked_boto3_request)
+        # run test
+        instance_manager.delete_instances(instance_ids_to_name, batch_size)
+
+    @pytest.mark.parametrize(
+        "instance_ids, mocked_boto3_request, expected_parsed_result",
+        [
+            (
+                ["i-1", "i-2"],
+                [
+                    MockedBoto3Request(
+                        method="describe_instance_status",
+                        response={
+                            "InstanceStatuses": [
                                 {
                                     "InstanceId": "i-1",
-                                    "PrivateIpAddress": "ip-1",
-                                    "PrivateDnsName": "hostname",
-                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    "InstanceState": {"Name": "running"},
+                                    "InstanceStatus": {"Status": "impaired"},
+                                    "SystemStatus": {"Status": "ok"},
                                 },
                                 {
                                     "InstanceId": "i-2",
-                                    "PrivateIpAddress": "ip-2",
-                                    "PrivateDnsName": "hostname",
-                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    "InstanceState": {"Name": "pending"},
+                                    "InstanceStatus": {"Status": "initializing"},
+                                    "SystemStatus": {"Status": "impaired"},
+                                    "Events": [{"InstanceEventId": "event-id-1"}],
                                 },
                             ]
-                        }
-                    ]
-                },
-                expected_params={
-                    "Filters": [
-                        {"Name": "tag:ClusterName", "Values": ["hit-test"]},
-                        {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
-                        {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
-                    ],
-                    "MaxResults": 1000,
-                },
-                generate_error=False,
-            ),
-            [
-                EC2Instance("i-1", "ip-1", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                EC2Instance("i-2", "ip-2", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-            ],
-        ),
-        (
-            {"include_master": False, "alive_states_only": True},
-            MockedBoto3Request(
-                method="describe_instances",
-                response={"Reservations": []},
-                expected_params={
-                    "Filters": [
-                        {"Name": "tag:ClusterName", "Values": ["hit-test"]},
-                        {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
-                        {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
-                    ],
-                    "MaxResults": 1000,
-                },
-                generate_error=False,
-            ),
-            [],
-        ),
-        (
-            {"include_master": True, "alive_states_only": False},
-            MockedBoto3Request(
-                method="describe_instances",
-                response={
-                    "Reservations": [
-                        {
-                            "Instances": [
+                        },
+                        expected_params={
+                            "Filters": [
+                                {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
+                            ],
+                            "MaxResults": 1000,
+                        },
+                        generate_error=False,
+                    ),
+                    MockedBoto3Request(
+                        method="describe_instance_status",
+                        response={
+                            "InstanceStatuses": [
                                 {
                                     "InstanceId": "i-1",
-                                    "PrivateIpAddress": "ip-1",
-                                    "PrivateDnsName": "hostname",
-                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    "InstanceState": {"Name": "running"},
+                                    "InstanceStatus": {"Status": "impaired"},
+                                    "SystemStatus": {"Status": "ok"},
                                 },
                             ]
-                        }
-                    ]
-                },
-                expected_params={"Filters": [{"Name": "tag:ClusterName", "Values": ["hit-test"]}], "MaxResults": 1000},
-                generate_error=False,
+                        },
+                        expected_params={
+                            "Filters": [
+                                {"Name": "instance-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
+                            ],
+                            "MaxResults": 1000,
+                        },
+                        generate_error=False,
+                    ),
+                    MockedBoto3Request(
+                        method="describe_instance_status",
+                        response={
+                            "InstanceStatuses": [
+                                {
+                                    "InstanceId": "i-2",
+                                    "InstanceState": {"Name": "pending"},
+                                    "InstanceStatus": {"Status": "initializing"},
+                                    "SystemStatus": {"Status": "impaired"},
+                                    "Events": [{"InstanceEventId": "event-id-1"}],
+                                },
+                            ]
+                        },
+                        expected_params={
+                            "Filters": [
+                                {"Name": "system-status.status", "Values": list(EC2_HEALTH_STATUS_UNHEALTHY_STATES)}
+                            ],
+                            "MaxResults": 1000,
+                        },
+                        generate_error=False,
+                    ),
+                    MockedBoto3Request(
+                        method="describe_instance_status",
+                        response={
+                            "InstanceStatuses": [
+                                {
+                                    "InstanceId": "i-2",
+                                    "InstanceState": {"Name": "pending"},
+                                    "InstanceStatus": {"Status": "initializing"},
+                                    "SystemStatus": {"Status": "impaired"},
+                                    "Events": [{"InstanceEventId": "event-id-1"}],
+                                },
+                            ]
+                        },
+                        expected_params={
+                            "Filters": [{"Name": "event.code", "Values": EC2_SCHEDULED_EVENT_CODES}],
+                            "MaxResults": 1000,
+                        },
+                        generate_error=False,
+                    ),
+                ],
+                [
+                    EC2InstanceHealthState("i-1", "running", {"Status": "ok"}, {"Status": "ok"}, None),
+                    EC2InstanceHealthState(
+                        "i-2",
+                        "pending",
+                        {"Status": "initializing"},
+                        {"Status": "initializing"},
+                        [{"InstanceEventId": "event-id-1"}],
+                    ),
+                ],
+            )
+        ],
+    )
+    def get_unhealthy_cluster_instance_status(
+        self, instance_ids, mocked_boto3_request, expected_parsed_result, boto3_stubber, instance_manager
+    ):
+        # patch boto3 call
+        boto3_stubber("ec2", mocked_boto3_request)
+        # run test
+        result = instance_manager.get_unhealthy_cluster_instance_status(instance_ids)
+        assert_that(result).is_equal_to(expected_parsed_result)
+
+    @pytest.mark.parametrize(
+        "mock_kwargs, mocked_boto3_request, expected_parsed_result",
+        [
+            (
+                {"include_master": False, "alive_states_only": True},
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-1",
+                                        "PrivateIpAddress": "ip-1",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                    {
+                                        "InstanceId": "i-2",
+                                        "PrivateIpAddress": "ip-2",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                ]
+                            }
+                        ]
+                    },
+                    expected_params={
+                        "Filters": [
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                            {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
+                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                        ],
+                        "MaxResults": 1000,
+                    },
+                    generate_error=False,
+                ),
+                [
+                    EC2Instance("i-1", "ip-1", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                    EC2Instance("i-2", "ip-2", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                ],
             ),
-            [EC2Instance("i-1", "ip-1", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc))],
-        ),
-    ],
-    ids=["default", "empty_response", "custom_args"],
-)
-def test_get_cluster_instances(mock_kwargs, mocked_boto3_request, expected_parsed_result, boto3_stubber):
-    # patch boto3 call
-    boto3_stubber("ec2", mocked_boto3_request)
-    # run test
-    instance_manager = InstanceManager("us-east-1", "hit-test", "some_boto3_config")
-    result = instance_manager.get_cluster_instances(**mock_kwargs)
-    assert_that(result).is_equal_to(expected_parsed_result)
+            (
+                {"include_master": False, "alive_states_only": True},
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={"Reservations": []},
+                    expected_params={
+                        "Filters": [
+                            {"Name": "tag:ClusterName", "Values": ["hit"]},
+                            {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
+                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                        ],
+                        "MaxResults": 1000,
+                    },
+                    generate_error=False,
+                ),
+                [],
+            ),
+            (
+                {"include_master": True, "alive_states_only": False},
+                MockedBoto3Request(
+                    method="describe_instances",
+                    response={
+                        "Reservations": [
+                            {
+                                "Instances": [
+                                    {
+                                        "InstanceId": "i-1",
+                                        "PrivateIpAddress": "ip-1",
+                                        "PrivateDnsName": "hostname",
+                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                    },
+                                ]
+                            }
+                        ]
+                    },
+                    expected_params={"Filters": [{"Name": "tag:ClusterName", "Values": ["hit"]}], "MaxResults": 1000},
+                    generate_error=False,
+                ),
+                [EC2Instance("i-1", "ip-1", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+            ),
+        ],
+        ids=["default", "empty_response", "custom_args"],
+    )
+    def test_get_cluster_instances(
+        self, mock_kwargs, mocked_boto3_request, expected_parsed_result, instance_manager, boto3_stubber
+    ):
+        # patch boto3 call
+        boto3_stubber("ec2", mocked_boto3_request)
+        # run test
+        result = instance_manager.get_cluster_instances(**mock_kwargs)
+        assert_that(result).is_equal_to(expected_parsed_result)
 
 
 @pytest.mark.parametrize(

--- a/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
+++ b/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
@@ -6,3 +6,6 @@ boto3_retry = 10
 max_batch_size = 50
 update_node_address = False
 logging_config = /path/to/resume_logging/config
+dynamodb_table = table-name
+hosted_zone = hosted-zone
+dns_domain = dns.domain

--- a/tests/slurm_plugin/test_resume/test_resume_config/default.conf
+++ b/tests/slurm_plugin/test_resume/test_resume_config/default.conf
@@ -1,3 +1,6 @@
 [slurm_resume]
 cluster_name = hit
 region = us-east-2
+dynamodb_table = table-name
+hosted_zone = hosted-zone
+dns_domain = dns.domain


### PR DESCRIPTION
The resume script will update DNS hostnames in the Route53 private hosted zone to add (assigned hostname - private ip) correspondence and the DynamoDB by adding the (assigned hostname - instance id) correspondence.

Note: In the node name the "." in the instance type is replaced by a "_"
so we are restoring it when parsing the nodename.

Other changes:
+ Align tests with the new behaviour: added dynamodb_table, hosted_zone and dns_domain config parameters
+ Use botocore.config.Config() in tests inplace of a string because the tests were failing with: `'str' object has no attribute 'user_agent_extra'` in the `boto3\session.py:379` file.
+ Define a class for `InstanceManager` tests and mock table resource on `instance_manager` fixture. It is required because we cannot use `boto3_stubber` to mock boto3 resources.


