### PR TITLE
Increased clustermgtd_timeout to 5 minutes

### DIFF
--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -37,7 +37,7 @@ class ComputemgtdConfig:
         "max_retry": 1,
         "loop_time": LOOP_TIME,
         "proxy": "NONE",
-        "clustermgtd_timeout": 180,
+        "clustermgtd_timeout": 300,
         "disable_computemgtd_actions": False,
         "slurm_nodename_file": os.path.join(CONFIG_FILE_DIR, "slurm_nodename"),
         "logging_config": os.path.join(

--- a/tests/slurm_plugin/test_computemgtd.py
+++ b/tests/slurm_plugin/test_computemgtd.py
@@ -32,7 +32,7 @@ from slurm_plugin.computemgtd import ComputemgtdConfig, _get_clustermgtd_heartbe
                 "cluster_name": "hit",
                 "region": "us-east-2",
                 "_boto3_config": {"retries": {"max_attempts": 1, "mode": "standard"}},
-                "clustermgtd_timeout": 180,
+                "clustermgtd_timeout": 300,
                 "clustermgtd_heartbeat_file_path": "/home/ec2-user/clustermgtd_heartbeat",
                 "disable_computemgtd_actions": False,
                 "_slurm_nodename_file": "/etc/parallelcluster/slurm_plugin/slurm_nodename",


### PR DESCRIPTION
This is done to be less aggressive when terminating nodes from computemgtd

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
