### PR TITLE
Use st/dy in place of static/dynamic as node type identifier

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -79,9 +79,9 @@ class SlurmNode:
         """
         Check if the node is static or dynamic.
 
-        Valid NodeName format: {queue_name}-{static/dynamic}-{instance_type}-{number}
+        Valid NodeName format: {queue_name}-{st/dy}-{instance_type}-{number}
         """
-        return "static" in self.name
+        return "-st-" in self.name
 
     def is_nodeaddr_set(self):
         """Check if nodeaddr(private ip) for the node is set."""
@@ -278,7 +278,7 @@ def get_nodes_info(nodes, command_timeout=5):
     """
     Retrieve SlurmNode list from slurm nodelist notation.
 
-    Sample slurm nodelist notation: queue1-dynamic-c5_xlarge-[1-3],queue2-static-t2_micro-5.
+    Sample slurm nodelist notation: queue1-dy-c5_xlarge-[1-3],queue2-st-t2_micro-5.
     """
     show_node_info_command = (
         f'{SCONTROL} show nodes {nodes} | grep -oP "^NodeName=\\K(\\S+)| '
@@ -326,7 +326,7 @@ def _get_partition_nodes(partition_name, command_timeout=5):
     # Which is the same as getting all nodes from scontrol
     nodes = []
     for nodename in all_nodes:
-        if "-static-" in nodename or (nodename not in power_down_nodes and nodename != "n/a"):
+        if "-st-" in nodename or (nodename not in power_down_nodes and nodename != "n/a"):
             nodes.append(nodename)
     return ",".join(nodes)
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -622,7 +622,7 @@ class ClusterManager:
         unhealthy_dynamic_nodes = []
         for node in slurm_nodes:
             if not self._is_node_healthy(node, private_ip_to_instance_map):
-                if node.is_static_node():
+                if node.is_static:
                     unhealthy_static_nodes.append(node)
                 else:
                     unhealthy_dynamic_nodes.append(node)
@@ -675,8 +675,8 @@ class ClusterManager:
                 log.debug("Node state check: node %s in DOWN but is currently being replaced, ignoring.", node)
                 return True
             else:
-                if not node.is_static_node() and not node.is_nodeaddr_set():
-                    # Sliently handle failed to launch dynamic node to clean up normal logging
+                if not node.is_static and not node.is_nodeaddr_set():
+                    # Silently handle failed to launch dynamic node to clean up normal logging
                     log.debug("Node state check: node %s in DOWN, replacing node", node)
                 else:
                     log.warning("Node state check: node %s in DOWN, replacing node", node)
@@ -685,7 +685,7 @@ class ClusterManager:
 
     def _is_node_healthy(self, node, private_ip_to_instance_map):
         """Check if a slurm node is considered healthy."""
-        if node.is_static_node():
+        if node.is_static:
             return (
                 ClusterManager._is_static_node_configuration_valid(node)
                 and ClusterManager._is_backing_instance_valid(

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -95,9 +95,9 @@ class InstanceManager:
         r"""
         Exception raised when encountering a NodeName that is invalid/incorrectly formatted.
 
-        Valid NodeName format: {queue-name}-{static/dynamic}-{instance-type}-{number}
-        And match: ^([a-z0-9\-]+)-(static|dynamic)-([a-z0-9-]+-[a-z0-9-]+)-\d+$
-        Sample NodeName: queue-1-static-c5-xlarge-2
+        Valid NodeName format: {queue-name}-{st/dy}-{instance-type}-{number}
+        And match: ^([a-z0-9\-]+)-(st|dy)-([a-z0-9-]+-[a-z0-9-]+)-\d+$
+        Sample NodeName: queue-1-st-c5-xlarge-2
         """
 
         pass
@@ -256,8 +256,8 @@ class InstanceManager:
         """
         Parse out which launch configurations (queue/instance type) are requested by slurm nodes from NodeName.
 
-        Valid NodeName format: {queue_name}-{static/dynamic}-{instance_type}-{number}
-        Sample NodeName: queue1-static-c5_xlarge-2
+        Valid NodeName format: {queue_name}-{st/dy}-{instance_type}-{number}
+        Sample NodeName: queue1-st-c5_xlarge-2
         """
         instances_to_launch = collections.defaultdict(lambda: collections.defaultdict(list))
         for node in node_list:
@@ -298,7 +298,7 @@ class InstanceManager:
 
     def _parse_nodename(self, nodename):
         """Parse queue_name and instance_type from nodename."""
-        nodename_capture = re.match(r"^([a-z0-9\-]+)-(static|dynamic)-([a-z0-9-]+-[a-z0-9-]+)-\d+$", nodename)
+        nodename_capture = re.match(r"^([a-z0-9\-]+)-(st|dy)-([a-z0-9-]+-[a-z0-9-]+)-\d+$", nodename)
         if not nodename_capture:
             raise self.InvalidNodenameError
 

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -20,6 +20,8 @@ from common.schedulers.slurm_commands import (
     _parse_nodes_info,
     get_jobs_info,
     get_pending_jobs_info,
+    is_static_node,
+    parse_nodename,
     set_nodes_down,
     set_nodes_drain,
     set_nodes_idle,
@@ -27,6 +29,47 @@ from common.schedulers.slurm_commands import (
     update_nodes,
 )
 from tests.common import read_text
+
+
+@pytest.mark.parametrize(
+    ("nodename", "expected_queue", "expected_node_type", "expected_instance_type", "expected_failure"),
+    [
+        ("queue1-st-c5-xlarge-1", "queue1", "st", "c5.xlarge", False),
+        ("queue-1-st-c5-xlarge-1", "queue-1", "st", "c5.xlarge", False),
+        ("queue1-st-dy-c5-xlarge-1", "queue1-st", "dy", "c5.xlarge", False),
+        ("queue1-dy-st-c5-xlarge-1", "queue1-dy", "st", "c5.xlarge", False),
+        ("queue1-dy-dy-dy-dy-c5-xlarge-1", "queue1-dy-dy-dy", "dy", "c5.xlarge", False),
+        # ("queue1-st-i3enmetal2tb-1", "queue1", "st", "i3en.metal-2tb", False), Not supported yet
+        ("queue1-st-u-6tb1-metal-1", "queue1", "st", "u-6tb1.metal", False),
+        ("queue1-st-c5.xlarge-1", None, None, None, True),
+        ("queue_1-st-c5-xlarge-1", None, None, None, True),
+    ],
+)
+def test_parse_nodename(nodename, expected_queue, expected_node_type, expected_instance_type, expected_failure):
+    if expected_failure:
+        with pytest.raises(Exception):
+            parse_nodename(nodename)
+    else:
+        queue_name, node_type, instance_type = parse_nodename(nodename)
+        assert_that(expected_queue).is_equal_to(queue_name)
+        assert_that(expected_node_type).is_equal_to(node_type)
+        assert_that(expected_instance_type).is_equal_to(instance_type)
+
+
+@pytest.mark.parametrize(
+    ("nodename", "expected_is_static"),
+    [
+        ("queue1-st-c5-xlarge-1", True),
+        ("queue-1-st-c5-xlarge-1", True),
+        ("queue1-st-dy-c5-xlarge-1", False),
+        ("queue1-dy-st-c5-xlarge-1", True),
+        ("queue1-dy-dy-dy-dy-c5-xlarge-1", False),
+        # ("queue1-st-i3en-metal2tb-1", True), Not supported yet
+        ("queue1-st-u-6tb1-metal-1", True),
+    ],
+)
+def test_is_static_node(nodename, expected_is_static):
+    assert_that(expected_is_static).is_equal_to(is_static_node(nodename))
 
 
 @pytest.mark.parametrize(
@@ -754,52 +797,74 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output):
 @pytest.mark.parametrize(
     "nodenames, nodeaddrs, hostnames, batch_size, expected_result",
     [
-        ("node-1,node-2,node-3", None, None, 2, [("node-1,node-2,node-3", None, None)]),
+        (
+            "queue1-st-c5-xlarge-1,queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3",
+            None,
+            None,
+            2,
+            [("queue1-st-c5-xlarge-1,queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3", None, None)],
+        ),
         (
             # Only split on commas after bucket
-            # So nodename like node-[1,3] can be processed safely
-            "node-[1-2],node-2,node-3,node-[4,6]",
+            # So nodename like queue1-st-c5-xlarge-[1,3] can be processed safely
+            "queue1-st-c5-xlarge-[1-2],queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3,queue1-st-c5-xlarge-[4,6]",
             "nodeaddr-[1-2],nodeaddr-2,nodeaddr-3,nodeaddr-[4,6]",
             None,
             2,
-            [("node-[1-2],node-2,node-3,node-[4,6]", "nodeaddr-[1-2],nodeaddr-2,nodeaddr-3,nodeaddr-[4,6]", None)],
+            [
+                (
+                    "queue1-st-c5-xlarge-[1-2],queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3,queue1-st-c5-xlarge-[4,6]",
+                    "nodeaddr-[1-2],nodeaddr-2,nodeaddr-3,nodeaddr-[4,6]",
+                    None,
+                )
+            ],
         ),
         (
-            "node-[1-2],node-2,node-[3],node-[4,6]",
+            "queue1-st-c5-xlarge-[1-2],queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-[3],queue1-st-c5-xlarge-[4,6]",
             "nodeaddr-[1-2],nodeaddr-2,nodeaddr-[3],nodeaddr-[4,6]",
             "nodehostname-[1-2],nodehostname-2,nodehostname-[3],nodehostname-[4,6]",
             2,
             [
                 (
-                    "node-[1-2],node-2,node-[3]",
+                    "queue1-st-c5-xlarge-[1-2],queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-[3]",
                     "nodeaddr-[1-2],nodeaddr-2,nodeaddr-[3]",
                     "nodehostname-[1-2],nodehostname-2,nodehostname-[3]",
                 ),
-                ("node-[4,6]", "nodeaddr-[4,6]", "nodehostname-[4,6]"),
+                ("queue1-st-c5-xlarge-[4,6]", "nodeaddr-[4,6]", "nodehostname-[4,6]"),
             ],
         ),
-        ("node-1,node-[2],node-3", ["nodeaddr-1"], None, 2, ValueError),
-        ("node-1,node-[2],node-3", None, ["nodehostname-1"], 2, ValueError),
+        ("queue1-st-c5-xlarge-1,queue1-st-c5-xlarge-[2],queue1-st-c5-xlarge-3", ["nodeaddr-1"], None, 2, ValueError),
         (
-            "node-1,node-2,node-3",
+            "queue1-st-c5-xlarge-1,queue1-st-c5-xlarge-[2],queue1-st-c5-xlarge-3",
+            None,
+            ["nodehostname-1"],
+            2,
+            ValueError,
+        ),
+        (
+            "queue1-st-c5-xlarge-1,queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3",
             ["nodeaddr-1", "nodeaddr-2"],
             "nodehostname-1,nodehostname-2,nodehostname-3",
             2,
             ValueError,
         ),
         (
-            ["node-1", "node-2", "node-3"],
+            ["queue1-st-c5-xlarge-1", "queue1-st-c5-xlarge-2", "queue1-st-c5-xlarge-3"],
             "nodeaddr-[1],nodeaddr-[2],nodeaddr-3",
             ["nodehostname-1", "nodehostname-2", "nodehostname-3"],
             2,
             [
-                ("node-1,node-2", "nodeaddr-[1],nodeaddr-[2]", "nodehostname-1,nodehostname-2"),
-                ("node-3", "nodeaddr-3", "nodehostname-3"),
+                (
+                    "queue1-st-c5-xlarge-1,queue1-st-c5-xlarge-2",
+                    "nodeaddr-[1],nodeaddr-[2]",
+                    "nodehostname-1,nodehostname-2",
+                ),
+                ("queue1-st-c5-xlarge-3", "nodeaddr-3", "nodehostname-3"),
             ],
         ),
         (
             # Test with strings of same length but different number of node entries
-            "node-[1-fillerr],node-[2-fillerr],node-[3-filler]",
+            "queue1-st-c5-xlarge-[1-fillerr],queue1-st-c5-xlarge-[2-fillerr],queue1-st-c5-xlarge-[3-filler]",
             "nodeaddr-1,nodeaddr-2,nodeaddr-3",
             ["nodehostname-1", "nodehostname-2", "nodehostname-3"],
             2,
@@ -947,14 +1012,19 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
     "batch_node_info, state, reason, raise_on_error, run_command_calls",
     [
         (
-            [("node-1", None, None), ("node-2,node-3", None, None)],
+            [("queue1-st-c5-xlarge-1", None, None), ("queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3", None, None)],
             None,
             None,
             False,
             [
-                call("/opt/slurm/bin/scontrol update nodename=node-1", raise_on_error=False, timeout=60, shell=True),
                 call(
-                    "/opt/slurm/bin/scontrol update nodename=node-2,node-3",
+                    "/opt/slurm/bin/scontrol update nodename=queue1-st-c5-xlarge-1",
+                    raise_on_error=False,
+                    timeout=60,
+                    shell=True,
+                ),
+                call(
+                    "/opt/slurm/bin/scontrol update nodename=queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3",
                     raise_on_error=False,
                     timeout=60,
                     shell=True,
@@ -962,19 +1032,24 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
             ],
         ),
         (
-            [("node-1", None, "hostname-1"), ("node-2,node-3", "addr-2,addr-3", None)],
+            [
+                ("queue1-st-c5-xlarge-1", None, "hostname-1"),
+                ("queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3", "addr-2,addr-3", None),
+            ],
             "power_down",
             None,
             True,
             [
                 call(
-                    "/opt/slurm/bin/scontrol update state=power_down nodename=node-1 nodehostname=hostname-1",
+                    "/opt/slurm/bin/scontrol update state=power_down "
+                    "nodename=queue1-st-c5-xlarge-1 nodehostname=hostname-1",
                     raise_on_error=True,
                     timeout=60,
                     shell=True,
                 ),
                 call(
-                    "/opt/slurm/bin/scontrol update state=power_down nodename=node-2,node-3 nodeaddr=addr-2,addr-3",
+                    "/opt/slurm/bin/scontrol update state=power_down "
+                    "nodename=queue1-st-c5-xlarge-2,queue1-st-c5-xlarge-3 nodeaddr=addr-2,addr-3",
                     raise_on_error=True,
                     timeout=60,
                     shell=True,
@@ -982,7 +1057,10 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
             ],
         ),
         (
-            [("node-1", None, "hostname-1"), ("node-[3-6]", "addr-[3-6]", "hostname-[3-6]")],
+            [
+                ("queue1-st-c5-xlarge-1", None, "hostname-1"),
+                ("queue1-st-c5-xlarge-[3-6]", "addr-[3-6]", "hostname-[3-6]"),
+            ],
             "down",
             "debugging",
             True,
@@ -990,7 +1068,7 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                 call(
                     (
                         '/opt/slurm/bin/scontrol update state=down reason="debugging"'
-                        + " nodename=node-1 nodehostname=hostname-1"
+                        + " nodename=queue1-st-c5-xlarge-1 nodehostname=hostname-1"
                     ),
                     raise_on_error=True,
                     timeout=60,
@@ -999,7 +1077,7 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                 call(
                     (
                         '/opt/slurm/bin/scontrol update state=down reason="debugging"'
-                        + " nodename=node-[3-6] nodeaddr=addr-[3-6] nodehostname=hostname-[3-6]"
+                        + " nodename=queue1-st-c5-xlarge-[3-6] nodeaddr=addr-[3-6] nodehostname=hostname-[3-6]"
                     ),
                     raise_on_error=True,
                     timeout=60,
@@ -1019,19 +1097,21 @@ def test_update_nodes(batch_node_info, state, reason, raise_on_error, run_comman
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("queue-_name-st-t2.mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
-        (SlurmNode("queuename-dy-t2.micro-1", "nodeip", "nodehostname", "somestate"), False),
+        (SlurmNode("queue-name-st-t2-mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
+        (SlurmNode("queue-name-st-dy-t2-mic-ro-1", "nodeip", "nodehostname", "somestate"), False),
+        (SlurmNode("queuename-dy-t2-micro-1", "nodeip", "nodehostname", "somestate"), False),
+        (SlurmNode("queuename-dy-dy-dy-st-t2-micro-1", "nodeip", "nodehostname", "somestate"), True),
     ],
 )
 def test_slurm_node_is_static(node, expected_output):
-    assert_that(node.is_static_node()).is_equal_to(expected_output)
+    assert_that(node.is_static).is_equal_to(expected_output)
 
 
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("queue-_name-st-t2.mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
-        (SlurmNode("queuename-dy-t2.micro-1", "queuename-dy-t2.micro-1", "nodehostname", "somestate"), False),
+        (SlurmNode("queue-name-st-t2-mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
+        (SlurmNode("queuename-dy-t2-micro-1", "queuename-dy-t2-micro-1", "nodehostname", "somestate"), False),
     ],
 )
 def test_slurm_node_is_nodeaddr_set(node, expected_output):
@@ -1041,12 +1121,12 @@ def test_slurm_node_is_nodeaddr_set(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("nodename", "nodeip", "nodehostname", "somestate"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN"), True),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), True),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "IDLE+CLOUD"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "DOWN+CLOUD"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "COMPLETING+DRAIN"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "somestate"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "COMPLETING+DRAIN"), True),
     ],
 )
 def test_slurm_node_has_job(node, expected_output):
@@ -1056,11 +1136,11 @@ def test_slurm_node_has_job(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("nodename", "nodeip", "nodehostname", "somestate"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "IDLE*+CLOUD+DRAIN"), True),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "somestate"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "IDLE*+CLOUD+DRAIN"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN"), True),
     ],
 )
 def test_slurm_node_is_drained(node, expected_output):
@@ -1070,11 +1150,11 @@ def test_slurm_node_is_drained(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("nodename", "nodeip", "nodehostname", "somestate"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "MIXED#+CLOUD+DOWN"), True),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "DOWN*+CLOUD"), True),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "DOWN+CLOUD+POWER"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "somestate"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DOWN"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "DOWN*+CLOUD"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+POWER"), True),
     ],
 )
 def test_slurm_node_is_down(node, expected_output):
@@ -1084,11 +1164,11 @@ def test_slurm_node_is_down(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("nodename", "nodeip", "nodehostname", "IDLE+CLOUD+POWER"), True),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DOWN"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "IDLE+CLOUD+POWERING_DOWN"), False),
-        (SlurmNode("nodename", "nodeip", "nodehostname", "IDLE#+CLOUD"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER"), True),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DOWN"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERING_DOWN"), False),
+        (SlurmNode("queue1-st-c5-xlarge-1", "nodeip", "nodehostname", "IDLE#+CLOUD"), True),
     ],
 )
 def test_slurm_node_is_up(node, expected_output):

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -721,26 +721,26 @@ def test_get_pending_jobs_info(
     [
         (
             (
-                "multiple-dynamic-c5-xlarge-1\n"
+                "multiple-dy-c5-xlarge-1\n"
                 "172.31.10.155\n"
                 "172-31-10-155\n"
                 "MIXED+CLOUD\n"
-                "multiple-dynamic-c5-xlarge-2\n"
+                "multiple-dy-c5-xlarge-2\n"
                 "172.31.7.218\n"
                 "172-31-7-218\n"
                 "IDLE+CLOUD+POWER\n"
-                "multiple-dynamic-c5-xlarge-3\n"
-                "multiple-dynamic-c5-xlarge-3\n"
-                "multiple-dynamic-c5-xlarge-3\n"
+                "multiple-dy-c5-xlarge-3\n"
+                "multiple-dy-c5-xlarge-3\n"
+                "multiple-dy-c5-xlarge-3\n"
                 "IDLE+CLOUD+POWER"
             ),
             [
-                SlurmNode("multiple-dynamic-c5-xlarge-1", "172.31.10.155", "172-31-10-155", "MIXED+CLOUD"),
-                SlurmNode("multiple-dynamic-c5-xlarge-2", "172.31.7.218", "172-31-7-218", "IDLE+CLOUD+POWER"),
+                SlurmNode("multiple-dy-c5-xlarge-1", "172.31.10.155", "172-31-10-155", "MIXED+CLOUD"),
+                SlurmNode("multiple-dy-c5-xlarge-2", "172.31.7.218", "172-31-7-218", "IDLE+CLOUD+POWER"),
                 SlurmNode(
-                    "multiple-dynamic-c5-xlarge-3",
-                    "multiple-dynamic-c5-xlarge-3",
-                    "multiple-dynamic-c5-xlarge-3",
+                    "multiple-dy-c5-xlarge-3",
+                    "multiple-dy-c5-xlarge-3",
+                    "multiple-dy-c5-xlarge-3",
                     "IDLE+CLOUD+POWER",
                 ),
             ],
@@ -1019,8 +1019,8 @@ def test_update_nodes(batch_node_info, state, reason, raise_on_error, run_comman
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("queue-_name-static-t2.mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
-        (SlurmNode("queuename-dynamic-t2.micro-1", "nodeip", "nodehostname", "somestate"), False),
+        (SlurmNode("queue-_name-st-t2.mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
+        (SlurmNode("queuename-dy-t2.micro-1", "nodeip", "nodehostname", "somestate"), False),
     ],
 )
 def test_slurm_node_is_static(node, expected_output):
@@ -1030,8 +1030,8 @@ def test_slurm_node_is_static(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (SlurmNode("queue-_name-static-t2.mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
-        (SlurmNode("queuename-dynamic-t2.micro-1", "queuename-dynamic-t2.micro-1", "nodehostname", "somestate"), False),
+        (SlurmNode("queue-_name-st-t2.mic-ro-1", "nodeip", "nodehostname", "somestate"), True),
+        (SlurmNode("queuename-dy-t2.micro-1", "queuename-dy-t2.micro-1", "nodehostname", "somestate"), False),
     ],
 )
 def test_slurm_node_is_nodeaddr_set(node, expected_output):

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -675,8 +675,8 @@ def test_is_node_being_replaced(
 @pytest.mark.parametrize(
     "node, expected_result",
     [
-        (SlurmNode("node-static-c5-xlarge-1", "node-static-c5-xlarge-1", "hostname", "IDLE+CLOUD"), False),
-        (SlurmNode("node-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), True),
+        (SlurmNode("node-st-c5-xlarge-1", "node-st-c5-xlarge-1", "hostname", "IDLE+CLOUD"), False),
+        (SlurmNode("node-st-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"), True),
     ],
     ids=["static_addr_not_set", "static_valid"],
 )
@@ -688,22 +688,22 @@ def test_is_static_node_configuration_valid(node, expected_result):
     "node, instances_ips_in_cluster, expected_result",
     [
         (
-            SlurmNode("node-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("node-st-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"),
             ["ip-2"],
             False,
         ),
         (
-            SlurmNode("node-dynamic-c5-xlarge-1", "node-dynamic-c5-xlarge-1", "hostname", "IDLE+CLOUD+POWER"),
+            SlurmNode("node-dy-c5-xlarge-1", "node-dy-c5-xlarge-1", "hostname", "IDLE+CLOUD+POWER"),
             ["ip-2"],
             True,
         ),
         (
-            SlurmNode("node-dynamic-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"),
+            SlurmNode("node-dy-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"),
             ["ip-2"],
             False,
         ),
         (
-            SlurmNode("node-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"),
+            SlurmNode("node-st-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER"),
             ["ip-1"],
             True,
         ),
@@ -783,7 +783,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
     "node, private_ip_to_instance_map, instance_ips_in_cluster, expected_result",
     [
         (
-            SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-st-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -792,7 +792,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             True,
         ),
         (
-            SlurmNode("queue-static-c5-xlarge-1", "queue-static-c5-xlarge-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-st-c5-xlarge-1", "queue-st-c5-xlarge-1", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -801,7 +801,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             False,
         ),
         (
-            SlurmNode("queue-dynamic-c5-xlarge-1", "queue-dynamic-c5-xlarge-1", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-dy-c5-xlarge-1", "queue-dy-c5-xlarge-1", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -810,7 +810,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             True,
         ),
         (
-            SlurmNode("queue-dynamic-c5-xlarge-1", "ip-3", "hostname", "IDLE+CLOUD"),
+            SlurmNode("queue-dy-c5-xlarge-1", "ip-3", "hostname", "IDLE+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -819,7 +819,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
             False,
         ),
         (
-            SlurmNode("queue-static-c5-xlarge-1", "ip-2", "hostname", "DOWN+CLOUD"),
+            SlurmNode("queue-st-c5-xlarge-1", "ip-2", "hostname", "DOWN+CLOUD"),
             {
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
@@ -1290,15 +1290,15 @@ def test_manage_cluster(
             "default.conf",
             [
                 # This node fail scheduler state check and corresponding instance will be terminated and replaced
-                SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+DRAIN"),
+                SlurmNode("queue-st-c5-xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+DRAIN"),
                 # This node fail scheduler state check and node will be power_down
-                SlurmNode("queue-dynamic-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
                 # This node is good and should not be touched by clustermgtd
-                SlurmNode("queue-dynamic-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
             ],
             [
-                SlurmNode("queue-static-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
-                SlurmNode("queue-dynamic-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-st-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
             ],
             [
                 # _get_ec2_instances: get all cluster instances by tags
@@ -1444,13 +1444,13 @@ def test_manage_cluster(
             # failures: All failure tolerant module will have an exception, but the program should not crash
             "default.conf",
             [
-                SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-st-c5-xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
             ],
             [
-                SlurmNode("queue-static-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
-                SlurmNode("queue-dynamic-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-st-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
             ],
             [
                 # _get_ec2_instances: get all cluster instances by tags
@@ -1599,7 +1599,7 @@ def test_manage_cluster(
                 r"Failed when performing health check action with exception",
                 r"Failed when terminating instances \(x1\) \['i-2'\]",
                 r"Failed when terminating instances \(x1\) \['i-1'\]",
-                r"Encountered exception when launching instances for nodes \(x1\) \['queue-static-c5.xlarge-1'\]",
+                r"Encountered exception when launching instances for nodes \(x1\) \['queue-st-c5.xlarge-1'\]",
                 r"Failed when terminating instances \(x1\) \['i-999'\]",
             ],
         ),
@@ -1607,13 +1607,13 @@ def test_manage_cluster(
             # critical_failure_1: _get_ec2_instances will have an exception, but the program should not crash
             "default.conf",
             [
-                SlurmNode("queue-static-c5-xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
-                SlurmNode("queue-dynamic-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-st-c5-xlarge-1", "ip-1", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-2", "ip-2", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-3", "ip-3", "hostname", "IDLE+CLOUD"),
             ],
             [
-                SlurmNode("queue-static-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
-                SlurmNode("queue-dynamic-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
+                SlurmNode("queue-st-c5-xlarge-4", "ip-4", "hostname", "IDLE+CLOUD"),
+                SlurmNode("queue-dy-c5-xlarge-5", "ip-5", "hostname", "DOWN+CLOUD"),
             ],
             [
                 # _get_ec2_instances: get all cluster instances by tags

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -78,10 +78,10 @@ class TestInstanceManager:
             (
                 {
                     "queue1": {
-                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
-                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
+                        "c5.xlarge": ["queue1-st-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-st-c5-2xlarge-1"],
                     },
-                    "queue2": {"c5.xlarge": ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"]},
+                    "queue2": {"c5.xlarge": ["queue2-st-c5-xlarge-1", "queue2-dy-c5-xlarge-1"]},
                 },
                 10,
                 True,
@@ -154,15 +154,15 @@ class TestInstanceManager:
                 None,
                 [
                     call(
-                        ["queue1-static-c5-xlarge-2"],
+                        ["queue1-st-c5-xlarge-2"],
                         [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     ),
                     call(
-                        ["queue1-static-c5-2xlarge-1"],
+                        ["queue1-st-c5-2xlarge-1"],
                         [EC2Instance("i-23456", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     ),
                     call(
-                        ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"],
+                        ["queue2-st-c5-xlarge-1", "queue2-dy-c5-xlarge-1"],
                         [
                             EC2Instance(
                                 "i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
@@ -178,10 +178,10 @@ class TestInstanceManager:
             (
                 {
                     "queue1": {
-                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
-                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
+                        "c5.xlarge": ["queue1-st-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-st-c5-2xlarge-1"],
                     },
-                    "queue2": {"c5.xlarge": ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"]},
+                    "queue2": {"c5.xlarge": ["queue2-st-c5-xlarge-1", "queue2-dy-c5-xlarge-1"]},
                 },
                 10,
                 True,
@@ -242,14 +242,14 @@ class TestInstanceManager:
                         },
                     ),
                 ],
-                ["queue1-static-c5-2xlarge-1"],
+                ["queue1-st-c5-2xlarge-1"],
                 [
                     call(
-                        ["queue1-static-c5-xlarge-2"],
+                        ["queue1-st-c5-xlarge-2"],
                         [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     ),
                     call(
-                        ["queue2-static-c5-xlarge-1", "queue2-dynamic-c5-xlarge-1"],
+                        ["queue2-st-c5-xlarge-1", "queue2-dy-c5-xlarge-1"],
                         [
                             EC2Instance(
                                 "i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
@@ -263,7 +263,7 @@ class TestInstanceManager:
             ),
             # no_update
             (
-                {"queue1": {"c5.xlarge": ["queue1-static-c5-xlarge-2"]}},
+                {"queue1": {"c5.xlarge": ["queue1-st-c5-xlarge-2"]}},
                 10,
                 False,
                 [
@@ -294,14 +294,14 @@ class TestInstanceManager:
             (
                 {
                     "queue1": {
-                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
-                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
+                        "c5.xlarge": ["queue1-st-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-st-c5-2xlarge-1"],
                     },
                     "queue2": {
                         "c5.xlarge": [
-                            "queue2-static-c5-xlarge-1",
-                            "queue2-static-c5-xlarge-2",
-                            "queue2-dynamic-c5-xlarge-1",
+                            "queue2-st-c5-xlarge-1",
+                            "queue2-st-c5-xlarge-2",
+                            "queue2-dy-c5-xlarge-1",
                         ],
                     },
                 },
@@ -349,14 +349,14 @@ class TestInstanceManager:
                     ),
                 ],
                 [
-                    "queue1-static-c5-2xlarge-1",
-                    "queue2-static-c5-xlarge-1",
-                    "queue2-static-c5-xlarge-2",
-                    "queue2-dynamic-c5-xlarge-1",
+                    "queue1-st-c5-2xlarge-1",
+                    "queue2-st-c5-xlarge-1",
+                    "queue2-st-c5-xlarge-2",
+                    "queue2-dy-c5-xlarge-1",
                 ],
                 [
                     call(
-                        ["queue1-static-c5-xlarge-2"],
+                        ["queue1-st-c5-xlarge-2"],
                         [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     )
                 ],
@@ -365,14 +365,14 @@ class TestInstanceManager:
             (
                 {
                     "queue1": {
-                        "c5.xlarge": ["queue1-static-c5-xlarge-2"],
-                        "c5.2xlarge": ["queue1-static-c5-2xlarge-1"],
+                        "c5.xlarge": ["queue1-st-c5-xlarge-2"],
+                        "c5.2xlarge": ["queue1-st-c5-2xlarge-1"],
                     },
                     "queue2": {
                         "c5.xlarge": [
-                            "queue2-static-c5-xlarge-1",
-                            "queue2-static-c5-xlarge-2",
-                            "queue2-dynamic-c5-xlarge-1",
+                            "queue2-st-c5-xlarge-1",
+                            "queue2-st-c5-xlarge-2",
+                            "queue2-dy-c5-xlarge-1",
                         ],
                     },
                 },
@@ -457,18 +457,18 @@ class TestInstanceManager:
                         },
                     ),
                 ],
-                ["queue1-static-c5-2xlarge-1", "queue2-static-c5-xlarge-2"],
+                ["queue1-st-c5-2xlarge-1", "queue2-st-c5-xlarge-2"],
                 [
                     call(
-                        ["queue1-static-c5-xlarge-2"],
+                        ["queue1-st-c5-xlarge-2"],
                         [EC2Instance("i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     ),
                     call(
-                        ["queue2-static-c5-xlarge-1"],
+                        ["queue2-st-c5-xlarge-1"],
                         [EC2Instance("i-34567", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     ),
                     call(
-                        ["queue2-dynamic-c5-xlarge-1"],
+                        ["queue2-dy-c5-xlarge-1"],
                         [EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     ),
                 ],
@@ -477,9 +477,9 @@ class TestInstanceManager:
                 {
                     "queue2": {
                         "c5.xlarge": [
-                            "queue2-static-c5-xlarge-1",
-                            "queue2-static-c5-xlarge-2",
-                            "queue2-dynamic-c5-xlarge-1",
+                            "queue2-st-c5-xlarge-1",
+                            "queue2-st-c5-xlarge-2",
+                            "queue2-dy-c5-xlarge-1",
                         ],
                     },
                 },
@@ -505,10 +505,10 @@ class TestInstanceManager:
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge"},
                     },
                 ),
-                ["queue2-static-c5-xlarge-2", "queue2-dynamic-c5-xlarge-1"],
+                ["queue2-st-c5-xlarge-2", "queue2-dy-c5-xlarge-1"],
                 [
                     call(
-                        ["queue2-static-c5-xlarge-1", "queue2-static-c5-xlarge-2", "queue2-dynamic-c5-xlarge-1"],
+                        ["queue2-st-c5-xlarge-1", "queue2-st-c5-xlarge-2", "queue2-dy-c5-xlarge-1"],
                         [EC2Instance("i-45678", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc))],
                     )
                 ],
@@ -895,12 +895,15 @@ class TestInstanceManager:
     @pytest.mark.parametrize(
         ("nodename", "expected_queue", "expected_instance_type", "expected_failure"),
         [
-            ("queue1-static-c5-xlarge-1", "queue1", "c5.xlarge", False),
-            ("queue-1-static-c5-xlarge-1", "queue-1", "c5.xlarge", False),
-            # ("queue1-static-i3en-metal-2tb-1", "queue1", "i3en.metal-2tb", False), not supported for now
-            ("queue1-static-u-6tb1-metal-1", "queue1", "u-6tb1.metal", False),
-            ("queue1-static-c5.xlarge-1", "queue1", "c5.xlarge", True),
-            ("queue_1-static-c5-xlarge-1", "queue_1", "c5.xlarge", True),
+            ("queue1-st-c5-xlarge-1", "queue1", "c5.xlarge", False),
+            ("queue-1-st-c5-xlarge-1", "queue-1", "c5.xlarge", False),
+            ("queue1-st-dy-c5-xlarge-1", "queue1-st", "c5.xlarge", False),
+            ("queue1-dy-st-c5-xlarge-1", "queue1-dy", "c5.xlarge", False),
+            ("queue1-dy-dy-dy-dy-c5-xlarge-1", "queue1-dy-dy-dy", "c5.xlarge", False),
+            # ("queue1-st-i3en-metal-2tb-1", "queue1", "i3en.metal-2tb", False), not supported for now
+            ("queue1-st-u-6tb1-metal-1", "queue1", "u-6tb1.metal", False),
+            ("queue1-st-c5.xlarge-1", "queue1", "c5.xlarge", True),
+            ("queue_1-st-c5-xlarge-1", "queue_1", "c5.xlarge", True),
         ],
     )
     def test_parse_nodename(self, nodename, expected_queue, expected_instance_type, expected_failure, instance_manager):
@@ -917,36 +920,36 @@ class TestInstanceManager:
         [
             (
                 [
-                    "queue1-static-c5-xlarge-1",
-                    "queue1-static-c5-xlarge-2",
-                    "queue1-dynamic-c5-xlarge-201",
-                    "queue2-static-g3-4xlarge-1",
-                    "in-valid/queue.name-static-c5-xlarge-2",
-                    "noBrackets-static-c5-xlarge-[1-2]",
-                    "queue2-dynamic-g3-8xlarge-1",
-                    "queue2-static-u-6tb1-metal-1",
+                    "queue1-st-c5-xlarge-1",
+                    "queue1-st-c5-xlarge-2",
+                    "queue1-dy-c5-xlarge-201",
+                    "queue2-st-g3-4xlarge-1",
+                    "in-valid/queue.name-st-c5-xlarge-2",
+                    "noBrackets-st-c5-xlarge-[1-2]",
+                    "queue2-dy-g3-8xlarge-1",
+                    "queue2-st-u-6tb1-metal-1",
                     "queue2-invalidnodetype-c5-xlarge-12",
-                    "queuename-with-dash-and_underscore-static-i3en-metal-2tb-1",
+                    "queuename-with-dash-and_underscore-st-i3en-metal-2tb-1",
                 ],
                 {
                     "queue1": {
                         "c5.xlarge": [
-                            "queue1-static-c5-xlarge-1",
-                            "queue1-static-c5-xlarge-2",
-                            "queue1-dynamic-c5-xlarge-201",
+                            "queue1-st-c5-xlarge-1",
+                            "queue1-st-c5-xlarge-2",
+                            "queue1-dy-c5-xlarge-201",
                         ]
                     },
                     "queue2": {
-                        "g3.4xlarge": ["queue2-static-g3-4xlarge-1"],
-                        "g3.8xlarge": ["queue2-dynamic-g3-8xlarge-1"],
-                        "u-6tb1.metal": ["queue2-static-u-6tb1-metal-1"],
+                        "g3.4xlarge": ["queue2-st-g3-4xlarge-1"],
+                        "g3.8xlarge": ["queue2-dy-g3-8xlarge-1"],
+                        "u-6tb1.metal": ["queue2-st-u-6tb1-metal-1"],
                     },
                 },
                 [
-                    "in-valid/queue.name-static-c5-xlarge-2",
-                    "noBrackets-static-c5-xlarge-[1-2]",
+                    "in-valid/queue.name-st-c5-xlarge-2",
+                    "noBrackets-st-c5-xlarge-[1-2]",
                     "queue2-invalidnodetype-c5-xlarge-12",
-                    "queuename-with-dash-and_underscore-static-i3en-metal-2tb-1",
+                    "queuename-with-dash-and_underscore-st-i3en-metal-2tb-1",
                 ],
             ),
         ],

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -562,37 +562,39 @@ class TestInstanceManager:
         ),
         [
             (
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
-                call(["node-1"], nodeaddrs=["ip-1"], nodehostnames=None),
+                call(["queue1-st-c5-xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=None),
                 [],
                 False,
                 "dns.domain",
             ),
-            (["node-1"], [], None, ["node-1"], False, "dns.domain"),
+            (["queue1-st-c5-xlarge-1"], [], None, ["queue1-st-c5-xlarge-1"], False, "dns.domain"),
             (
-                ["node-1", "node-2", "node-3", "node-4"],
+                ["queue1-st-c5-xlarge-1", "queue1-st-c5-xlarge-2", "queue1-st-c5-xlarge-3", "queue1-st-c5-xlarge-4"],
                 [
                     EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
                     EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
                 ],
-                call(["node-1", "node-2"], nodeaddrs=["ip-1", "ip-2"], nodehostnames=None),
-                ["node-3", "node-4"],
+                call(
+                    ["queue1-st-c5-xlarge-1", "queue1-st-c5-xlarge-2"], nodeaddrs=["ip-1", "ip-2"], nodehostnames=None
+                ),
+                ["queue1-st-c5-xlarge-3", "queue1-st-c5-xlarge-4"],
                 False,
                 "dns.domain",
             ),
             (
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
-                call(["node-1"], nodeaddrs=["ip-1"], nodehostnames=["hostname-1"]),
+                call(["queue1-st-c5-xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=["hostname-1"]),
                 [],
                 True,
                 "dns.domain",
             ),
             (
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
-                call(["node-1"], nodeaddrs=["ip-1"], nodehostnames=None),
+                call(["queue1-st-c5-xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=None),
                 [],
                 False,
                 "",
@@ -628,26 +630,26 @@ class TestInstanceManager:
         [
             (
                 None,
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 None,
                 "Empty table name configuration parameter",
             ),
             (
                 "table_name",
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [],
                 None,
                 None,
             ),
             (
                 "table_name",
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 [
                     call(
                         Item={
-                            "Id": "node-1",
+                            "Id": "queue1-st-c5-xlarge-1",
                             "InstanceId": "id-1",
                             "MasterPrivateIp": "master.ip",
                             "MasterHostname": "master-hostname",
@@ -658,7 +660,7 @@ class TestInstanceManager:
             ),
             (
                 "table_name",
-                ["node-1", "node-2"],
+                ["queue1-st-c5-xlarge-1", "queue1-st-c5-xlarge-2"],
                 [
                     EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
                     EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
@@ -666,7 +668,7 @@ class TestInstanceManager:
                 [
                     call(
                         Item={
-                            "Id": "node-1",
+                            "Id": "queue1-st-c5-xlarge-1",
                             "InstanceId": "id-1",
                             "MasterPrivateIp": "master.ip",
                             "MasterHostname": "master-hostname",
@@ -674,7 +676,7 @@ class TestInstanceManager:
                     ),
                     call(
                         Item={
-                            "Id": "node-2",
+                            "Id": "queue1-st-c5-xlarge-2",
                             "InstanceId": "id-2",
                             "MasterPrivateIp": "master.ip",
                             "MasterHostname": "master-hostname",
@@ -727,18 +729,26 @@ class TestInstanceManager:
             (
                 None,
                 "dns.domain",
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 None,
                 "Empty table name configuration parameter",
                 False,
             ),
-            ("hosted_zone", None, ["node-1"], [], None, "Empty table name configuration parameter", False),
-            ("hosted_zone", "dns.domain", ["node-1"], [], None, None, False),
+            (
+                "hosted_zone",
+                None,
+                ["queue1-st-c5-xlarge-1"],
+                [],
+                None,
+                "Empty table name configuration parameter",
+                False,
+            ),
+            ("hosted_zone", "dns.domain", ["queue1-st-c5-xlarge-1"], [], None, None, False),
             (
                 "hosted_zone",
                 "dns.domain",
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 MockedBoto3Request(
                     method="change_resource_record_sets",
@@ -756,7 +766,7 @@ class TestInstanceManager:
                                 {
                                     "Action": "UPSERT",
                                     "ResourceRecordSet": {
-                                        "Name": "node-1.dns.domain",
+                                        "Name": "queue1-st-c5-xlarge-1.dns.domain",
                                         "ResourceRecords": [{"Value": "ip-1"}],
                                         "Type": "A",
                                         "TTL": 120,
@@ -772,7 +782,7 @@ class TestInstanceManager:
             (
                 "hosted_zone",
                 "dns.domain",
-                ["node-1", "node-2"],
+                ["queue1-st-c5-xlarge-1", "queue1-st-c5-xlarge-2"],
                 [
                     EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
                     EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
@@ -794,7 +804,7 @@ class TestInstanceManager:
                                     {
                                         "Action": "UPSERT",
                                         "ResourceRecordSet": {
-                                            "Name": "node-1.dns.domain",
+                                            "Name": "queue1-st-c5-xlarge-1.dns.domain",
                                             "ResourceRecords": [{"Value": "ip-1"}],
                                             "Type": "A",
                                             "TTL": 120,
@@ -803,7 +813,7 @@ class TestInstanceManager:
                                     {
                                         "Action": "UPSERT",
                                         "ResourceRecordSet": {
-                                            "Name": "node-2.dns.domain",
+                                            "Name": "queue1-st-c5-xlarge-2.dns.domain",
                                             "ResourceRecords": [{"Value": "ip-2"}],
                                             "Type": "A",
                                             "TTL": 120,
@@ -820,7 +830,7 @@ class TestInstanceManager:
             (
                 "hosted_zone",
                 "dns.domain",
-                ["node-1"],
+                ["queue1-st-c5-xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 MockedBoto3Request(
                     method="change_resource_record_sets",
@@ -832,7 +842,7 @@ class TestInstanceManager:
                                 {
                                     "Action": "UPSERT",
                                     "ResourceRecordSet": {
-                                        "Name": "node-1.dns.domain",
+                                        "Name": "queue1-st-c5-xlarge-1.dns.domain",
                                         "ResourceRecords": [{"Value": "ip-1"}],
                                         "Type": "A",
                                         "TTL": 120,
@@ -891,29 +901,6 @@ class TestInstanceManager:
                 instance_manager._update_dns_hostnames(assigned_nodes)
         else:
             instance_manager._update_dns_hostnames(assigned_nodes)
-
-    @pytest.mark.parametrize(
-        ("nodename", "expected_queue", "expected_instance_type", "expected_failure"),
-        [
-            ("queue1-st-c5-xlarge-1", "queue1", "c5.xlarge", False),
-            ("queue-1-st-c5-xlarge-1", "queue-1", "c5.xlarge", False),
-            ("queue1-st-dy-c5-xlarge-1", "queue1-st", "c5.xlarge", False),
-            ("queue1-dy-st-c5-xlarge-1", "queue1-dy", "c5.xlarge", False),
-            ("queue1-dy-dy-dy-dy-c5-xlarge-1", "queue1-dy-dy-dy", "c5.xlarge", False),
-            # ("queue1-st-i3en-metal-2tb-1", "queue1", "i3en.metal-2tb", False), not supported for now
-            ("queue1-st-u-6tb1-metal-1", "queue1", "u-6tb1.metal", False),
-            ("queue1-st-c5.xlarge-1", "queue1", "c5.xlarge", True),
-            ("queue_1-st-c5-xlarge-1", "queue_1", "c5.xlarge", True),
-        ],
-    )
-    def test_parse_nodename(self, nodename, expected_queue, expected_instance_type, expected_failure, instance_manager):
-        if expected_failure:
-            with pytest.raises(Exception):
-                instance_manager._parse_nodename(nodename)
-        else:
-            queue_name, instance_type = instance_manager._parse_nodename(nodename)
-            assert_that(expected_queue).is_equal_to(queue_name)
-            assert_that(expected_instance_type).is_equal_to(instance_type)
 
     @pytest.mark.parametrize(
         ("node_list", "expected_results", "expected_failed_nodes"),

--- a/tests/slurm_plugin/test_computemgtd.py
+++ b/tests/slurm_plugin/test_computemgtd.py
@@ -92,15 +92,15 @@ def test_get_clustermgtd_heartbeat(time, expected_parsed_time, mocker):
     "mock_node_info, expected_result",
     [
         (
-            [SlurmNode("nodename-1", "ip-1", "host-1", "DOWN*+CLOUD")],
+            [SlurmNode("queue1-st-c5-xlarge-1", "ip-1", "host-1", "DOWN*+CLOUD")],
             True,
         ),
         (
-            [SlurmNode("nodename-1", "ip-1", "host-1", "IDLE+CLOUD+DRAIN")],
+            [SlurmNode("queue1-st-c5-xlarge-1", "ip-1", "host-1", "IDLE+CLOUD+DRAIN")],
             False,
         ),
         (
-            [SlurmNode("nodename-1", "ip-1", "host-1", "DOWN+CLOUD+DRAIN")],
+            [SlurmNode("queue1-st-c5-xlarge-1", "ip-1", "host-1", "DOWN+CLOUD+DRAIN")],
             True,
         ),
         (
@@ -116,4 +116,4 @@ def test_is_self_node_down(mock_node_info, expected_result, mocker):
     else:
         mocker.patch("slurm_plugin.computemgtd._get_nodes_info_with_retry", return_value=mock_node_info)
 
-    assert_that(_is_self_node_down("nodename-1")).is_equal_to(expected_result)
+    assert_that(_is_self_node_down("queue1-st-c5-xlarge-1")).is_equal_to(expected_result)


### PR DESCRIPTION
## Use st/dy in place of static/dynamic as node type identifier

Added extra tests to the parse_nodename function

## Use parse_nodename to evaluate if a node is a static one

The test we were using `'-st-' in self.name` was not safe.
Now we're parsing the slurm nodename when initializing the `SlurmNode` object and saving the info in the `is_static` variable.

The same methods will be used by clustermgtd and instance manager.

Added tests for `is_static_node`

