### PR TITLE
Fix clustermgtd and computemgtd sleep time computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+
+2.10.0
+-----
+
+**BUG FIXES**
+- Fix a bug that was causing clustermgtd and computemgtd sleep interval to be incorrectly computed when
+  system timezone is not set to UTC.
+
 2.9.1
 -----
 

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -387,20 +387,14 @@ def get_compute_instance_type(region, proxy_config, stack_name, fallback):
 
 
 def sleep_remaining_loop_time(total_loop_time, loop_start_time=None):
-    end_time = datetime.now()
+    end_time = datetime.now(tz=timezone.utc)
     if not loop_start_time:
         loop_start_time = end_time
-    # Always try to localize datetime objects to UTC if not previously localized
-    # For example, datetime in tradition daemons are not localized(sqswatcher, jobwatcher, ...)
-    # Daemons in HIT integration are required to use localized datetime
-    # This operation DOES NOT convert datetime from 1 timezone into UTC
-    # It simply replaces the timezone info if datetime is not localized
-    if not end_time.tzinfo:
-        end_time = end_time.replace(tzinfo=timezone.utc)
-    if not loop_start_time.tzinfo:
-        loop_start_time = loop_start_time.replace(tzinfo=timezone.utc)
+    # Always convert the received loop_start_time to utc timezone. This is so that we never rely on the system local
+    # time and risk to compare naive datatime instances with localized ones
+    loop_start_time = loop_start_time.astimezone(tz=timezone.utc)
     time_delta = (end_time - loop_start_time).total_seconds()
-    if time_delta < total_loop_time:
+    if 0 <= time_delta < total_loop_time:
         time.sleep(total_loop_time - time_delta)
 
 

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -392,13 +392,13 @@ def time_is_up(initial_time, current_time, grace_time):
     """Check if timeout is exceeded."""
     # Localize datetime objects to UTC if not previously localized
     # All timestamps used in this function should be already localized
-    # Assume timestamp was taken from UTC is there is no localization info
+    # Assume timestamp was taken from system local time if there is no localization info
     if not initial_time.tzinfo:
         logger.warning("Timestamp %s is not localized. Please double check that this is expected, localizing to UTC.")
-        initial_time = initial_time.replace(tzinfo=timezone.utc)
+        initial_time = initial_time.astimezone(tz=timezone.utc)
     if not current_time.tzinfo:
         logger.warning("Timestamp %s is not localized. Please double check that this is expected, localizing to UTC")
-        current_time = current_time.replace(tzinfo=timezone.utc)
+        current_time = current_time.astimezone(tz=timezone.utc)
     time_diff = (current_time - initial_time).total_seconds()
     return time_diff >= grace_time
 


### PR DESCRIPTION
This was broken when the system timezone was not set to UTC because it was forcing the timezone to be UTC when unset. In Python's datetime object when timezone is unset the so called naive datetime relies on the system local time.

This addresses: https://github.com/aws/aws-parallelcluster/issues/2162

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
