### PR TITLE
Use cloud_reg_addrs option and do not manually reset nodeaddr on power_down

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -289,8 +289,13 @@ def set_nodes_drain(nodes, reason):
 
 
 def set_nodes_power_down(nodes, reason=None):
-    """Place slurm node into power_down state and reset nodeaddr/nodehostname."""
-    reset_nodes(nodes=nodes, state="power_down", reason=reason, raise_on_error=True)
+    """
+    Place slurm node into power_down state.
+
+    Do not reset the nodeaddr/nodehostname manually.
+    Nodeaddr/nodehostname will be reset automatically after power_down with cloud_reg_addrs.
+    """
+    update_nodes(nodes=nodes, state="power_down", reason=reason, raise_on_error=True)
 
 
 def reset_nodes(nodes, state=None, reason=None, raise_on_error=False):

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -342,7 +342,7 @@ def test_set_nodes_down(nodes, reason, reset_addrs, update_call_kwargs, mocker):
     ],
 )
 def test_set_nodes_power_down(nodes, reason, reset_addrs, update_call_kwargs, mocker):
-    update_mock = mocker.patch("common.schedulers.slurm_commands.reset_nodes", autospec=True)
+    update_mock = mocker.patch("common.schedulers.slurm_commands.update_nodes", autospec=True)
     set_nodes_power_down(nodes, reason)
     update_mock.assert_called_with(**update_call_kwargs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ envlist =
 passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
 whitelist_externals =
     bash
+# Upgrade pip/wheel/setuptools to the latest version
+download = true
 deps =
     -r tests/requirements.txt
 commands =


### PR DESCRIPTION
* Using cloud_reg_addrs and let slurm reset nodeaddr automatically. This option is available in Slurm 20.11.
* Keep reset nodes for inactivate partitions because nodes are not power_down in this case

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
