### PR TITLE
Add retries to change_resource_record_sets Route53 API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **CHANGES**
 - Use inclusive language in internal naming convention.
 - Improve error handling in slurm plugin processes when clustermgtd is down.
+- Increase max attempts when retrying on Route53 API call failures. 
 
 2.10.0
 -----


### PR DESCRIPTION
change_resource_record_sets Route53 API has an account why throttling. I'm adding some retry to slurm_resume in order to better handle such failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
