### PR TITLE
Set nodes to power_down when deactivating a partition

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -485,7 +485,12 @@ class ClusterManager:
                 )
                 # Try to reset nodeaddr if possible to avoid potential problems
                 try:
-                    reset_nodes([node.name for node in inactive_nodes], raise_on_error=False)
+                    reset_nodes(
+                        [node.name for node in inactive_nodes],
+                        raise_on_error=False,
+                        state="power_down",
+                        reason="inactive partition",
+                    )
                 except Exception as e:
                     log.error("Encountered exception when resetting nodeaddr for INACTIVE nodes: %s", e)
             instances_still_in_cluster = []

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -125,7 +125,7 @@ def _get_clustermgtd_heartbeat(clustermgtd_heartbeat_file_path):
         # Note: heartbeat must be written with datetime.strftime to convert localized datetime into str
         # datetime.strptime will not work with str(datetime)
         # Example timestamp written to heartbeat file: 2020-07-30 19:34:02.613338+00:00
-        return datetime.strptime(timestamp_file.read(), TIMESTAMP_FORMAT)
+        return datetime.strptime(timestamp_file.read().strip(), TIMESTAMP_FORMAT)
 
 
 def _expired_clustermgtd_heartbeat(last_heartbeat, current_time, clustermgtd_timeout):

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -297,7 +297,9 @@ def test_clean_up_inactive_parititon(
     result = cluster_manager._clean_up_inactive_partition(inactive_nodes, mock_cluster_instances)
     mock_instance_manager.delete_instances.assert_called_with(mock_backing_instances, terminate_batch_size=4)
     if delete_instances_side_effect is not Exception:
-        mock_reset_node.assert_called_with(["queue1-st-c5xlarge-3"], raise_on_error=False)
+        mock_reset_node.assert_called_with(
+            ["queue1-st-c5xlarge-3"], raise_on_error=False, reason="inactive partition", state="power_down"
+        )
     assert_that(result).is_equal_to(expected_result)
 
 


### PR DESCRIPTION
Set nodes to power_down when deactivating a partition. Same behavior as in stop so that dynamic nodes are available right away when reactivating partition.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
