### PR TITLE
sge: always use shortname as hostname filter with qstat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+2.x.x
+-----
+
+**ENHANCEMENTS**
+- SGE: make `qstat` command in nodewatcher more robust in case a custom DHCP option set is configured.
+
 2.10.1
 -----
 

--- a/src/common/schedulers/sge_commands.py
+++ b/src/common/schedulers/sge_commands.py
@@ -184,7 +184,8 @@ def _run_qstat(full_format=False, hostname_filter=None, job_state_filter=None):
     if full_format:
         command += " -f"
     if hostname_filter:
-        command += " -l hostname={0}".format(hostname_filter)
+        short_name = hostname_filter.split(".")[0]
+        command += " -l hostname={0}".format(short_name)
     if job_state_filter:
         command += " -s {0}".format(job_state_filter)
     return check_sge_command_output(command)


### PR DESCRIPTION
This makes the qstat command more robust in case of custom DHCP when the full hostname seen by SGE might differ from the one returned from EC2 metadata (local-hostname).

### Tests:
* Manually tested by verifying that the qstat command properly works with short hostnames.
* Integ tests:
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
    scaling:
      test_scaling.py::test_multiple_jobs_submission:
        dimensions:
          - regions: ["us-west-1"]
            instances: {{ common.INSTANCES_DEFAULT_X86 }}
            oss: {{ common.OSS_COMMERCIAL_X86 }}
            schedulers: ["sge"]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
