### PR TITLE
3.0: Change tag prefix to 'parallelcluster:'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **CHANGES**
 
 - Drop support for SGE and Torque schedulers.
+- Change tags prefix from `aws-parallelcluster-` to `parallelcluster:`.
 
 2.x.x
 -----

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -378,7 +378,7 @@ class InstanceManager:
         if alive_states_only:
             args["Filters"].append({"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)})
         if not include_head_node:
-            args["Filters"].append({"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]})
+            args["Filters"].append({"Name": "tag:parallelcluster:node-type", "Values": ["Compute"]})
         response_iterator = paginator.paginate(PaginationConfig={"PageSize": BOTO3_PAGINATION_PAGE_SIZE}, **args)
         filtered_iterator = response_iterator.search("Reservations[].Instances[]")
         return [

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1529,7 +1529,7 @@ def test_manage_cluster(
                         "Filters": [
                             {"Name": "tag:ClusterName", "Values": ["hit"]},
                             {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
-                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                            {"Name": "tag:parallelcluster:node-type", "Values": ["Compute"]},
                         ],
                         "MaxResults": 1000,
                     },
@@ -1687,7 +1687,7 @@ def test_manage_cluster(
                         "Filters": [
                             {"Name": "tag:ClusterName", "Values": ["hit"]},
                             {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
-                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                            {"Name": "tag:parallelcluster:node-type", "Values": ["Compute"]},
                         ],
                         "MaxResults": 1000,
                     },
@@ -1830,7 +1830,7 @@ def test_manage_cluster(
                         "Filters": [
                             {"Name": "tag:ClusterName", "Values": ["hit"]},
                             {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
-                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                            {"Name": "tag:parallelcluster:node-type", "Values": ["Compute"]},
                         ],
                         "MaxResults": 1000,
                     },

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -1246,7 +1246,7 @@ class TestInstanceManager:
                         "Filters": [
                             {"Name": "tag:ClusterName", "Values": ["hit"]},
                             {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
-                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                            {"Name": "tag:parallelcluster:node-type", "Values": ["Compute"]},
                         ],
                         "MaxResults": 1000,
                     },
@@ -1266,7 +1266,7 @@ class TestInstanceManager:
                         "Filters": [
                             {"Name": "tag:ClusterName", "Values": ["hit"]},
                             {"Name": "instance-state-name", "Values": list(EC2_INSTANCE_ALIVE_STATES)},
-                            {"Name": "tag:aws-parallelcluster-node-type", "Values": ["Compute"]},
+                            {"Name": "tag:parallelcluster:node-type", "Values": ["Compute"]},
                         ],
                         "MaxResults": 1000,
                     },


### PR DESCRIPTION
* Change tag prefix from 'aws-parallelcluster-' to 'parallelcluster:'

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
