### PR TITLE
Replace instances that fails status check during node replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **ENHANCEMENTS**
 - SGE: make `qstat` command in nodewatcher more robust in case a custom DHCP option set is configured.
 
+**BUG FIXES**
+- Fix a bug that caused `clustermgtd` to not immediately replace instances with failed status check that are in replacement process.
+
 2.10.1
 -----
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -652,6 +652,15 @@ class ClusterManager:
                         health_check_type,
                         instance,
                     )
+                    if unhealthy_node.name in self._static_nodes_in_replacement:
+                        log.warning(
+                            "Detected failed health check for static node in replacement. "
+                            "No longer considering node %s(%s) as in replacement process. "
+                            "Will attempt to replace node again immediately.",
+                            unhealthy_node.name,
+                            unhealthy_node.nodeaddr,
+                        )
+                        self._static_nodes_in_replacement.remove(unhealthy_node.name)
                     nodes_failing_health_check.append(unhealthy_node.name)
         if nodes_failing_health_check:
             # Place unhealthy node into drain, this operation is idempotent


### PR DESCRIPTION
* Fix the issue of not immediately replacing instances with failed status check that are in replacement process
* Fix https://github.com/aws/aws-parallelcluster/issues/2340

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
