### PR TITLE
Increase default Slurm commands timeout from 10 to 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This file is used to list changes made in each version of the aws-parallelcluste
 2.10.0
 -----
 
+**CHANGES**
+- Increase default timeout for Slurm commands submitted by clustermgtd and computemgtd from 10 to 30 seconds.
+
 **BUG FIXES**
 - Fix a bug that was causing clustermgtd and computemgtd sleep interval to be incorrectly computed when
   system timezone is not set to UTC.

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -51,7 +51,7 @@ SlurmPartition = collections.namedtuple("SlurmPartition", ["name", "nodes", "sta
 
 # Set default timeouts for running different slurm commands.
 # These timeouts might be needed when running on large scale
-DEFAULT_GET_INFO_COMMAND_TIMEOUT = 10
+DEFAULT_GET_INFO_COMMAND_TIMEOUT = 30
 DEFAULT_UPDATE_COMMAND_TIMEOUT = 60
 
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -440,12 +440,12 @@ class ClusterManager:
     @staticmethod
     @retry(stop_max_attempt_number=2, wait_fixed=1000)
     def _get_node_info_with_retry(nodes):
-        return get_nodes_info(nodes, command_timeout=10)
+        return get_nodes_info(nodes)
 
     @staticmethod
     @retry(stop_max_attempt_number=2, wait_fixed=1000)
     def _get_partition_info_with_retry():
-        return get_partition_info(command_timeout=10, get_all_nodes=True)
+        return get_partition_info(get_all_nodes=True)
 
     @staticmethod
     def _get_node_info_from_partition():

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -143,7 +143,7 @@ def _expired_clustermgtd_heartbeat(last_heartbeat, current_time, clustermgtd_tim
 
 @retry(stop_max_attempt_number=3, wait_fixed=1500)
 def _get_nodes_info_with_retry(nodes):
-    return get_nodes_info(nodes, command_timeout=10)
+    return get_nodes_info(nodes)
 
 
 def _is_self_node_down(self_nodename):


### PR DESCRIPTION
When the number of CLOUD nodes grows (meaning the sum of max_count of all compute resources is big) Slurm is slow at returning the list of all nodes (`scontrol show nodes`). 
Increasing the timeout to 30 seconds makes  it possible to work with bigger cluster sizes but in the long term we need to find a way to reduce the number of queried nodes.

### Tests
- Worked on a cluster with c5.xlarge as head node and 10000 configured CLOUD nodes
- Did not work on the same cluster and 15000 compute nodes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
