### PR TITLE
Upload cluster metrics to CloudWatch for slurm

### DIFF
--- a/src/slurm_plugin/metrics.py
+++ b/src/slurm_plugin/metrics.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import abc
+import sys
+from datetime import datetime, timezone
+
+if sys.version_info >= (3, 4):  # FIXME: Is it really needed? Which Python version is installed on Master instance?
+    ABC = abc.ABC
+else:
+    ABC = abc.ABCMeta("ABC", (), {})
+
+MISSED_METRICS_UPDATE_FACTOR = 3
+
+
+class MetricsProvider(ABC):
+    @abc.abstractmethod
+    def update_metric_values(self, metrics):
+        pass
+
+
+class ActiveNodesMetricsProvider(MetricsProvider):
+    def __init__(self, slurm_active_nodes):
+        self._slurm_active_nodes = slurm_active_nodes
+
+    def update_metric_values(self, metrics):
+        num_power_up_nodes = 0
+        num_power_down_nodes = 0
+
+        for node in self._slurm_active_nodes:
+            if node.is_nodeaddr_set():
+                num_power_up_nodes += 1
+            else:
+                num_power_down_nodes += 1
+        metrics["slurm_number_power_up_nodes"] = num_power_up_nodes
+        metrics["slurm_number_power_down_nodes"] = num_power_down_nodes
+
+
+class MetricsCollector:
+    def __init__(self):
+        self.timestamp = datetime(2020, 7, 6, tzinfo=timezone.utc)
+        self.metrics = {}
+        self.metrics_providers = {}
+        self.config = None
+
+    def add_metric(self, name, value):
+        self.metrics[name] = value
+
+    def add_metrics_provider(self, name, metrics_provider):
+        self.metrics_providers[name] = metrics_provider
+
+    def get_values(self):
+        time_since_last_metric = int((datetime.now(tz=timezone.utc) - self.timestamp).total_seconds())
+        time_between_metrics_update = self.config.loop_time if self.config else -1
+        # If the metrics have not been updated for a long time (MISSED_METRICS_UPDATE_FACTOR updates missed)
+        # do not return anything
+        if time_since_last_metric < MISSED_METRICS_UPDATE_FACTOR * time_between_metrics_update:
+            # Getting metrics from metrics providers
+            for metrics_provider in self.metrics_providers.values():
+                metrics_provider.update_metric_values(self.metrics)
+            return self.metrics
+        return {}

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -79,8 +79,7 @@ class TestClustermgtdConfig:
                     "disable_scheduled_event_health_check": False,
                     "disable_all_health_checks": False,
                     "health_check_timeout": 180,
-                    # Disable pushing cluster metrics to cloudwatch
-                    "disable_push_metrics_to_cloudwatch": False,
+                    "disable_cloudwatch_metrics": False,
                 },
             ),
             (
@@ -112,8 +111,7 @@ class TestClustermgtdConfig:
                     "disable_scheduled_event_health_check": True,
                     "disable_all_health_checks": False,
                     "health_check_timeout": 10,
-                    # Disable pushing cluster metrics to cloudwatch
-                    "disable_push_metrics_to_cloudwatch": True,
+                    "disable_cloudwatch_metrics": True,
                 },
             ),
             (

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -25,10 +25,10 @@ import slurm_plugin
 from common.schedulers.slurm_commands import PartitionStatus, SlurmNode, SlurmPartition, update_all_partitions
 from slurm_plugin.clustermgtd import (
     ClusterManager,
-    ClusterMetrics,
     ClustermgtdConfig,
     ComputeFleetStatus,
     ComputeFleetStatusManager,
+    MetricsCollector,
 )
 from slurm_plugin.common import (
     EC2_HEALTH_STATUS_UNHEALTHY_STATES,
@@ -1339,11 +1339,11 @@ def test_manage_cluster(
         return_value=(mock_active_nodes, mock_inactive_nodes),
     )
 
-    cluster_metrics = ClusterMetrics()
+    metrics_collector = MetricsCollector()
     # TODO add mock.assert_called_once() if we had setters instead of setting attributes directly
 
     # Run test
-    cluster_manager.manage_cluster(cluster_metrics)
+    cluster_manager.manage_cluster(metrics_collector)
     # Assert function calls
     initialize_instance_manager_mock.assert_called_once()
     initialize_compute_fleet_status_manager_mock.assert_called_once()
@@ -1784,8 +1784,8 @@ def test_manage_cluster_boto3(
         )
     cluster_manager._instance_manager._store_assigned_hostnames = mocker.MagicMock()
     cluster_manager._instance_manager._update_dns_hostnames = mocker.MagicMock()
-    cluster_metrics = ClusterMetrics()
-    cluster_manager.manage_cluster(cluster_metrics)
+    metrics_collector = MetricsCollector()
+    cluster_manager.manage_cluster(metrics_collector)
 
     assert_that(expected_error_messages).is_length(len(caplog.records))
     for actual, expected in zip(caplog.records, expected_error_messages):
@@ -2024,5 +2024,5 @@ def initialize_compute_fleet_status_manager_mock(mocker):
     )
 
 
-# TODO Add tests to verify the behaviour of _upload_cluster_metrics (we could mock boto3 calls as in
+# TODO Add tests to verify the behaviour of _push_metrics_to_cloudwatch (we could mock boto3 calls as in
 # test_manage_cluster_boto3 maybe)

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -79,6 +79,8 @@ class TestClustermgtdConfig:
                     "disable_scheduled_event_health_check": False,
                     "disable_all_health_checks": False,
                     "health_check_timeout": 180,
+                    # Disable pushing cluster metrics to cloudwatch
+                    "disable_push_metrics_to_cloudwatch": False,
                 },
             ),
             (
@@ -110,6 +112,8 @@ class TestClustermgtdConfig:
                     "disable_scheduled_event_health_check": True,
                     "disable_all_health_checks": False,
                     "health_check_timeout": 10,
+                    # Disable pushing cluster metrics to cloudwatch
+                    "disable_push_metrics_to_cloudwatch": True,
                 },
             ),
             (

--- a/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
+++ b/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
@@ -24,4 +24,4 @@ master_hostname = master-hostname
 hosted_zone = hosted-zone
 dns_domain = dns.domain
 use_private_hostname = false
-disable_push_metrics_to_cloudwatch = True
+disable_cloudwatch_metrics = True

--- a/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
+++ b/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
@@ -24,3 +24,4 @@ master_hostname = master-hostname
 hosted_zone = hosted-zone
 dns_domain = dns.domain
 use_private_hostname = false
+disable_push_metrics_to_cloudwatch = True


### PR DESCRIPTION
With this commit, cluster metrics are uploaded to CloudWatch. In order not to impact the job of the current clustermgtd, a separate thread was created to upload those metrics. Threads were used instead of processes as the functions here are I/O bound, threads are thus suitable. Some code has been added to the current deamon so that it saves the information it requests from the scheduler or from ec2. This information is then used by the second thread to upload the cluster metrics.
Testing: still to do, just modified so that it passed current tests but test coverage is less good as the new functions are not tested (and some code has been added in the old deamon)
Handling exception: working on it as exceptions from a sub-thread is not raised to the thread.

Signed-off-by: Alexandre Gobeaux <gobeaa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
