### PR TITLE
Fix suspend workflow and cluster stop/start workflow

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -352,7 +352,10 @@ class ClusterManager:
                 # partitions and EC2 instances
                 if self._compute_fleet_status == ComputeFleetStatus.STOP_REQUESTED:
                     self._update_compute_fleet_status(ComputeFleetStatus.STOPPING)
-                partitions_deactivated_successfully = update_all_partitions(PartitionStatus.INACTIVE)
+                # When setting partition to INACTIVE, always try to reset nodeaddr/nodehostname to avoid issue
+                partitions_deactivated_successfully = update_all_partitions(
+                    PartitionStatus.INACTIVE, reset_node_addrs_hostname=True
+                )
                 nodes_terminated = self._instance_manager.terminate_all_compute_nodes(
                     self._config.terminate_max_batch_size
                 )
@@ -362,7 +365,10 @@ class ClusterManager:
             elif ComputeFleetStatus.is_start_in_progress(self._compute_fleet_status):
                 if self._compute_fleet_status == ComputeFleetStatus.START_REQUESTED:
                     self._update_compute_fleet_status(ComputeFleetStatus.STARTING)
-                partitions_activated_successfully = update_all_partitions(PartitionStatus.UP)
+                # When setting partition to UP, DO NOT reset nodeaddr/nodehostname to avoid breaking nodes already up
+                partitions_activated_successfully = update_all_partitions(
+                    PartitionStatus.UP, reset_node_addrs_hostname=False
+                )
                 if partitions_activated_successfully:
                     self._update_compute_fleet_status(ComputeFleetStatus.RUNNING)
         except ComputeFleetStatusManager.ConditionalStatusUpdateFailed:

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1812,7 +1812,10 @@ def test_manage_compute_fleet_status_transitions(
 
     # Check partitions updated correctly
     if update_partition_status:
-        update_all_partitions_spy.assert_called_with(update_partition_status)
+        if update_partition_status == PartitionStatus.UP:
+            update_all_partitions_spy.assert_called_with(update_partition_status, reset_node_addrs_hostname=False)
+        else:
+            update_all_partitions_spy.assert_called_with(update_partition_status, reset_node_addrs_hostname=True)
     else:
         update_all_partitions_spy.assert_not_called()
     # Check nodes terminated correctly


### PR DESCRIPTION
* Change suspend logic to reset nodeaddr/nodehostname on power_down
* Change cluster stop logic to reset nodeaddr/nodehostname when setting partition to INACTIVE

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
