### PR TITLE
3.0: Modify uploadNode utility to be aligned with new S3 Bucket tree

### DIFF
--- a/util/upload-node.sh
+++ b/util/upload-node.sh
@@ -92,10 +92,11 @@ main() {
     md5sum aws-parallelcluster-node-${_version}.tgz > aws-parallelcluster-node-${_version}.md5
 
     # upload package
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-node-${_version}.tgz s3://${_bucket}/node/aws-parallelcluster-node-${_version}.tgz || _error_exit 'Failed to push node to S3'
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-node-${_version}.md5 s3://${_bucket}/node/aws-parallelcluster-node-${_version}.md5 || _error_exit 'Failed to push node md5 to S3'
-    aws ${_profile} --region "${_region}" s3api head-object --bucket ${_bucket} --key node/aws-parallelcluster-node-${_version}.tgz --output text --query LastModified > aws-parallelcluster-node-${_version}.tgz.date || _error_exit 'Failed to fetch LastModified date'
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-node-${_version}.tgz.date s3://${_bucket}/node/aws-parallelcluster-node-${_version}.tgz.date || _error_exit 'Failed to push node date'
+    _key_path="parallelcluster/${_version}/node"
+    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-node-${_version}.tgz s3://${_bucket}/${_key_path}/aws-parallelcluster-node-${_version}.tgz || _error_exit 'Failed to push node to S3'
+    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-node-${_version}.md5 s3://${_bucket}/${_key_path}/aws-parallelcluster-node-${_version}.md5 || _error_exit 'Failed to push node md5 to S3'
+    aws ${_profile} --region "${_region}" s3api head-object --bucket ${_bucket} --key ${_key_path}/aws-parallelcluster-node-${_version}.tgz --output text --query LastModified > aws-parallelcluster-node-${_version}.tgz.date || _error_exit 'Failed to fetch LastModified date'
+    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-node-${_version}.tgz.date s3://${_bucket}/${_key_path}/aws-parallelcluster-node-${_version}.tgz.date || _error_exit 'Failed to push node date'
 
     _bucket_region=$(aws ${_profile} s3api get-bucket-location --bucket ${_bucket} --output text)
     if [ ${_bucket_region} = "None" ]; then
@@ -105,8 +106,10 @@ main() {
     fi
 
     echo ""
-    echo "Done. Add the following variable to the pcluster config file, under the [cluster ...] section"
-    echo "extra_json = { \"cluster\" : { \"custom_node_package\" : \"https://s3${_bucket_region}.amazonaws.com/${_bucket}/node/aws-parallelcluster-node-${_version}.tgz\" } }"
+    echo "Done. Add the following configuration to the pcluster create config file:"
+    echo ""
+    echo "DevSettings:"
+    echo "  NodePackage: s3://${_bucket}/${_key_path}/node/aws-parallelcluster-node-${_version}.tgz"
 }
 
 main "$@"


### PR DESCRIPTION
```
custom-bucket  # bucket selected by user for custom artifacts
└── parallelcluster
    └── 3.0.0 # new folder
        ├── cli # uploaded by uploadCLI.sh script
        │   └── aws-parallelcluster-3.0.0.tgz
        ├── cookbooks  # uploaded by uploadCookbok.sh script
        │   └── aws-parallelcluster-cookbook-3.0.0.*
        └── node  # uploaded by uploadNode.sh script
            └── aws-parallelcluster-node-3.0.0.*
```
