### PR TITLE
Add DNS conf params to clustermgtd conf and add possibility to use private hostnames

### DIFF
--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -54,8 +54,9 @@ class SlurmResumeConfig:
         self.region = config.get("slurm_resume", "region")
         self.cluster_name = config.get("slurm_resume", "cluster_name")
         self.dynamodb_table = config.get("slurm_resume", "dynamodb_table")
-        self.hosted_zone = config.get("slurm_resume", "hosted_zone")
-        self.dns_domain = config.get("slurm_resume", "dns_domain")
+        self.hosted_zone = config.get("slurm_resume", "hosted_zone", fallback=None)
+        self.dns_domain = config.get("slurm_resume", "dns_domain", fallback=None)
+        self.use_private_hostname = config.getboolean("slurm_resume", "use_private_hostname", fallback=False)
         self.max_batch_size = config.getint(
             "slurm_resume", "max_batch_size", fallback=self.DEFAULTS.get("max_batch_size")
         )
@@ -106,9 +107,10 @@ def _resume(arg_nodes, resume_config):
         resume_config.region,
         resume_config.cluster_name,
         resume_config.boto3_config,
-        resume_config.dynamodb_table,
-        resume_config.hosted_zone,
-        resume_config.dns_domain,
+        table_name=resume_config.dynamodb_table,
+        hosted_zone=resume_config.hosted_zone,
+        dns_domain=resume_config.dns_domain,
+        use_private_hostname=resume_config.use_private_hostname,
     )
     instance_manager.add_instances_for_nodes(node_list, resume_config.max_batch_size, resume_config.update_node_address)
     success_nodes = [node for node in node_list if node not in instance_manager.failed_nodes]

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -298,7 +298,13 @@ def test_clean_up_inactive_parititon(
 def test_get_ec2_instances(mocker):
     # Test setup
     mock_sync_config = SimpleNamespace(
-        region="us-east-2", cluster_name="hit-test", boto3_config=botocore.config.Config()
+        region="us-east-2",
+        cluster_name="hit-test",
+        boto3_config=botocore.config.Config(),
+        dynamodb_table="table_name",
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._instance_manager.get_cluster_instances = mocker.MagicMock()
@@ -400,6 +406,9 @@ def test_perform_health_check_actions(
         cluster_name="hit-test",
         boto3_config=botocore.config.Config(),
         dynamodb_table="table_name",
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
     )
     # Mock functions
     cluster_manager = ClusterManager(mock_sync_config)
@@ -920,6 +929,10 @@ def test_handle_unhealthy_static_nodes(
         region="us-east-2",
         cluster_name="hit-test",
         boto3_config=botocore.config.Config(),
+        dynamodb_table="table_name",
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._static_nodes_in_replacement = current_replacing_nodes
@@ -1067,6 +1080,10 @@ def test_terminate_orphaned_instances(
         region="us-east-2",
         cluster_name="hit-test",
         boto3_config=botocore.config.Config(),
+        dynamodb_table="table_name",
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = current_time
@@ -1148,6 +1165,10 @@ def test_manage_cluster(
         region="us-east-2",
         cluster_name="hit-test",
         boto3_config=botocore.config.Config(),
+        dynamodb_table="table_name",
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
     )
     ip_to_slurm_node_map = {node.nodeaddr: node for node in mock_active_nodes}
     cluster_manager = ClusterManager(mock_sync_config)
@@ -1693,6 +1714,9 @@ def test_manage_compute_fleet_status_transitions(
         boto3_config=botocore.config.Config(),
         dynamodb_table="table_name",
         terminate_max_batch_size=4,
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
     )
     cluster_manager = ClusterManager(config)
     mocker.patch("subprocess.run", side_effect=None if partitions_updated_successfully else Exception)
@@ -1739,6 +1763,9 @@ def test_manage_compute_fleet_status_transitions_concurrency(mocker, caplog):
         boto3_config=botocore.config.Config(),
         dynamodb_table="table_name",
         terminate_max_batch_size=4,
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
     )
     cluster_manager = ClusterManager(config)
     mocker.patch("slurm_plugin.clustermgtd.update_all_partitions")

--- a/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
+++ b/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
@@ -19,3 +19,6 @@ disable_scheduled_event_health_check = True
 disable_all_health_checks = False
 health_check_timeout = 10
 dynamodb_table = table-name
+hosted_zone = hosted-zone
+dns_domain = dns.domain
+use_private_hostname = false

--- a/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/health_check.conf
+++ b/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/health_check.conf
@@ -17,3 +17,6 @@ disable_ec2_health_check = True
 disable_scheduled_event_health_check = True
 health_check_timeout = 10
 dynamodb_table = table-name
+hosted_zone = hosted-zone
+dns_domain = dns.domain
+use_private_hostname = false

--- a/tests/slurm_plugin/test_clustermgtd/test_manage_cluster_boto3/default.conf
+++ b/tests/slurm_plugin/test_clustermgtd/test_manage_cluster_boto3/default.conf
@@ -3,3 +3,6 @@ cluster_name = hit
 region = us-east-2
 heartbeat_file_path = /home/ec2-user/clustermgtd_heartbeat
 dynamodb_table = table-name
+hosted_zone = hosted-zone
+dns_domain = dns.domain
+use_private_hostname = no

--- a/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
+++ b/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
@@ -9,3 +9,4 @@ logging_config = /path/to/resume_logging/config
 dynamodb_table = table-name
 hosted_zone = hosted-zone
 dns_domain = dns.domain
+use_private_hostname = False

--- a/tests/slurm_plugin/test_resume/test_resume_config/default.conf
+++ b/tests/slurm_plugin/test_resume/test_resume_config/default.conf
@@ -2,5 +2,3 @@
 cluster_name = hit
 region = us-east-2
 dynamodb_table = table-name
-hosted_zone = hosted-zone
-dns_domain = dns.domain


### PR DESCRIPTION
The clustermgtd daemon starts the static instances so it is required to have all the DNS info.

We're also setting use_private_hostname configuration parameters to both clustermgtd and resume conf to have a way to force the
use of private hostnames in place of the custom ones. 

Signed-off-by: Enrico Usai <usai@amazon.com>
