### PR TITLE
Add node memory size to slurm config

### DIFF
--- a/src/sqswatcher/plugins/slurm.py
+++ b/src/sqswatcher/plugins/slurm.py
@@ -136,8 +136,11 @@ def _update_node_lists(update_events):
         elif event.action == EventType.ADD:
             # Only include GPU info if instance has GPU
             gpu_info = "Gres=gpu:tesla:{gpus} ".format(gpus=event.host.gpus) if event.host.gpus != 0 else ""
-            new_node = "NodeName={nodename} CPUs={cpus} {gpu_info}State=UNKNOWN\n".format(
-                nodename=event.host.hostname, cpus=event.host.slots, gpu_info=gpu_info
+            new_node = "NodeName={nodename} CPUs={cpus} RealMemory={memory} {gpu_info}State=UNKNOWN\n".format(
+                nodename=event.host.hostname,
+                cpus=event.host.slots,
+                memory=int(event.host.memory * 0.95),  # We can only use ~95% of the total physical RAM with slurm
+                gpu_info=gpu_info,
             )
 
             if new_node not in node_list:

--- a/src/sqswatcher/sqswatcher.py
+++ b/src/sqswatcher/sqswatcher.py
@@ -274,11 +274,12 @@ def _process_compute_ready_event(sqs_config_region, sqs_config_proxy, message_at
     # Get instances properties for each event because instance types
     # from instance and CloudFormation could be out-of-sync
     instance_properties = get_instance_properties(sqs_config_region, sqs_config_proxy, instance_type)
+    memory = instance_properties["memory"]
     gpus = instance_properties["gpus"]
     slots = message_attrs.get("Slots")
     hostname = message_attrs.get("LocalHostname").split(".")[0]
     _retry_on_request_limit_exceeded(lambda: table.put_item(Item={"instanceId": instance_id, "hostname": hostname}))
-    return UpdateEvent(EventType.ADD, message, Host(instance_id, hostname, slots, gpus))
+    return UpdateEvent(EventType.ADD, message, Host(instance_id, hostname, slots, gpus, memory))
 
 
 def _process_instance_terminate_event(message_attrs, message, table, queue):
@@ -295,7 +296,7 @@ def _process_instance_terminate_event(message_attrs, message, table, queue):
 
     if item.get("Item") is not None:
         hostname = item.get("Item").get("hostname")
-        return UpdateEvent(EventType.REMOVE, message, Host(instance_id, hostname, None, None))
+        return UpdateEvent(EventType.REMOVE, message, Host(instance_id, hostname, None, None, None))
     else:
         log.error("Instance %s not found in the database.", instance_id)
         _requeue_message(queue, message)

--- a/tests/common/schedulers/test_sge_commands.py
+++ b/tests/common/schedulers/test_sge_commands.py
@@ -277,7 +277,11 @@ def test_qconf_commands(qconf_output, command, expected_succeeded_hosts, mocker)
     mock = mocker.patch(
         "common.schedulers.sge_commands.check_sge_command_output", return_value=qconf_output, autospec=True
     )
-    hosts = [Host("id", "ip-10-0-0-157", 1, 0), Host("id", "ip-10-0-0-155", 1, 0), Host("id", "ip-10-0-0", 1, 0)]
+    hosts = [
+        Host("id", "ip-10-0-0-157", 1, 0, 1),
+        Host("id", "ip-10-0-0-155", 1, 0, 1),
+        Host("id", "ip-10-0-0", 1, 0, 1),
+    ]
     succeeded_hosts = exec_qconf_command(hosts, QCONF_COMMANDS[command])
 
     mock.assert_called_with(

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -46,16 +46,18 @@ def test_get_instance_info_from_pricing_file(caplog, mocker):
     dummy_instance_type = "dummy-instance-type"
     dummy_args = ("dummy-region", "dummy-proxy-config", dummy_instance_type)
     dummy_instance_info = {"InstanceType": dummy_instance_type}
-    dummy_vcpus, dummy_gpus = 3, 1
+    dummy_vcpus, dummy_gpus, dummy_memory = 3, 1, 2
     fetch_instance_info_patch = mocker.patch("common.utils._fetch_instance_info", return_value=dummy_instance_info)
     get_vcpus_patch = mocker.patch("common.utils._get_vcpus_from_instance_info", return_value=dummy_vcpus)
     get_gpus_patch = mocker.patch("common.utils._get_gpus_from_instance_info", return_value=dummy_gpus)
-    returned_vcpus, returned_gpus = utils._get_instance_info_from_pricing_file(*dummy_args)
+    get_memory_patch = mocker.patch("common.utils._get_memory_from_instance_info", return_value=dummy_memory)
+    returned_vcpus, returned_gpus, returned_memory = utils._get_instance_info_from_pricing_file(*dummy_args)
     fetch_instance_info_patch.assert_called_with(*dummy_args)
-    for instance_info_func_patch in (get_vcpus_patch, get_gpus_patch):
+    for instance_info_func_patch in (get_vcpus_patch, get_gpus_patch, get_memory_patch):
         instance_info_func_patch.assert_called_with(dummy_instance_info)
     assert_that(returned_vcpus).is_equal_to(dummy_vcpus)
     assert_that(returned_gpus).is_equal_to(dummy_gpus)
+    assert_that(returned_memory).is_equal_to(dummy_memory)
     for log_message in [
         "Fetching info for instance_type {0}".format(dummy_instance_type),
         "Received the following information for instance type {0}: {1}".format(

--- a/tests/sqswatcher/plugins/test_slurm.py
+++ b/tests/sqswatcher/plugins/test_slurm.py
@@ -23,9 +23,9 @@ from sqswatcher.plugins.slurm import _update_gres_node_lists, _update_node_lists
         (
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n"],
             [
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
             ],
             [
                 "NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n",
@@ -35,8 +35,8 @@ from sqswatcher.plugins.slurm import _update_gres_node_lists, _update_node_lists
         (
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n"],
             [
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, 128)),
             ],
             [],
         ),
@@ -44,8 +44,8 @@ from sqswatcher.plugins.slurm import _update_gres_node_lists, _update_node_lists
             # GPU files should be updated after remove/add sequence
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-1]\n"],
             [
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
             ],
             ["NodeName=ip-10-0-000-111 Name=gpu Type=tesla File=/dev/nvidia[0-15]\n"],
         ),
@@ -64,37 +64,40 @@ def test_update_gres_node_lists(gres_node_list, events, expected_result, mocker)
     "gpu_node_list, events, expected_result",
     [
         (
-            ["NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 Gres=gpu:tesla:16 State=UNKNOWN\n"],
             [
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
             ],
             (
                 [
-                    "NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n",
-                    "NodeName=ip-10-0-000-222 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 Gres=gpu:tesla:16 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-222 CPUs=32 RealMemory=121 Gres=gpu:tesla:16 State=UNKNOWN\n",
                 ],
                 # Note nodes_to_restart list is expected to be repetitive because we want to restart with every ADD
                 ["ip-10-0-000-111", "ip-10-0-000-222", "ip-10-0-000-111"],
             ),
         ),
         (
-            ["NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 Gres=gpu:tesla:16 State=UNKNOWN\n"],
             [
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 16, 128)),
             ],
             ([], []),
         ),
         (
             # CPU/GPU information should be updated after remove/add sequence
-            ["NodeName=ip-10-0-000-111 CPUs=8 Gres=gpu:tesla:1 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 CPUs=8 RealMemory=121 Gres=gpu:tesla:1 State=UNKNOWN\n"],
             [
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 16, 128)),
             ],
-            (["NodeName=ip-10-0-000-111 CPUs=32 Gres=gpu:tesla:16 State=UNKNOWN\n"], ["ip-10-0-000-111"]),
+            (
+                ["NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 Gres=gpu:tesla:16 State=UNKNOWN\n"],
+                ["ip-10-0-000-111"],
+            ),
         ),
     ],
     ids=["repetitive_add", "remove_nonexisting_node", "reusing_nodename"],
@@ -111,37 +114,37 @@ def test_gpu_update_node_lists(gpu_node_list, events, expected_result, mocker):
     "node_list, events, expected_result",
     [
         (
-            ["NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 State=UNKNOWN\n"],
             [
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, 128)),
             ],
             (
                 [
-                    "NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n",
-                    "NodeName=ip-10-0-000-222 CPUs=32 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 State=UNKNOWN\n",
+                    "NodeName=ip-10-0-000-222 CPUs=32 RealMemory=121 State=UNKNOWN\n",
                 ],
                 # Note nodes_to_restart list is expected to be repetitive because we want to restart with every ADD
                 ["ip-10-0-000-111", "ip-10-0-000-222", "ip-10-0-000-111"],
             ),
         ),
         (
-            ["NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 State=UNKNOWN\n"],
             [
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, 128)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-222", "32", 0, 128)),
             ],
             ([], []),
         ),
         (
             # CPU information should be updated after remove/add sequence
-            ["NodeName=ip-10-0-000-111 CPUs=8 State=UNKNOWN\n"],
+            ["NodeName=ip-10-0-000-111 CPUs=8 RealMemory=121 State=UNKNOWN\n"],
             [
-                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
-                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0)),
+                UpdateEvent(EventType.REMOVE, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, 128)),
+                UpdateEvent(EventType.ADD, "some message", Host("i-0c1234567", "ip-10-0-000-111", "32", 0, 128)),
             ],
-            (["NodeName=ip-10-0-000-111 CPUs=32 State=UNKNOWN\n"], ["ip-10-0-000-111"]),
+            (["NodeName=ip-10-0-000-111 CPUs=32 RealMemory=121 State=UNKNOWN\n"], ["ip-10-0-000-111"]),
         ),
     ],
     ids=["repetitive_add", "remove_nonexisting_node", "reusing_nodename"],


### PR DESCRIPTION
*Issue #, if available:*

None, as it looks like issues are disabled for this repo.

*Description of changes:*

I want to use memory as a consumable resource in my slurm configuration. 
This adds the required configuration to slurm on a per node basis as new nodes come online. This is required for trying to do this with mixed node types.

This will have no impact on anyone running the current configuration. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
