### PR TITLE
Improve error handling in slurm plugin processes when clustermgtd is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 
 **CHANGES**
 - Use inclusive language in internal naming convention.
+- Improve error handling in slurm plugin processes when clustermgtd is down.
 
 2.10.0
 -----

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -432,7 +432,8 @@ class ClusterManager:
 
     def _write_timestamp_to_file(self):
         """Write timestamp into shared file so compute nodes can determine if head node is online."""
-        with open(self._config.heartbeat_file_path, "w") as timestamp_file:
+        # Make clustermgtd heartbeat readable to all users
+        with open(os.open(self._config.heartbeat_file_path, os.O_WRONLY | os.O_CREAT, 0o644), "w") as timestamp_file:
             # Note: heartbeat must be written with datetime.strftime to convert localized datetime into str
             # datetime.strptime will not work with str(datetime)
             timestamp_file.write(datetime.now(tz=timezone.utc).strftime(TIMESTAMP_FORMAT))

--- a/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
+++ b/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
@@ -13,3 +13,5 @@ hosted_zone = hosted-zone
 dns_domain = dns.domain
 use_private_hostname = False
 all_or_nothing_batch = True
+clustermgtd_heartbeat_file_path = alternate/clustermgtd_heartbeat
+clustermgtd_timeout = 5

--- a/tests/slurm_plugin/test_resume/test_resume_config/default.conf
+++ b/tests/slurm_plugin/test_resume/test_resume_config/default.conf
@@ -4,3 +4,4 @@ region = us-east-2
 dynamodb_table = table-name
 master_private_ip = master.ip
 master_hostname = master-hostname
+clustermgtd_heartbeat_file_path = /home/ec2-user/clustermgtd_heartbeat

--- a/tests/slurm_plugin/test_suspend.py
+++ b/tests/slurm_plugin/test_suspend.py
@@ -27,9 +27,18 @@ from slurm_plugin.suspend import SlurmSuspendConfig
                 "logging_config": os.path.join(
                     os.path.dirname(slurm_plugin.__file__), "logging", "parallelcluster_suspend_logging.conf"
                 ),
+                "clustermgtd_timeout": 300,
+                "clustermgtd_heartbeat_file_path": "/home/ec2-user/clustermgtd_heartbeat",
             },
         ),
-        ("all_options.conf", {"logging_config": "/path/to/suspend_logging/config"}),
+        (
+            "all_options.conf",
+            {
+                "logging_config": "/path/to/suspend_logging/config",
+                "clustermgtd_timeout": 5,
+                "clustermgtd_heartbeat_file_path": "alternate/clustermgtd_heartbeat",
+            },
+        ),
     ],
 )
 def test_suspend_config(config_file, expected_attributes, test_datadir):

--- a/tests/slurm_plugin/test_suspend/test_suspend_config/all_options.conf
+++ b/tests/slurm_plugin/test_suspend/test_suspend_config/all_options.conf
@@ -1,2 +1,4 @@
 [slurm_suspend]
 logging_config = /path/to/suspend_logging/config
+clustermgtd_heartbeat_file_path = alternate/clustermgtd_heartbeat
+clustermgtd_timeout = 5

--- a/tests/slurm_plugin/test_suspend/test_suspend_config/default.conf
+++ b/tests/slurm_plugin/test_suspend/test_suspend_config/default.conf
@@ -1,1 +1,2 @@
 [slurm_suspend]
+clustermgtd_heartbeat_file_path = /home/ec2-user/clustermgtd_heartbeat


### PR DESCRIPTION
* Computemgtd: Add logic to consider self node as down if node appears to be in power saving. When a node is in appears to be in power saving but the backing instance is up the node is not correctly attached to the scheduler. Computemgtd should consider self node as node and self-terminate the instance in this case
* ResumeProgram: Add logic to prevent launching new instances when unable to retrieve relevant clustermgtd heartbeat
* SuspendProgram: Print additional warning message when unable to retrieve relevant clustermgtd heartbeat
* Fix unit tests for above changes

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
