### PR TITLE
Optimized the retrieval of nodes info from Slurm scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 -----
 
 **CHANGES**
+- Optimized the retrieval of nodes info from Slurm scheduler.
 - Increase default timeout for Slurm commands submitted by clustermgtd and computemgtd from 10 to 30 seconds.
 
 **BUG FIXES**

--- a/tests/slurm_plugin/test_computemgtd.py
+++ b/tests/slurm_plugin/test_computemgtd.py
@@ -92,15 +92,15 @@ def test_get_clustermgtd_heartbeat(time, expected_parsed_time, mocker):
     "mock_node_info, expected_result",
     [
         (
-            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN*+CLOUD")],
+            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN*+CLOUD", "queue1")],
             True,
         ),
         (
-            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "IDLE+CLOUD+DRAIN")],
+            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "IDLE+CLOUD+DRAIN", "queue1")],
             False,
         ),
         (
-            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN+CLOUD+DRAIN")],
+            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN+CLOUD+DRAIN", "queue1")],
             True,
         ),
         (


### PR DESCRIPTION
Retrieving all nodes with scontrol show nodes is much faster than having Slurm filter those from inactive partition out.
Filtering is now performed in clustermgtd.

```
[ec2-user@ip-10-0-0-58 ~]$ time scontrol show nodes > /dev/null
real	0m2.475s
user	0m2.374s
sys	0m0.036s
[ec2-user@ip-10-0-0-58 ~]$ time scontrol show nodes compute-dy-c5xlarge-[1-50000] > /dev/null
real	5m22.115s
user	5m6.202s
sys	0m7.104s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
