### PR TITLE
Fix to clustermgtd

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -333,26 +333,22 @@ def _parse_partition_name_and_state(partition_info):
 
 def _get_partition_nodes(partition_name, command_timeout=5):
     """Get up nodes in a parition by querying sinfo, and filtering out power_down nodes."""
-    show_all_nodes_command = f"{SINFO} -h -p {partition_name} -o %N | tr ',' '\n'"
-    # To-do: add logic to include power_down nodes that are not idle
-    # The above should not happen if system is functioning correctly and can be manually cleared with scontrol
-    show_power_down_nodes_command = f"{SINFO} -h -p {partition_name} -t power_down,powering_down -o %N | tr ',' '\n'"
-    # Results nodelists are grouped by dominating states and displayed in separate lines, split into a list
+    show_all_nodes_command = f"{SINFO} -h -p {partition_name} -N -o %N"
+    show_power_down_nodes_command = f"{SINFO} -h -p {partition_name} -t power_down,powering_down -N -o %N"
+    show_down_nodes_command = f"{SINFO} -h -p {partition_name} -t down -N -o %N"
+    # Every node is print on a separate line
     all_nodes = check_command_output(show_all_nodes_command, timeout=command_timeout, shell=True).splitlines()
     power_down_nodes = check_command_output(
         show_power_down_nodes_command, timeout=command_timeout, shell=True
     ).splitlines()
-    # This logic of getting all nodes then excluding power_down node is needed because of a current slurm limitation
-    # There is currently no sinfo filter that will show IDLE+CLOUD nodes
-    # The only way to see IDLE+CLOUD nodes is to show all
-    # There is also no "negation" filter to exclude power_down nodes
-    # To-do: modify into a logic using filters only, when there is filter available
-    # This simple not-in logic works because power_down nodes has to be a subset of all nodes
-    # At worst, if nodelist notation do not match exactly, we will just end up getting all nodes
-    # Which is the same as getting all nodes from scontrol
+    down_nodes = check_command_output(show_down_nodes_command, timeout=command_timeout, shell=True).splitlines()
     nodes = []
     for nodename in all_nodes:
-        if "-st-" in nodename or (nodename not in power_down_nodes and nodename != "n/a"):
+        # Always try to maintain the following nodes:
+        # Static nodes
+        # Any node in down
+        # Any node not in power_saving mode
+        if "-st-" in nodename or nodename in down_nodes or (nodename not in power_down_nodes and nodename != "n/a"):
             nodes.append(nodename)
     return ",".join(nodes)
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -130,7 +130,7 @@ class ClustermgtdConfig:
         # Terminate configs
         "terminate_max_batch_size": 1000,
         # Timeout to wait for node initialization, should be the same as ResumeTimeout
-        "node_replacement_timeout": 600,
+        "node_replacement_timeout": 3600,
         "terminate_drain_nodes": True,
         "terminate_down_nodes": True,
         "orphaned_instance_timeout": 120,
@@ -458,7 +458,7 @@ class ClusterManager:
 
             return active_nodes, inactive_nodes
         except Exception as e:
-            log.error("Failed when getting partition/node states from scheduler with exception %s" % e)
+            log.error("Failed when getting partition/node states from scheduler with exception %s", e)
             raise ClusterManager.SchedulerUnavailable
 
     def _clean_up_inactive_partition(self, inactive_nodes, cluster_instances):
@@ -502,7 +502,7 @@ class ClusterManager:
         try:
             return self._instance_manager.get_cluster_instances(include_master=False, alive_states_only=True)
         except Exception as e:
-            log.error("Failed when getting instance info from EC2 with exception %s" % e)
+            log.error("Failed when getting instance info from EC2 with exception %s", e)
             raise ClusterManager.EC2InstancesInfoUnavailable
 
     @log_exception(log, "performing health check action", catch_exception=Exception, raise_on_error=False)
@@ -789,10 +789,10 @@ class ClusterManager:
             slurm_nodes, private_ip_to_instance_map
         )
         if unhealthy_dynamic_nodes:
-            log.info("Found the following unhealthy dynamic nodes: %s", unhealthy_dynamic_nodes)
+            log.info("Found the following unhealthy dynamic nodes: %s", print_with_count(unhealthy_dynamic_nodes))
             self._handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes, private_ip_to_instance_map)
         if unhealthy_static_nodes:
-            log.info("Found the following unhealthy static nodes: %s", unhealthy_static_nodes)
+            log.info("Found the following unhealthy static nodes: %s", print_with_count(unhealthy_static_nodes))
             self._handle_unhealthy_static_nodes(unhealthy_static_nodes, private_ip_to_instance_map)
 
     @log_exception(log, "terminating orphaned instances", catch_exception=Exception, raise_on_error=False)

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -82,6 +82,8 @@ def log_exception(
 
 def print_with_count(resource_list):
     """Print resource list with the len of the list."""
+    if isinstance(resource_list, str):
+        return resource_list
     resource_list = list(resource_list)
     return f"(x{len(resource_list)}) {str(resource_list)}"
 

--- a/src/slurm_plugin/suspend.py
+++ b/src/slurm_plugin/suspend.py
@@ -17,7 +17,6 @@ from logging.config import fileConfig
 import argparse
 from configparser import ConfigParser
 
-from common.schedulers.slurm_commands import set_nodes_idle
 from slurm_plugin.common import CONFIG_FILE_DIR
 
 log = logging.getLogger(__name__)
@@ -42,45 +41,29 @@ class SlurmSuspendConfig:
         log.info(self.__repr__())
 
 
-def _set_nodes_idle(slurm_nodenames):
-    """
-    Set POWER_DOWN nodes back to IDLE by resuming the node.
-
-    This is also the fall back mechanism to handle failure when removing instances.
-    When encountering a failure, update the node state to IDLE so the node can be used for future jobs.
-    Cloud-sync daemon will be responsible for removing orphaned nodes.
-    """
-    log.info("Resuming the following nodes back to IDLE: %s", slurm_nodenames)
-    set_nodes_idle(slurm_nodenames, reset_node_addrs_hostname=True)
-
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("nodes", help="Nodes to release")
     args = parser.parse_args()
+    suspend_config = SlurmSuspendConfig(os.path.join(CONFIG_FILE_DIR, "parallelcluster_slurm_suspend.conf"))
     try:
-        suspend_config = SlurmSuspendConfig(os.path.join(CONFIG_FILE_DIR, "parallelcluster_slurm_suspend.conf"))
-        try:
-            # Configure root logger
-            fileConfig(suspend_config.logging_config, disable_existing_loggers=False)
-        except Exception as e:
-            default_log_file = "/var/log/parallelcluster/slurm_suspend.log"
-            logging.basicConfig(
-                filename=default_log_file,
-                level=logging.INFO,
-                format="%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s",
-            )
-            log.warning(
-                "Unable to configure logging from %s, using default settings and writing to %s.\nException: %s",
-                suspend_config.logging_config,
-                default_log_file,
-                e,
-            )
-        log.info("Resetting following nodes into IDLE. Clustermgtd will cleanup orphaned instances: %s", args.nodes)
-        _set_nodes_idle(args.nodes)
-        log.info("SuspendProgram finished.")
+        # Configure root logger
+        fileConfig(suspend_config.logging_config, disable_existing_loggers=False)
     except Exception as e:
-        log.exception("Encountered exception %s when setting following nodes to DOWN: %s", e, args.nodes)
+        default_log_file = "/var/log/parallelcluster/slurm_suspend.log"
+        logging.basicConfig(
+            filename=default_log_file,
+            level=logging.INFO,
+            format="%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s",
+        )
+        log.warning(
+            "Unable to configure logging from %s, using default settings and writing to %s.\nException: %s",
+            suspend_config.logging_config,
+            default_log_file,
+            e,
+        )
+    log.info("Suspending following nodes. Clustermgtd will cleanup orphaned instances: %s", args.nodes)
+    log.info("SuspendProgram finished. Nodes will be available after SuspendTimeout")
 
 
 if __name__ == "__main__":

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -64,7 +64,7 @@ class TestClustermgtdConfig:
                     "launch_max_batch_size": 500,
                     # terminate configs
                     "terminate_max_batch_size": 1000,
-                    "node_replacement_timeout": 600,
+                    "node_replacement_timeout": 3600,
                     "terminate_drain_nodes": True,
                     "terminate_down_nodes": True,
                     "orphaned_instance_timeout": 120,


### PR DESCRIPTION
* Change node_replacement_timeout=3600 to give more time for static nodes to spin up in case of long pre/post-install. This value should always be the same as ResumeTimeout
* Minor fix to logging
* Related to https://github.com/aws/aws-parallelcluster-cookbook/pull/710

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
