### PR TITLE
Fix issue with subprocess run and shell settings

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -275,7 +275,7 @@ def get_nodes_info(nodes, command_timeout=5):
         f'{SCONTROL} show nodes {nodes} | grep -oP "^NodeName=\\K(\\S+)| '
         'NodeAddr=\\K(\\S+)| NodeHostName=\\K(\\S+)| State=\\K(\\S+)"'
     )
-    nodeinfo_str = check_command_output(show_node_info_command, timeout=command_timeout)
+    nodeinfo_str = check_command_output(show_node_info_command, timeout=command_timeout, shell=True)
 
     return _parse_nodes_info(nodeinfo_str)
 
@@ -285,7 +285,7 @@ def get_partition_info(command_timeout=5):
     show_partition_info_command = (
         f'{SCONTROL} show partitions | grep -oP "^PartitionName=\\K(\\S+)| ' 'Nodes=\\K(\\S+)| State=\\K(\\S+)"'
     )
-    partition_info_str = check_command_output(show_partition_info_command, timeout=command_timeout)
+    partition_info_str = check_command_output(show_partition_info_command, timeout=command_timeout, shell=True)
 
     return _parse_partition_info(partition_info_str)
 

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -103,7 +103,9 @@ def get_asg_settings(region, proxy_config, asg_name):
         raise
 
 
-def check_command_output(command, env=None, raise_on_error=True, execute_as_user=None, log_error=True, timeout=60):
+def check_command_output(
+    command, env=None, raise_on_error=True, execute_as_user=None, log_error=True, timeout=60, shell=False
+):
     """
     Execute shell command and retrieve command output.
 
@@ -125,7 +127,7 @@ def check_command_output(command, env=None, raise_on_error=True, execute_as_user
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             encoding="utf-8",
-            shell=True,
+            shell=shell,
         ),
         command,
         env,
@@ -137,7 +139,7 @@ def check_command_output(command, env=None, raise_on_error=True, execute_as_user
     return result.stdout if hasattr(result, "stdout") else ""
 
 
-def run_command(command, env=None, raise_on_error=True, execute_as_user=None, log_error=True, timeout=60):
+def run_command(command, env=None, raise_on_error=True, execute_as_user=None, log_error=True, timeout=60, shell=False):
     """
     Execute shell command.
 
@@ -149,7 +151,7 @@ def run_command(command, env=None, raise_on_error=True, execute_as_user=None, lo
     """
     _run_command(
         lambda _command, _env, _preexec_fn: subprocess.run(
-            _command, env=_env, preexec_fn=_preexec_fn, timeout=timeout, check=True, encoding="utf-8", shell=True,
+            _command, env=_env, preexec_fn=_preexec_fn, timeout=timeout, check=True, encoding="utf-8", shell=shell,
         ),
         command,
         env,


### PR DESCRIPTION
Introduced in https://github.com/aws/aws-parallelcluster-node/pull/215

When shell=True the subprocess.run args need to be passed as a string. In case we pass a sequence additional items are used as shell args and not command args.

From Python docs:
> If shell is True, the specified command will be executed through the shell. This can be useful if you are using Python primarily for the enhanced control flow it offers over most system shells and still want convenient access to other shell features such as shell pipes, filename wildcards, environment variable expansion, and expansion of ~ to a user’s home directory. However, note that Python itself offers implementations of many shell-like features (in particular, glob, fnmatch, os.walk(), os.path.expandvars(), os.path.expanduser(), and shutil).

>On POSIX with shell=True, the shell defaults to /bin/sh. If args is a string, the string specifies the command to execute through the shell. This means that the string must be formatted exactly as it would be when typed at the shell prompt. This includes, for example, quoting or backslash escaping filenames with spaces in them. If args is a sequence, the first item specifies the command string, and any additional items will be treated as additional arguments to the shell itself.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
