### PR TITLE
Always reset nodeaddrs for nodes

### DIFF
--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -1175,6 +1175,7 @@ def test_slurm_node_is_drained(node, expected_output):
         (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN"), False),
         (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN*+CLOUD"), True),
         (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+POWER"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE~+CLOUD+POWERING_DOWN"), False),
     ],
 )
 def test_slurm_node_is_down(node, expected_output):


### PR DESCRIPTION
* Change logic to retrieve all node information instead of filtering out power_down nodes
* Reset nodeaddrs whenever there is no backing instance to keep cluster in a consistent state

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
