### PR TITLE
Implement Slurm Protected mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **ENHANCEMENTS**
 - SGE: make `qstat` command in nodewatcher more robust in case a custom DHCP option set is configured.
 - Transition from IMDSv1 to IMDSv2.
+- Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' state 
+  in case recurrent failures are encountered when provisioning nodes.
 
 **BUG FIXES**
 - Fix a bug that caused `clustermgtd` to not immediately replace instances with failed status check that are in replacement process.

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -15,7 +15,7 @@ import logging
 import re
 from enum import Enum
 
-from common.utils import check_command_output, grouper, run_command
+from common.utils import check_command_output, convert_range_to_list, grouper, run_command
 from retrying import retry
 
 PENDING_RESOURCES_REASONS = [
@@ -47,6 +47,7 @@ SCONTROL = "/opt/slurm/bin/scontrol"
 SINFO = "/opt/slurm/bin/sinfo"
 
 SlurmPartition = collections.namedtuple("SlurmPartition", ["name", "nodes", "state"])
+NodeType = collections.namedtuple("NodeType", ["instance_type", "partition"])
 
 # Set default timeouts for running different slurm commands.
 # These timeouts might be needed when running on large scale
@@ -71,6 +72,10 @@ class SlurmNode:
     SLURM_SCONTROL_DRAIN_STATE = "DRAIN"
     SLURM_SCONTROL_POWERING_DOWN_STATE = "POWERING_DOWN"
     SLURM_SCONTROL_POWER_STATE = "IDLE+CLOUD+POWER"
+    SLURM_SCONTROL_POWER_UP_STATE = "#"
+    SLURM_SCONTROL_ONLINE_STATES = {"IDLE+CLOUD", "MIXED+CLOUD", "ALLOCATED+CLOUD", "COMPLETING+CLOUD"}
+    SLURM_SCONTROL_POWER_WITH_JOB_STATE = "MIXED+CLOUD+POWER"
+    SLURM_SCONTROL_RESUME_FAILED_STATE = "DOWN*+CLOUD+POWER"
 
     def __init__(self, name, nodeaddr, nodehostname, state, partitions=None):
         """Initialize slurm node with attributes."""
@@ -118,6 +123,30 @@ class SlurmNode:
     def is_up(self):
         """Check if slurm node is in a healthy state."""
         return not self._is_drain() and not self.is_down() and not self.is_powering_down()
+
+    def is_powering_up(self):
+        """Check if slurm node is in powering up state."""
+        return self.SLURM_SCONTROL_POWER_UP_STATE in self.state
+
+    def is_online(self):
+        """Check if slurm node is online with backing instance."""
+        return self.state in self.SLURM_SCONTROL_ONLINE_STATES
+
+    def is_configuring_job(self):
+        """Check if slurm node is configuring with job and haven't begun to run a job."""
+        return self.is_powering_up() and self.has_job()
+
+    def is_power_with_job(self):
+        """Dynamic nodes allocated a job but power up process has not started yet."""
+        return self.state == self.SLURM_SCONTROL_POWER_WITH_JOB_STATE
+
+    def is_running_job(self):
+        """Check if slurm node is running a job but not in configuring job state."""
+        return not self.is_powering_up() and self.has_job() and not self.is_power_with_job()
+
+    def is_resume_failed(self):
+        """Check if node resume timeout expires."""
+        return self.state == self.SLURM_SCONTROL_RESUME_FAILED_STATE
 
     def __eq__(self, other):
         """Compare 2 SlurmNode objects."""
@@ -440,3 +469,51 @@ def _parse_nodes_info(slurm_node_info):
         if lines:
             slurm_nodes.append(SlurmNode(*lines))
     return slurm_nodes
+
+
+def get_nodes_type(nodes):
+    """Get node type given nodename. Node type format: NodeType(instancetype, queue_name)."""
+    nodes_types = set()
+    for node in nodes:
+        queue_name, _, instance_name = parse_nodename(node.name)
+        nodes_types.add(NodeType(instance_name, queue_name))
+    return nodes_types
+
+
+def get_inactive_partition_names(partitions):
+    """Get the name of all inactive partitions from partitions and name mapping."""
+    inactive_partitions_name = []
+    for partition_name, partition in partitions.items():
+        if partition.state == "INACTIVE":
+            inactive_partitions_name.append(partition_name)
+    return inactive_partitions_name
+
+
+def retrieve_partitions_from_node_types(node_types):
+    """Retrieve partitions for node types."""
+    return {node_type.partition for node_type in node_types}
+
+
+def get_partition_node_names(nodenames):
+    """
+    Convert partition nodenames read from partition to a list of nodes.
+
+    Example input nodenames: "queue1-st-c5xlarge-[1,3,4-5],queue1-st-c5large-20"
+    Example output [queue1-st-c5xlarge-1, queue1-st-c5xlarge-3, queue1-st-c5xlarge-4, queue1-st-c5xlarge-5,
+    queue1-st-c5large-20]
+    """
+    if type(nodenames) is str:
+        matches = re.findall(r"((([a-z0-9\-]+)-(st|dy)-([a-z0-9]+)-)(\[[\d+,-]+\]|\d+))", nodenames)
+        # [('queue1-st-c5xlarge-[1,3,4-5]', 'queue1-st-c5xlarge-', 'queue1', 'st', 'c5xlarge', '[1,3,4-5]'),
+        # ('queue1-st-c5large-20', 'queue1-st-c5large-', 'queue1', 'st', 'c5large', '20')]
+    partition_node_names = []
+    for match in matches:
+        nodename, prefix, _, _, _, nodes = match
+        if "[" not in nodes:
+            # Single nodename
+            partition_node_names.append(nodename)
+        else:
+            # Multiple nodenames
+            node_list = convert_range_to_list(nodes.strip("[]"))
+            partition_node_names += [prefix + str(n) for n in node_list]
+    return partition_node_names

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -491,3 +491,19 @@ def get_metadata(metadata_path):
 
     log.debug("%s=%s", metadata_path, metadata_value)
     return metadata_value
+
+
+def convert_range_to_list(node_range):
+    """
+    Convert a number range to a list.
+
+    Example input: Input can be like one of the format: "1-3", "1-2,6", "2, 8"
+    Example output: [1, 2, 3]
+    """
+    return sum(
+        (
+            (list(range(*[int(j) + k for k, j in enumerate(i.split("-"))])) if "-" in i else [int(i)])
+            for i in node_range.split(",")
+        ),
+        [],
+    )

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -24,13 +24,18 @@ from boto3.dynamodb.conditions import Attr
 from botocore.config import Config
 from common.schedulers.slurm_commands import (
     PartitionStatus,
+    get_inactive_partition_names,
     get_nodes_info,
+    get_nodes_type,
     get_partition_info,
+    get_partition_node_names,
     reset_nodes,
+    retrieve_partitions_from_node_types,
     set_nodes_down,
     set_nodes_down_and_power_save,
     set_nodes_drain,
     update_all_partitions,
+    update_partitions,
 )
 from common.time_utils import seconds
 from common.utils import sleep_remaining_loop_time
@@ -59,6 +64,8 @@ class ComputeFleetStatus(Enum):
     STARTING = "STARTING"  # clustermgtd is handling the start request.
     STOP_REQUESTED = "STOP_REQUESTED"  # A request to stop the fleet has been submitted.
     START_REQUESTED = "START_REQUESTED"  # A request to start the fleet has been submitted.
+    # PROTECTED indicates that some partitions have consistent bootstrap failures. Affected partitions are inactive.
+    PROTECTED = "PROTECTED"
 
     def __str__(self):
         return str(self.value)
@@ -74,6 +81,10 @@ class ComputeFleetStatus(Enum):
     @staticmethod
     def is_stop_in_progress(status):
         return status in {ComputeFleetStatus.STOP_REQUESTED, ComputeFleetStatus.STOPPING}
+
+    @staticmethod
+    def is_protected_status(status):
+        return status == ComputeFleetStatus.PROTECTED
 
 
 class ComputeFleetStatusManager:
@@ -130,7 +141,7 @@ class ClustermgtdConfig:
         # Terminate configs
         "terminate_max_batch_size": 1000,
         # Timeout to wait for node initialization, should be the same as ResumeTimeout
-        "node_replacement_timeout": 3600,
+        "node_replacement_timeout": 1800,
         "terminate_drain_nodes": True,
         "terminate_down_nodes": True,
         "orphaned_instance_timeout": 120,
@@ -143,6 +154,7 @@ class ClustermgtdConfig:
         "hosted_zone": None,
         "dns_domain": None,
         "use_private_hostname": False,
+        "protected_failure_count": 10,
     }
 
     def __init__(self, config_file_path):
@@ -233,6 +245,9 @@ class ClustermgtdConfig:
         self.orphaned_instance_timeout = config.getint(
             "clustermgtd", "orphaned_instance_timeout", fallback=self.DEFAULTS.get("orphaned_instance_timeout")
         )
+        self.protected_failure_count = config.getint(
+            "clustermgtd", "protected_failure_count", fallback=self.DEFAULTS.get("protected_failure_count")
+        )
 
     def _get_dns_config(self, config):
         """Get config option related to Route53 DNS domain."""
@@ -287,6 +302,10 @@ class ClusterManager:
         This state is required because we need to ignore static nodes that might have long bootstrap time
         """
         self._static_nodes_in_replacement = set()
+        self._bootstrap_failure_nodes_types = set()
+        self._instance_ips_in_cluster = set()
+        self._partitions_protected_failure_count_map = {}
+        self._inactive_partitions = []
         self._compute_fleet_status = ComputeFleetStatus.RUNNING
         self._current_time = None
         self._config = None
@@ -371,12 +390,41 @@ class ClusterManager:
                 )
                 if partitions_activated_successfully:
                     self._update_compute_fleet_status(ComputeFleetStatus.RUNNING)
+                    # Reset protected failure
+                    self._partitions_protected_failure_count_map = {}
+                    self._bootstrap_failure_nodes_types = set()
         except ComputeFleetStatusManager.ConditionalStatusUpdateFailed:
             log.warning(
                 "Cluster status was updated while handling a transition from %s. "
                 "Status transition will be retried at the next iteration",
                 self._compute_fleet_status,
             )
+
+    def _handle_successfully_launched_nodes(self, healthy_nodes):
+        """
+        Handle nodes have been failed in bootstrap are launched successfully during this iteration.
+
+        Includes resetting partition bootstrap failure count for these nodes type and updating the
+        bootstrap_failure_nodes_types.
+        If a node has been failed successfully launched, the partition count of this node will be reset.
+        So the successfully launched nodes type will be remove from bootstrap_failure_nodes_types. If there's node types
+        failed in this partition later, it will keep count again.
+        """
+        online_nodes_types = self._get_online_nodes_types(healthy_nodes)
+        bootstrap_failure_nodes_types_successfully_launched = online_nodes_types.intersection(
+            self._bootstrap_failure_nodes_types
+        )
+
+        if bootstrap_failure_nodes_types_successfully_launched:
+            # Reset bootstrap failure count of successfully launched partitions
+            successful_launched_partitions = retrieve_partitions_from_node_types(
+                bootstrap_failure_nodes_types_successfully_launched
+            )
+            for partition in successful_launched_partitions:
+                self._reset_partition_failure_count(partition)
+
+            # Remove successfully launched node types from the set of bootstrap failure nodes.
+            self._bootstrap_failure_nodes_types -= bootstrap_failure_nodes_types_successfully_launched
 
     def manage_cluster(self):
         """Manage cluster by syncing scheduler states with EC2 states and performing node maintenance actions."""
@@ -389,13 +437,19 @@ class ClusterManager:
         if not self._config.disable_all_cluster_management and self._compute_fleet_status in {
             None,
             ComputeFleetStatus.RUNNING,
+            ComputeFleetStatus.PROTECTED,
         }:
             # Get node states for nodes in inactive and active partitions
             try:
                 log.info("Retrieving nodes info from the scheduler")
-                active_nodes, inactive_nodes = self._get_node_info_from_partition()
+                partitions = {
+                    partition.name: partition for partition in ClusterManager._get_partition_info_with_retry()
+                }
+                log.debug("Partitions: %s", partitions)
+                active_nodes, inactive_nodes = self._get_node_info_from_partition(partitions)
                 log.debug("Current active slurm nodes in scheduler: %s", active_nodes)
                 log.debug("Current inactive slurm nodes in scheduler: %s", inactive_nodes)
+                self._inactive_partitions = get_inactive_partition_names(partitions)
             except ClusterManager.SchedulerUnavailable:
                 log.error("Unable to get partition/node info from slurm, no other action can be performed. Sleeping...")
                 return
@@ -416,6 +470,7 @@ class ClusterManager:
                 cluster_instances = self._clean_up_inactive_partition(inactive_nodes, cluster_instances)
             log.debug("Current cluster instances in EC2: %s", cluster_instances)
             private_ip_to_instance_map = {instance.private_ip: instance for instance in cluster_instances}
+            self._instance_ips_in_cluster = set(private_ip_to_instance_map.keys())
             log.debug("private_ip_to_instance_map %s", private_ip_to_instance_map)
             # Clean up orphaned instances and skip all other operations if no active node
             if active_nodes:
@@ -423,7 +478,7 @@ class ClusterManager:
                 if not self._config.disable_all_health_checks:
                     self._perform_health_check_actions(cluster_instances, ip_to_slurm_node_map)
                 # Maintain slurm nodes
-                self._maintain_nodes(private_ip_to_instance_map, active_nodes)
+                self._maintain_nodes(private_ip_to_instance_map, active_nodes, partitions)
             # Clean up orphaned instances
             self._terminate_orphaned_instances(cluster_instances, ips_used_by_slurm=list(ip_to_slurm_node_map.keys()))
         # Write clustermgtd heartbeat to file
@@ -448,7 +503,7 @@ class ClusterManager:
         return get_partition_info(get_all_nodes=True)
 
     @staticmethod
-    def _get_node_info_from_partition():
+    def _get_node_info_from_partition(partitions):
         """
         Retrieve node belonging in UP/INACTIVE partitions.
 
@@ -458,8 +513,6 @@ class ClusterManager:
             inactive_nodes = []
             active_nodes = []
             ignored_nodes = []
-            partitions = {partition.name: partition for partition in ClusterManager._get_partition_info_with_retry()}
-            log.debug("Partitions: %s", partitions)
             nodes = ClusterManager._get_node_info_with_retry()
             log.debug("Nodes: %s", nodes)
             for node in nodes:
@@ -660,6 +713,23 @@ class ClusterManager:
                             unhealthy_node.nodeaddr,
                         )
                         self._static_nodes_in_replacement.remove(unhealthy_node.name)
+                        if self._is_protected_mode_enabled():
+                            self._handle_bootstrap_failure_nodes([unhealthy_node])
+                            log.warning(
+                                "Node bootstrap error: Node %s failed health check during replacement, "
+                                f"increase partition failure count: {self._partitions_protected_failure_count_map}, "
+                                "Cluster will be set into protected mode if protected failure count reach threshold.",
+                                unhealthy_node,
+                            )
+                    if self._is_protected_mode_enabled() and unhealthy_node.is_powering_up():
+                        self._handle_bootstrap_failure_nodes([unhealthy_node])
+                        log.warning(
+                            "Node bootstrap error: Node %s fails during bootstrap when performing health check, "
+                            "increase partition failure count: %s, "
+                            "Cluster will be set into protected mode if protected failure count reach threshold.",
+                            unhealthy_node,
+                            self._partitions_protected_failure_count_map,
+                        )
                     nodes_failing_health_check.append(unhealthy_node.name)
         if nodes_failing_health_check:
             # Place unhealthy node into drain, this operation is idempotent
@@ -679,18 +749,31 @@ class ClusterManager:
                 nodes_still_in_replacement.add(nodename)
         self._static_nodes_in_replacement = nodes_still_in_replacement
 
-    def _find_unhealthy_slurm_nodes(self, slurm_nodes, private_ip_to_instance_map):
-        """Check and return slurm nodes with unhealthy scheduler state, grouping by node type (static/dynamic)."""
+    def _group_slurm_nodes(self, slurm_nodes, private_ip_to_instance_map):
+        """
+        Group slurm nodes into different types.
+
+        Check and return slurm nodes with unhealthy and healthy scheduler state, grouping unhealthy nodes
+        by node type (static/dynamic).
+        """
         unhealthy_static_nodes = []
         unhealthy_dynamic_nodes = []
+        bootstrap_failure_nodes = []
+        healthy_nodes = []
         for node in slurm_nodes:
             if not self._is_node_healthy(node, private_ip_to_instance_map):
                 if node.is_static:
                     unhealthy_static_nodes.append(node)
                 else:
                     unhealthy_dynamic_nodes.append(node)
+                if self._is_protected_mode_enabled() and self._is_node_bootstrap_failure(
+                    node, private_ip_to_instance_map
+                ):
+                    bootstrap_failure_nodes.append(node)
+            else:
+                healthy_nodes.append(node)
 
-        return unhealthy_dynamic_nodes, unhealthy_static_nodes
+        return unhealthy_dynamic_nodes, unhealthy_static_nodes, bootstrap_failure_nodes, healthy_nodes
 
     def _is_node_being_replaced(self, node, private_ip_to_instance_map):
         """Check if a node is currently being replaced and within node_replacement_timeout."""
@@ -752,7 +835,7 @@ class ClusterManager:
             return (
                 ClusterManager._is_static_node_configuration_valid(node)
                 and ClusterManager._is_backing_instance_valid(
-                    node, instance_ips_in_cluster=list(private_ip_to_instance_map.keys())
+                    node, instance_ips_in_cluster=self._instance_ips_in_cluster
                 )
                 and self._is_node_state_healthy(node, private_ip_to_instance_map)
             )
@@ -762,9 +845,54 @@ class ClusterManager:
             return (
                 node.is_powering_down()
                 or ClusterManager._is_backing_instance_valid(
-                    node, instance_ips_in_cluster=list(private_ip_to_instance_map.keys())
+                    node, instance_ips_in_cluster=self._instance_ips_in_cluster
                 )
             ) and self._is_node_state_healthy(node, private_ip_to_instance_map)
+
+    def _is_node_bootstrap_failure(self, node, private_ip_to_instance_map):
+        """
+        Check if a slurm node has boostrap failure.
+
+        Here's the cases of bootstrap error we are checking:
+        Bootstrap error that causes instance to self terminate.
+        Bootstrap error that prevents instance from joining cluster but does not cause self termination.
+        """
+        if node.is_static and node.name in self._static_nodes_in_replacement:
+            # Node is currently in replacement and no backing instance
+            if not ClusterManager._is_backing_instance_valid(
+                node, instance_ips_in_cluster=self._instance_ips_in_cluster
+            ):
+                log.warning("Node bootstrap error: Node %s is currently in replacement and no backing instance", node)
+                return True
+            # Replacement timeout expires for node in replacement
+            elif time_is_up(
+                private_ip_to_instance_map.get(node.nodeaddr).launch_time,
+                self._current_time,
+                grace_time=self._config.node_replacement_timeout,
+            ):
+                log.warning("Node bootstrap error: Replacement timeout expires for node %s in replacement", node)
+                return True
+
+        elif not node.is_static:
+            # no backing instance + [working state]# in node state
+            if node.is_configuring_job() and not ClusterManager._is_backing_instance_valid(
+                node, instance_ips_in_cluster=self._instance_ips_in_cluster
+            ):
+                log.warning("Node bootstrap error: Node %s is in power up state without valid backing instance", node)
+                return True
+            # Dynamic node in DOWN*+CLOUD+POWER state
+            elif node.is_resume_failed():
+                log.warning("Node bootstrap error: Resume timeout expires for node %s", node)
+                return True
+        return False
+
+    def _increase_partitions_protected_failure_count(self, bootstrap_failure_nodes):
+        """Keep count of boostrap failures."""
+        for node in bootstrap_failure_nodes:
+            for p in node.partitions:
+                self._partitions_protected_failure_count_map[p] = (
+                    self._partitions_protected_failure_count_map.get(p, 0) + 1
+                )
 
     @log_exception(log, "maintaining unhealthy dynamic nodes", raise_on_error=False)
     def _handle_unhealthy_dynamic_nodes(self, unhealthy_dynamic_nodes, private_ip_to_instance_map):
@@ -863,7 +991,7 @@ class ClusterManager:
         )
 
     @log_exception(log, "maintaining slurm nodes", catch_exception=Exception, raise_on_error=False)
-    def _maintain_nodes(self, private_ip_to_instance_map, slurm_nodes):
+    def _maintain_nodes(self, private_ip_to_instance_map, slurm_nodes, partitions):
         """
         Call functions to maintain unhealthy nodes.
 
@@ -878,15 +1006,21 @@ class ClusterManager:
         log.info(
             "Following nodes are currently in replacement: %s", print_with_count(self._static_nodes_in_replacement)
         )
-        unhealthy_dynamic_nodes, unhealthy_static_nodes = self._find_unhealthy_slurm_nodes(
-            slurm_nodes, private_ip_to_instance_map
-        )
+        (
+            unhealthy_dynamic_nodes,
+            unhealthy_static_nodes,
+            bootstrap_failure_nodes,
+            healthy_nodes,
+        ) = self._group_slurm_nodes(slurm_nodes, private_ip_to_instance_map)
         if unhealthy_dynamic_nodes:
             log.info("Found the following unhealthy dynamic nodes: %s", print_with_count(unhealthy_dynamic_nodes))
             self._handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes, private_ip_to_instance_map)
         if unhealthy_static_nodes:
             log.info("Found the following unhealthy static nodes: %s", print_with_count(unhealthy_static_nodes))
             self._handle_unhealthy_static_nodes(unhealthy_static_nodes, private_ip_to_instance_map)
+
+        if self._is_protected_mode_enabled():
+            self._handle_protected_mode_process(slurm_nodes, partitions, bootstrap_failure_nodes, healthy_nodes)
 
     @log_exception(log, "terminating orphaned instances", catch_exception=Exception, raise_on_error=False)
     def _terminate_orphaned_instances(self, cluster_instances, ips_used_by_slurm):
@@ -903,6 +1037,125 @@ class ClusterManager:
             self._instance_manager.delete_instances(
                 instances_to_terminate, terminate_batch_size=self._config.terminate_max_batch_size
             )
+
+    def _enter_protected_mode(self, partitions_to_disable):
+        """Entering protected mode if no active running job in queue."""
+        if partitions_to_disable:
+            # Change compute fleet status to protected
+            if ComputeFleetStatus.is_protected_status(self._compute_fleet_status):
+                log.warning(
+                    "Cluster is in protected mode due to failures detected in node provisioning. "
+                    "Please investigate the issue and then use pcluster start command to re-enable the fleet."
+                )
+            else:
+                log.warning(
+                    "Setting cluster into protected mode due to failures detected in node provisioning. "
+                    "Please investigate the issue and then use pcluster start command to re-enable the fleet."
+                )
+                self._update_compute_fleet_status(ComputeFleetStatus.PROTECTED)
+
+            # Place partitions into inactive
+            log.info("Placing bootstrap failure partitions to INACTIVE: %s", print_with_count(partitions_to_disable))
+            update_partitions(partitions_to_disable, PartitionStatus.INACTIVE)
+        else:
+            log.info("Not entering protected mode since active are jobs running in bootstrap failure partitions")
+
+    def _find_online_slurm_nodes(self, healthy_nodes):
+        """Find slurm nodes online."""
+        online_nodes = []
+        for node in healthy_nodes:
+            if node.is_online():
+                online_nodes.append(node)
+        return online_nodes
+
+    def _reset_partition_failure_count(self, partition):
+        """Reset bootstrap failure count for partition which has bootstrap failure nodes successfully launched."""
+        log.info("Find successfully launched node in partition %s, reset partition protected failure count", partition)
+        self._partitions_protected_failure_count_map.pop(partition, None)
+
+    def _handle_bootstrap_failure_nodes(self, bootstrap_failure_nodes):
+        """Increase the partition failure count and add failed nodes to the set of bootstrap failure nodes."""
+        self._increase_partitions_protected_failure_count(bootstrap_failure_nodes)
+        # Update bootstrap_failure_nodes to include all nodes types have been failed during bootstrap
+        self._bootstrap_failure_nodes_types |= get_nodes_type(bootstrap_failure_nodes)
+
+    def _get_online_nodes_types(self, healthy_nodes):
+        """Find nodes types which have been failed during bootstrap now become online."""
+        online_nodes = self._find_online_slurm_nodes(healthy_nodes)
+        online_nodes_types = get_nodes_type(online_nodes)
+
+        return online_nodes_types
+
+    @staticmethod
+    def _get_partitions_to_disable(nodename_to_slurm_nodes_map, bootstrap_failure_partitions, partitions):
+        """Get partitions not running jobs to disable."""
+        # Get partitions have jobs running
+        partitions_have_active_jobs = ClusterManager._filter_partitions_with_active_jobs(
+            nodename_to_slurm_nodes_map, partitions
+        )
+        # Only disable bootstrap failure partitions that not having active jobs running
+        partitions_to_disable = set(bootstrap_failure_partitions) - partitions_have_active_jobs
+        bootstrap_failure_partitions_have_jobs = set(bootstrap_failure_partitions) - partitions_to_disable
+        if bootstrap_failure_partitions_have_jobs:
+            log.info(
+                "Bootstrap failure partitions %s currently have jobs running, not disabling them.",
+                print_with_count(bootstrap_failure_partitions_have_jobs),
+            )
+        return partitions_to_disable
+
+    def _is_protected_mode_enabled(self):
+        """When protected_failure_count is set to -1, disable protected mode."""
+        if self._config.protected_failure_count <= 0:
+            return False
+        return True
+
+    def _handle_protected_mode_process(self, slurm_nodes, partitions, bootstrap_failure_nodes, healthy_nodes):
+        """Handle the process of entering protected mode."""
+        # Handle successfully launched nodes
+        self._handle_successfully_launched_nodes(healthy_nodes)
+
+        # Handle bootstrap failures nodes
+        if bootstrap_failure_nodes:
+            log.warning("Found the following bootstrap failure nodes: %s", print_with_count(bootstrap_failure_nodes))
+            self._handle_bootstrap_failure_nodes(bootstrap_failure_nodes)
+
+        # Enter protected mode
+        # We will put a partition into inactive state only if the partition satisfies the following:
+        # Partition is not INACTIVE
+        # Partition bootstrap failure count above threshold
+        # Partition does not have job running
+        log.info(
+            "Partitions bootstrap failure count: %s, cluster will be set into protected mode if "
+            "protected failure count reach threshold",
+            self._partitions_protected_failure_count_map,
+        )
+        partitions_above_threshold = [
+            part
+            for part, failures in self._partitions_protected_failure_count_map.items()
+            if part not in self._inactive_partitions and failures >= self._config.protected_failure_count
+        ]
+        if partitions_above_threshold:
+            log.info("Bootstrap failure partitions: %s", print_with_count(partitions_above_threshold))
+            nodename_to_slurm_nodes_map = {node.name: node for node in slurm_nodes}
+            partitions_to_disable = ClusterManager._get_partitions_to_disable(
+                nodename_to_slurm_nodes_map, partitions_above_threshold, partitions
+            )
+            self._enter_protected_mode(partitions_to_disable)
+
+    @staticmethod
+    def _filter_partitions_with_active_jobs(nodename_to_slurm_nodes_map, partitions):
+        """Retrieve partitions currently have active jobs running."""
+        partitions_have_active_jobs = set()
+        for partition_name, partition in partitions.items():
+            partiton_nodenames = get_partition_node_names(partition.nodes)
+            for nodename in partiton_nodenames:
+                if (
+                    nodename_to_slurm_nodes_map.get(nodename)
+                    and nodename_to_slurm_nodes_map.get(nodename).is_running_job()
+                ):
+                    partitions_have_active_jobs.add(partition_name)
+                    break
+        return partitions_have_active_jobs
 
 
 def _run_clustermgtd():

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -13,13 +13,17 @@ from unittest.mock import call
 import pytest
 from assertpy import assert_that
 from common.schedulers.slurm_commands import (
+    NodeType,
     PartitionStatus,
     SlurmNode,
     SlurmPartition,
     _batch_node_info,
     _parse_nodes_info,
+    get_inactive_partition_names,
+    get_nodes_type,
     is_static_node,
     parse_nodename,
+    retrieve_partitions_from_node_types,
     set_nodes_down,
     set_nodes_drain,
     set_nodes_idle,
@@ -696,3 +700,144 @@ def test_update_all_partitions(
     else:
         reset_node_spy.assert_not_called()
     update_partitions_spy.assert_called_with(partitions_to_update, state)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), True),
+    ],
+)
+def test_is_powering_up(node, expected_output):
+    assert_that(node.is_powering_up()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE*+CLOUD+DRAIN", "queue1"), False),
+    ],
+)
+def test_is_online(node, expected_output):
+    assert_that(node.is_online()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE#+CLOUD", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue1"), False),
+    ],
+)
+def test_is_configuring_job(node, expected_output):
+    assert_that(node.is_configuring_job()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DOWN", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDEL#+CLOUD", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWER", "queue1"), False),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED*+CLOUD", "queue1"), True),
+    ],
+)
+def test_is_running_job(node, expected_output):
+    assert_that(node.is_running_job()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWER", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), False),
+    ],
+)
+def test_is_power_with_job(node, expected_output):
+    assert_that(node.is_power_with_job()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (SlurmNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWER", "queue1"), True),
+        (SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), False),
+    ],
+)
+def test_is_resume_failed(node, expected_output):
+    assert_that(node.is_power_with_job()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "nodes, expected_output",
+    [
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"),
+                SlurmNode("queue1-st-c5large-1", "nodeip", "nodehostname", "IDEL#+CLOUD", "queue1"),
+                SlurmNode("queue2-st-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue2"),
+                SlurmNode("queue3-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue3"),
+                SlurmNode("queue1-st-c4xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue1"),
+            ],
+            {
+                NodeType("c5xlarge", "queue1"),
+                NodeType("c5xlarge", "queue2"),
+                NodeType("c5xlarge", "queue3"),
+                NodeType("c4xlarge", "queue1"),
+                NodeType("c5large", "queue1"),
+            },
+        )
+    ],
+)
+def test_get_nodes_type(nodes, expected_output):
+    assert_that(get_nodes_type(nodes)).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "partitions, expected_output",
+    [
+        (
+            {
+                "part-1": SlurmPartition("part-1", "node-1,node-2", "DRAIN"),
+                "part-2": SlurmPartition("part-2", "node-3,node-4", "UP"),
+                "part-3": SlurmPartition("part-3", "node-3,node-4", "INACTIVE"),
+            },
+            ["part-3"],
+        )
+    ],
+)
+def test_get_inactive_partition_names(partitions, expected_output):
+    assert_that(get_inactive_partition_names(partitions)).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node_types, expected_output",
+    [
+        (
+            {
+                NodeType("queue1-c5xlarge", "queue1"),
+                NodeType("queue2-c5xlarge", "queue2"),
+                NodeType("queue3-c5xlarge", "queue3"),
+                NodeType("queue1-c4xlarge", "queue1"),
+                NodeType("queue1-c5large", "queue1"),
+            },
+            {"queue1", "queue2", "queue3"},
+        )
+    ],
+)
+def test_retrieve_partitions_from_node_types(node_types, expected_output):
+    assert_that(retrieve_partitions_from_node_types(node_types)).is_equal_to(expected_output)

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -21,7 +21,7 @@ import botocore
 import pytest
 import slurm_plugin
 from assertpy import assert_that
-from common.schedulers.slurm_commands import PartitionStatus, SlurmNode, SlurmPartition, update_all_partitions
+from common.schedulers.slurm_commands import NodeType, PartitionStatus, SlurmNode, SlurmPartition, update_all_partitions
 from slurm_plugin.clustermgtd import ClusterManager, ClustermgtdConfig, ComputeFleetStatus, ComputeFleetStatusManager
 from slurm_plugin.common import (
     EC2_HEALTH_STATUS_UNHEALTHY_STATES,
@@ -64,7 +64,7 @@ class TestClustermgtdConfig:
                     "launch_max_batch_size": 500,
                     # terminate configs
                     "terminate_max_batch_size": 1000,
-                    "node_replacement_timeout": 3600,
+                    "node_replacement_timeout": 1800,
                     "terminate_drain_nodes": True,
                     "terminate_down_nodes": True,
                     "orphaned_instance_timeout": 120,
@@ -73,6 +73,7 @@ class TestClustermgtdConfig:
                     "disable_scheduled_event_health_check": False,
                     "disable_all_health_checks": False,
                     "health_check_timeout": 180,
+                    "protected_failure_count": 10,
                 },
             ),
             (
@@ -104,6 +105,7 @@ class TestClustermgtdConfig:
                     "disable_scheduled_event_health_check": True,
                     "disable_all_health_checks": False,
                     "health_check_timeout": 10,
+                    "protected_failure_count": 5,
                 },
             ),
             (
@@ -176,12 +178,12 @@ def test_set_config(initialize_instance_manager_mock, initialize_compute_fleet_s
     "partitions, nodes, expected_inactive_nodes, expected_active_nodes",
     [
         (
-            [
-                SlurmPartition("partition1", "placeholder_nodes", "UP"),
-                SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
-                SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
-                SlurmPartition("partition4", "placeholder_nodes", "INACTIVE"),
-            ],
+            {
+                "partition1": SlurmPartition("partition1", "placeholder_nodes", "UP"),
+                "partition2": SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
+                "partition3": SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
+                "partition4": SlurmPartition("partition4", "placeholder_nodes", "INACTIVE"),
+            },
             [
                 SlurmNode("queue1-st-c5xlarge-1", "nodeaddr", "nodeaddr", "DOWN", "partition1"),
                 SlurmNode("queue1-st-c5xlarge-2", "nodeaddr", "nodeaddr", "IDLE", "partition1"),
@@ -210,16 +212,12 @@ def test_set_config(initialize_instance_manager_mock, initialize_compute_fleet_s
     ids=["mixed"],
 )
 def test_get_node_info_from_partition(partitions, nodes, expected_inactive_nodes, expected_active_nodes, mocker):
-    get_partition_info_with_retry_mock = mocker.patch(
-        "slurm_plugin.clustermgtd.ClusterManager._get_partition_info_with_retry", return_value=partitions
-    )
     get_node_info_with_retry_mock = mocker.patch(
         "slurm_plugin.clustermgtd.ClusterManager._get_node_info_with_retry", return_value=nodes
     )
-    active_nodes, inactive_nodes = ClusterManager._get_node_info_from_partition()
+    active_nodes, inactive_nodes = ClusterManager._get_node_info_from_partition(partitions)
     assert_that(active_nodes).is_equal_to(expected_active_nodes)
     assert_that(inactive_nodes).is_equal_to(expected_inactive_nodes)
-    get_partition_info_with_retry_mock.assert_called_once()
     get_node_info_with_retry_mock.assert_called_once_with()
 
 
@@ -595,25 +593,36 @@ def test_fail_scheduled_events_health_check(instance_health_state, expected_resu
         "expected_failed_nodes",
         "current_node_in_replacement",
         "expected_node_in_replacement",
+        "expected_bootstrap_failure_node",
     ),
     [
         (
             ClusterManager.HealthCheckTypes.scheduled_event,
-            [True, False],
-            [False, True],
-            ["queue1-st-c5xlarge-2"],
+            [True, False, True, False],
+            [False, True, False, True],
+            ["queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-4"],
             {"some_node_in_replacement1"},
             {"some_node_in_replacement1"},
+            SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "host-2", "ALLOCATED#+CLOUD", "queue1"),
         ),
         (
             ClusterManager.HealthCheckTypes.ec2_health,
-            [True, False],
-            [False, True],
-            ["queue1-st-c5xlarge-1"],
+            [True, False, True, False],
+            [False, True, True, False],
+            ["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-3"],
             {"some_node_in_replacement1", "queue1-st-c5xlarge-1"},
             {"some_node_in_replacement1"},
+            SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN*+CLOUD", "queue1"),
         ),
-        (ClusterManager.HealthCheckTypes.ec2_health, [False, False], [False, True], [], {}, {}),
+        (
+            ClusterManager.HealthCheckTypes.ec2_health,
+            [False, False, False, False],
+            [False, True, False, True],
+            [],
+            {},
+            {},
+            None,
+        ),
     ],
     ids=["scheduled_event", "ec2_health", "all_healthy"],
 )
@@ -625,19 +634,26 @@ def test_handle_health_check(
     expected_failed_nodes,
     current_node_in_replacement,
     expected_node_in_replacement,
+    expected_bootstrap_failure_node,
     mocker,
 ):
     # Define variable that will be used for all tests
     health_state_1 = EC2InstanceHealthState("id-1", "some_state", "some_status", "some_status", "some_event")
     health_state_2 = EC2InstanceHealthState("id-2", "some_state", "some_status", "some_status", "some_event")
-    placeholder_states = [health_state_1, health_state_2]
+    health_state_3 = EC2InstanceHealthState("id-3", "some_state", "some_status", "some_status", "some_event")
+    health_state_4 = EC2InstanceHealthState("id-4", "some_state", "some_status", "some_status", "some_event")
+    placeholder_states = [health_state_1, health_state_2, health_state_3, health_state_4]
     id_to_instance_map = {
         "id-1": EC2Instance("id-1", "ip-1", "host-1", "some_launch_time"),
         "id-2": EC2Instance("id-2", "ip-2", "host-2", "some_launch_time"),
+        "id-3": EC2Instance("id-3", "ip-3", "host-3", "some_launch_time"),
+        "id-4": EC2Instance("id-4", "ip-4", "host-4", "some_launch_time"),
     }
     ip_to_slurm_node_map = {
-        "ip-1": SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "some_states", "queue1"),
-        "ip-2": SlurmNode("queue1-st-c5xlarge-2", "ip-2", "host-2", "some_states", "queue1"),
+        "ip-1": SlurmNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN*+CLOUD", "queue1"),
+        "ip-2": SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "host-2", "ALLOCATED#+CLOUD", "queue1"),
+        "ip-3": SlurmNode("queue1-st-c5xlarge-3", "ip-3", "host-3", "ALLOCATED+CLOUD", "queue1"),
+        "ip-4": SlurmNode("queue1-st-c5xlarge-4", "ip-4", "host-4", "ALLOCATED+CLOUD", "queue1"),
     }
     mock_ec2_health_check = mocker.patch(
         "slurm_plugin.clustermgtd.ClusterManager._fail_ec2_health_check",
@@ -647,8 +663,12 @@ def test_handle_health_check(
         "slurm_plugin.clustermgtd.ClusterManager._fail_scheduled_events_check",
         side_effect=mock_fail_scheduled_events_side_effect,
     )
+    mock_handle_bootstrap_failure_nodes = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._handle_bootstrap_failure_nodes"
+    )
     # Setup mocking
-    mock_sync_config = SimpleNamespace(health_check_timeout=10)
+    mock_sync_config = SimpleNamespace(health_check_timeout=10, protected_failure_count=2)
+
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = "some_current_time"
     cluster_manager._static_nodes_in_replacement = current_node_in_replacement
@@ -671,8 +691,10 @@ def test_handle_health_check(
         )
     if expected_failed_nodes:
         drain_node_mock.assert_called_with(expected_failed_nodes, reason=f"Node failing {health_check_type}")
+        mock_handle_bootstrap_failure_nodes.assert_called_with([expected_bootstrap_failure_node])
     else:
         drain_node_mock.assert_not_called()
+        mock_handle_bootstrap_failure_nodes.assert_not_called()
     assert_that(cluster_manager._static_nodes_in_replacement).is_equal_to(expected_node_in_replacement)
 
 
@@ -944,6 +966,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
 def test_is_node_healthy(node, private_ip_to_instance_map, expected_result, mocker):
     mock_sync_config = SimpleNamespace(terminate_down_nodes=True)
     cluster_manager = ClusterManager(mock_sync_config)
+    cluster_manager._instance_ips_in_cluster = set(private_ip_to_instance_map.keys())
     assert_that(cluster_manager._is_node_healthy(node, private_ip_to_instance_map)).is_equal_to(expected_result)
 
 
@@ -1131,6 +1154,7 @@ def test_handle_unhealthy_static_nodes(
         dns_domain="dns.domain",
         use_private_hostname=False,
         instance_name_type_mapping={"c5xlarge": "c5.xlarge"},
+        protected_failure_count=10,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._static_nodes_in_replacement = current_replacing_nodes
@@ -1195,7 +1219,7 @@ def test_get_backing_instance_ids(slurm_nodes, private_ip_to_instance_map, expec
 
 
 @pytest.mark.parametrize(
-    "private_ip_to_instance_map, active_nodes, mock_unhealthy_nodes",
+    "private_ip_to_instance_map, active_nodes, group_slurm_nodes, _is_protected_mode_enabled, partitions",
     [
         (
             {"ip-1", EC2Instance("id-1", "ip-1", "hostname", "launch_time")},
@@ -1203,7 +1227,9 @@ def test_get_backing_instance_ids(slurm_nodes, private_ip_to_instance_map, expec
                 SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1"),
                 SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "some_state", "queue1"),
             ],
-            (["queue1-st-c5xlarge-1"], ["queue1-st-c5xlarge-2"]),
+            (["queue1-st-c5xlarge-1"], ["queue1-st-c5xlarge-2"], ["queue1-st-c5xlarge-2"], ["queue1-st-c5xlarge-2"]),
+            True,
+            {"partition_name": SlurmPartition("name", "node", "states")},
         ),
         (
             {"ip-1", EC2Instance("id-1", "ip-1", "hostname", "launch_time")},
@@ -1212,34 +1238,56 @@ def test_get_backing_instance_ids(slurm_nodes, private_ip_to_instance_map, expec
                 SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1"),
                 SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "some_state", "queue1"),
             ],
-            (["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-1"], ["queue1-st-c5xlarge-2"]),
+            (
+                ["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-1"],
+                ["queue1-st-c5xlarge-2"],
+                ["queue1-st-c5xlarge-2"],
+                ["queue1-st-c5xlarge-2"],
+            ),
+            False,
+            {"partition_name": SlurmPartition("name", "node", "states")},
         ),
     ],
     ids=["basic", "repetitive_ip"],
 )
 @pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
-def test_maintain_nodes(private_ip_to_instance_map, active_nodes, mock_unhealthy_nodes, mocker):
+def test_maintain_nodes(
+    private_ip_to_instance_map, active_nodes, group_slurm_nodes, _is_protected_mode_enabled, partitions, mocker
+):
     # Mock functions
     cluster_manager = ClusterManager(mocker.MagicMock())
     mock_update_replacement = mocker.patch.object(
         cluster_manager, "_update_static_nodes_in_replacement", auto_spec=True
     )
-    mock_find_unhealthy = mocker.patch.object(
-        cluster_manager, "_find_unhealthy_slurm_nodes", return_value=mock_unhealthy_nodes, auto_spec=True
+    mock_group_slurm_nodes = mocker.patch.object(
+        cluster_manager, "_group_slurm_nodes", return_value=group_slurm_nodes, auto_spec=True
     )
     mock_handle_dynamic = mocker.patch.object(cluster_manager, "_handle_unhealthy_dynamic_nodes", auto_spec=True)
     mock_handle_static = mocker.patch.object(cluster_manager, "_handle_unhealthy_static_nodes", auto_spec=True)
     mock_handle_powering_down_nodes = mocker.patch.object(
         cluster_manager, "_handle_powering_down_nodes", auto_spec=True
     )
+    mock_handle_protected_mode_process = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._handle_protected_mode_process"
+    )
+    mock_is_protected_mode_enabled = mocker.patch.object(
+        cluster_manager, "_is_protected_mode_enabled", return_value=_is_protected_mode_enabled
+    )
     # Run test
-    cluster_manager._maintain_nodes(private_ip_to_instance_map, active_nodes)
+    cluster_manager._maintain_nodes(private_ip_to_instance_map, active_nodes, partitions)
     # Check function calls
     mock_update_replacement.assert_called_with(active_nodes)
-    mock_find_unhealthy.assert_called_with(active_nodes, private_ip_to_instance_map)
-    mock_handle_dynamic.assert_called_with(mock_unhealthy_nodes[0], private_ip_to_instance_map)
-    mock_handle_static.assert_called_with(mock_unhealthy_nodes[1], private_ip_to_instance_map)
+    mock_group_slurm_nodes.assert_called_with(active_nodes, private_ip_to_instance_map)
+    mock_handle_dynamic.assert_called_with(group_slurm_nodes[0], private_ip_to_instance_map)
+    mock_handle_static.assert_called_with(group_slurm_nodes[1], private_ip_to_instance_map)
     mock_handle_powering_down_nodes.assert_called_with(active_nodes, private_ip_to_instance_map)
+    mock_is_protected_mode_enabled.assert_called_once()
+    if _is_protected_mode_enabled:
+        mock_handle_protected_mode_process.assert_called_with(
+            active_nodes, partitions, group_slurm_nodes[2], group_slurm_nodes[3]
+        )
+    else:
+        mock_handle_protected_mode_process.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -1293,6 +1341,7 @@ def test_terminate_orphaned_instances(
         dns_domain="dns.domain",
         use_private_hostname=False,
         instance_name_type_mapping={"c5xlarge": "c5.xlarge"},
+        protected_failure_count=10,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = current_time
@@ -1307,7 +1356,8 @@ def test_terminate_orphaned_instances(
 
 
 @pytest.mark.parametrize(
-    "disable_cluster_management, disable_health_check, mock_cluster_instances, mock_active_nodes, mock_inactive_nodes",
+    "disable_cluster_management, disable_health_check, mock_cluster_instances, mock_active_nodes, mock_inactive_nodes, "
+    "partitions",
     [
         (
             False,
@@ -1321,6 +1371,12 @@ def test_terminate_orphaned_instances(
                 SlurmNode("queue1-st-c5xlarge-2", "ip", "hostname", "some_state", "queue1"),
             ],
             [],
+            [
+                SlurmPartition("partition1", "placeholder_nodes", "UP"),
+                SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
+                SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
+                SlurmPartition("partition4", "placeholder_nodes", "INACTIVE"),
+            ],
         ),
         (
             True,
@@ -1331,6 +1387,12 @@ def test_terminate_orphaned_instances(
                 SlurmNode("queue1-st-c5xlarge-2", "ip", "hostname", "some_state", "queue1"),
             ],
             [],
+            [
+                SlurmPartition("partition1", "placeholder_nodes", "UP"),
+                SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
+                SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
+                SlurmPartition("partition4", "placeholder_nodes", "INACTIVE"),
+            ],
         ),
         (
             False,
@@ -1341,6 +1403,12 @@ def test_terminate_orphaned_instances(
                 SlurmNode("queue1-st-c5xlarge-2", "ip", "hostname", "some_state", "queue1"),
             ],
             [],
+            [
+                SlurmPartition("partition1", "placeholder_nodes", "UP"),
+                SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
+                SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
+                SlurmPartition("partition4", "placeholder_nodes", "INACTIVE"),
+            ],
         ),
         (
             False,
@@ -1351,6 +1419,12 @@ def test_terminate_orphaned_instances(
                 SlurmNode("inactive-queue1-st-c5xlarge-1", "ip", "hostname", "some_state", "inactive-queue1"),
                 SlurmNode("inactive-queue1-st-c5xlarge-2", "ip", "hostname", "some_state", "inactive-queue1"),
             ],
+            [
+                SlurmPartition("partition1", "placeholder_nodes", "UP"),
+                SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
+                SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
+                SlurmPartition("partition4", "placeholder_nodes", "INACTIVE"),
+            ],
         ),
         (
             False,
@@ -1358,6 +1432,12 @@ def test_terminate_orphaned_instances(
             [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
             [],
             [],
+            [
+                SlurmPartition("partition1", "placeholder_nodes", "UP"),
+                SlurmPartition("partition2", "placeholder_nodes", "INACTIVE"),
+                SlurmPartition("partition3", "placeholder_nodes", "DRAIN"),
+                SlurmPartition("partition4", "placeholder_nodes", "INACTIVE"),
+            ],
         ),
     ],
     ids=["all_enabled", "disable_all", "disable_health_check", "no_active", "no_node"],
@@ -1372,6 +1452,7 @@ def test_manage_cluster(
     initialize_instance_manager_mock,
     initialize_compute_fleet_status_manager_mock,
     caplog,
+    partitions,
 ):
     caplog.set_level(logging.ERROR)
     mock_sync_config = SimpleNamespace(
@@ -1386,6 +1467,7 @@ def test_manage_cluster(
         hosted_zone="hosted_zone",
         dns_domain="dns.domain",
         use_private_hostname=False,
+        protected_failure_count=10,
     )
     mocker.patch("time.sleep")
     ip_to_slurm_node_map = {node.nodeaddr: node for node in mock_active_nodes}
@@ -1396,6 +1478,10 @@ def test_manage_cluster(
         cluster_manager, "_compute_fleet_status_manager", spec=ComputeFleetStatusManager
     )
     compute_fleet_status_manager_mock.get_status.return_value = ComputeFleetStatus.RUNNING
+    get_partition_info_with_retry_mock = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._get_partition_info_with_retry", return_value=partitions
+    )
+    partitions_map = {partition.name: partition for partition in partitions}
     write_timestamp_to_file_mock = mocker.patch.object(ClusterManager, "_write_timestamp_to_file", auto_spec=True)
     perform_health_check_actions_mock = mocker.patch.object(
         ClusterManager, "_perform_health_check_actions", auto_spec=True
@@ -1445,13 +1531,14 @@ def test_manage_cluster(
     else:
         perform_health_check_actions_mock.assert_called_with(mock_cluster_instances, ip_to_slurm_node_map)
     maintain_nodes_mock.assert_called_with(
-        {instance.private_ip: instance for instance in mock_cluster_instances}, mock_active_nodes
+        {instance.private_ip: instance for instance in mock_cluster_instances}, mock_active_nodes, partitions_map
     )
     terminate_orphaned_instances_mock.assert_called_with(
         mock_cluster_instances, ips_used_by_slurm=list(ip_to_slurm_node_map.keys())
     )
 
     assert_that(caplog.text).is_empty()
+    get_partition_info_with_retry_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -2032,6 +2119,7 @@ def test_manage_compute_fleet_status_transitions_concurrency(mocker, caplog):
         dns_domain="dns.domain",
         use_private_hostname=False,
         instance_name_type_mapping={},
+        protected_failure_count=10,
     )
     cluster_manager = ClusterManager(config)
     mocker.patch("slurm_plugin.clustermgtd.update_all_partitions")
@@ -2110,6 +2198,669 @@ class TestComputeFleetStatusManager:
         else:
             compute_fleet_status_manager._table.put_item.return_value = put_item_response
             compute_fleet_status_manager.update_status(ComputeFleetStatus.STARTING, ComputeFleetStatus.RUNNING)
+
+
+@pytest.mark.parametrize(
+    "healthy_nodes, bootstrap_failure_nodes_types, expected_bootstrap_failure_nodes_types, "
+    "expected_partitions_protected_failure_count_map",
+    [
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD", "queue1"),
+                SlurmNode("queue2-st-c5xlarge-2", "ip-2", "hostname", "MIXED#+CLOUD", "queue2"),
+            ],
+            {NodeType("c5xlarge", "queue1"), NodeType("c5large", "queue1")},
+            {NodeType("c5large", "queue1")},
+            {"queue2": 8},
+        ),
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD", "queue1"),
+                SlurmNode("queue1-st-c5large-2", "ip-2", "hostname", "MIXED+CLOUD", "queue1"),
+            ],
+            {NodeType("c5xlarge", "queue1"), NodeType("c5large", "queue1")},
+            set(),
+            {"queue2": 8},
+        ),
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "IDLE#+CLOUD", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "MIXED*+CLOUD", "queue1"),
+            ],
+            {NodeType("c5xlarge", "queue1"), NodeType("c5large", "queue1")},
+            {NodeType("c5xlarge", "queue1"), NodeType("c5large", "queue1")},
+            {"queue1": 5, "queue2": 8},
+        ),
+    ],
+)
+def test_handle_successfully_launched_nodes(
+    healthy_nodes,
+    bootstrap_failure_nodes_types,
+    expected_bootstrap_failure_nodes_types,
+    expected_partitions_protected_failure_count_map,
+    mocker,
+):
+    # Test setup
+    mock_sync_config = SimpleNamespace(
+        terminate_max_batch_size=1,
+        launch_max_batch_size=5,
+        update_node_address=True,
+        region="us-east-2",
+        cluster_name="hit-test",
+        boto3_config=botocore.config.Config(),
+        dynamodb_table="table_name",
+        head_node_private_ip="master.ip",
+        head_node_hostname="master-hostname",
+        hosted_zone="hosted_zone",
+        dns_domain="dns.domain",
+        use_private_hostname=False,
+        instance_name_type_mapping={"c5xlarge": "c5.xlarge"},
+        protected_failure_count=10,
+    )
+    # Mock associated function
+    cluster_manager = ClusterManager(mock_sync_config)
+
+    cluster_manager._bootstrap_failure_nodes_types = bootstrap_failure_nodes_types
+    cluster_manager._partitions_protected_failure_count_map = {"queue1": 5, "queue2": 8}
+
+    # Run test
+    cluster_manager._handle_successfully_launched_nodes(healthy_nodes)
+    # Assert calls
+    assert_that(cluster_manager._bootstrap_failure_nodes_types).is_equal_to(expected_bootstrap_failure_nodes_types)
+    assert_that(cluster_manager._partitions_protected_failure_count_map).is_equal_to(
+        expected_partitions_protected_failure_count_map
+    )
+
+
+@pytest.mark.parametrize(
+    "bootstrap_failure_nodes, initial_bootstrap_failure_nodes_types, expected_bootstrap_failure_nodes_types, "
+    "expected_partitions_protected_failure_count_map",
+    [
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "some_state", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-3", "ip-3", "hostname", "some_state", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-999", "ip-1", "hostname", "some_state", "queue1"),
+            ],
+            set(),
+            {NodeType("c5xlarge", "queue1")},
+            {"queue1": 5},
+        ),
+        (
+            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1")],
+            {NodeType("c5xlarge", "queue1")},
+            {NodeType("c5xlarge", "queue1")},
+            {"queue1": 2},
+        ),
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1"),
+                SlurmNode("queue2-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue2"),
+            ],
+            {NodeType("c5xlarge", "queue1")},
+            {NodeType("c5xlarge", "queue1"), NodeType("c5xlarge", "queue2")},
+            {"queue1": 2, "queue2": 1},
+        ),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_handle_bootstrap_failure_nodes(
+    bootstrap_failure_nodes,
+    expected_bootstrap_failure_nodes_types,
+    initial_bootstrap_failure_nodes_types,
+    expected_partitions_protected_failure_count_map,
+    mocker,
+):
+    cluster_manager = ClusterManager(mocker.MagicMock())
+
+    cluster_manager._bootstrap_failure_nodes_types = initial_bootstrap_failure_nodes_types
+    cluster_manager._partitions_protected_failure_count_map = {"queue1": 1}
+    cluster_manager._handle_bootstrap_failure_nodes(bootstrap_failure_nodes)
+    assert_that(cluster_manager._bootstrap_failure_nodes_types).is_equal_to(expected_bootstrap_failure_nodes_types)
+    assert_that(cluster_manager._partitions_protected_failure_count_map).is_equal_to(
+        expected_partitions_protected_failure_count_map
+    )
+
+
+@pytest.mark.parametrize(
+    "node, private_ip_to_instance_map, is_backing_instance_valid, current_node_in_replacement, "
+    "bootstrap_failure_messages, is_node_bootstrap_failure",
+    [
+        (
+            SlurmNode("queue1-st-c5xlarge-1", "ip-1", "DOWN*+CLOUD", "some_state", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            False,
+            {"queue1-st-c5xlarge-1"},
+            "Node bootstrap error: Node queue1-st-c5xlarge-1(ip-1) is currently in replacement and no backing instance",
+            True,
+        ),
+        (
+            SlurmNode("queue1-st-c5xlarge-1", "ip-1", "DOWN*+CLOUD", "some_state", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            },
+            True,
+            {"queue1-st-c5xlarge-1"},
+            "Node bootstrap error: Replacement timeout expires for node queue1-st-c5xlarge-1(ip-1) in replacement",
+            True,
+        ),
+        (
+            SlurmNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "MIXED#+CLOUD", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            False,
+            {"some_node_in_replacement"},
+            "Node bootstrap error: Node queue1-dy-c5xlarge-1(ip-1) is in power up state without valid backing instance",
+            True,
+        ),
+        (
+            SlurmNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN*+CLOUD+POWER", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            True,
+            {"some_node_in_replacement"},
+            "Node bootstrap error: Resume timeout expires",
+            True,
+        ),
+        (
+            SlurmNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN#+CLOUD", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            False,
+            {"some_node_in_replacement"},
+            None,
+            False,
+        ),
+        (
+            SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN*+CLOUD", "queue1"),
+            {
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            False,
+            {"some_node_in_replacement"},
+            None,
+            False,
+        ),
+        (
+            SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN*+CLOUD", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            False,
+            {"some_node_in_replacement"},
+            None,
+            False,
+        ),
+        (
+            SlurmNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWER", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            False,
+            {"queue1-st-c5xlarge-1"},
+            None,
+            False,
+        ),
+        (
+            SlurmNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DRAIN+CLOUD", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            True,
+            {"queue1-st-c5xlarge-1"},
+            None,
+            False,
+        ),
+        (
+            SlurmNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWERING_DOWN", "queue1"),
+            {
+                "ip-1": EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+                "ip-2": EC2Instance("id-2", "ip-2", "hostname", "launch_time"),
+            },
+            True,
+            {"queue1-st-c5xlarge-1"},
+            None,
+            False,
+        ),
+    ],
+    ids=[
+        "static_self_terminate",
+        "static_timeout",
+        "dynamic_self_terminate",
+        "dynamic_timeout",
+        "dynamic_runinstance",
+        "static_runinstance",
+        "static_joined_cluster",
+        "dynamic_reset_incorrect",
+        "normal_down_1",
+        "normal_down_2",
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_is_node_bootstrap_failure(
+    node,
+    private_ip_to_instance_map,
+    is_backing_instance_valid,
+    current_node_in_replacement,
+    bootstrap_failure_messages,
+    is_node_bootstrap_failure,
+    mocker,
+    caplog,
+):
+    mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._is_backing_instance_valid", return_value=is_backing_instance_valid
+    )
+    mock_sync_config = SimpleNamespace(node_replacement_timeout=30)
+    caplog.set_level(logging.WARNING)
+    cluster_manager = ClusterManager(mock_sync_config)
+    cluster_manager._current_time = datetime(2020, 1, 2, 0, 0, 0)
+    cluster_manager._static_nodes_in_replacement = current_node_in_replacement
+    # Run tests and assert calls
+    assert_that(cluster_manager._is_node_bootstrap_failure(node, private_ip_to_instance_map)).is_equal_to(
+        is_node_bootstrap_failure
+    )
+    if bootstrap_failure_messages:
+        assert_that(caplog.text).contains(bootstrap_failure_messages)
+
+
+@pytest.mark.parametrize(
+    "nodes, initial_map, expected_map",
+    [
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1"),
+                SlurmNode("queue2-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue2"),
+            ],
+            {"queue1": 1, "queue2": 1},
+            {"queue1": 2, "queue2": 2},
+        ),
+        (
+            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue2")],
+            {"queue1": 1},
+            {"queue1": 1, "queue2": 1},
+        ),
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1"),
+                SlurmNode("queue1-st-c5large-1", "ip-1", "hostname", "some_state", "queue1"),
+            ],
+            {},
+            {"queue1": 2},
+        ),
+        (
+            [SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1,queue2")],
+            {},
+            {"queue1": 1, "queue2": 1},
+        ),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_increase_partitions_protected_failure_count(nodes, initial_map, expected_map, mocker):
+    # Mock associated function
+    cluster_manager = ClusterManager(mocker.MagicMock())
+    cluster_manager._partitions_protected_failure_count_map = initial_map
+    # Run test
+    cluster_manager._increase_partitions_protected_failure_count(nodes)
+    # Assert calls
+    assert_that(cluster_manager._partitions_protected_failure_count_map).is_equal_to(expected_map)
+
+
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+@pytest.mark.parametrize(
+    "slurm_nodes, online_nodes",
+    [
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "IDLE+CLOUD", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-3", "ip-2", "hostname", "MIXED+CLOUD", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-4", "ip-3", "hostname", "MIXED#", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-4", "ip-3", "hostname", "MIXED+CLOUD+POWER", "queue1"),
+            ],
+            [
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "IDLE+CLOUD", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-3", "ip-2", "hostname", "MIXED+CLOUD", "queue1"),
+            ],
+        ),
+    ],
+)
+def test_find_online_slurm_nodes(mocker, slurm_nodes, online_nodes):
+    # Mock associated function
+    cluster_manager = ClusterManager(mocker.MagicMock())
+    assert_that(cluster_manager._find_online_slurm_nodes(slurm_nodes)).is_equal_to(online_nodes)
+
+
+@pytest.mark.parametrize(
+    "partition, expected_map",
+    [
+        ("queue1", {"queue2": 1}),
+        ("queue2", {"queue1": 2}),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_reset_partition_failure_count(mocker, partition, expected_map):
+    # Mock associated function
+    cluster_manager = ClusterManager(mocker.MagicMock())
+    cluster_manager._partitions_protected_failure_count_map = {"queue1": 2, "queue2": 1}
+    cluster_manager._reset_partition_failure_count(partition)
+    assert_that(cluster_manager._partitions_protected_failure_count_map).is_equal_to(expected_map)
+
+
+@pytest.mark.parametrize(
+    "slurm_nodes, online_nodes, expected_return",
+    [
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "MIXED", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-3", "ip-3", "hostname", "MIXED#", "queue1"),
+            ],
+            [
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5large-2", "ip-2", "hostname", "MIXED", "queue1"),
+            ],
+            {
+                NodeType(instance_type="c5xlarge", partition="queue1"),
+                NodeType(instance_type="c5large", partition="queue1"),
+            },
+        ),
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "MIXED", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-3", "ip-3", "hostname", "MIXED#", "queue1"),
+            ],
+            [
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "MIXED", "queue1"),
+            ],
+            {NodeType(instance_type="c5xlarge", partition="queue1")},
+        ),
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "MIXED", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-3", "ip-3", "hostname", "MIXED#", "queue1"),
+            ],
+            [],
+            set(),
+        ),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_get_online_nodes_types(slurm_nodes, online_nodes, expected_return, mocker):
+    # Mock associated function
+    cluster_manager = ClusterManager(mocker.MagicMock())
+    mock_find_online_slurm_nodes = mocker.patch.object(
+        cluster_manager, "_find_online_slurm_nodes", return_value=online_nodes
+    )
+    # Run test and assert calls
+    assert_that(cluster_manager._get_online_nodes_types(slurm_nodes)).is_equal_to(expected_return)
+    mock_find_online_slurm_nodes.assert_called_with(slurm_nodes)
+
+
+@pytest.mark.parametrize(
+    "nodename_to_slurm_nodes_map, bootstrap_failure_partitions, expected_partitions_to_disable, "
+    "partitions, partitions_with_active_jobs",
+    [
+        (
+            {
+                "queue1-st-c5xlarge-1": SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+                "queue1-st-c5xlarge-2": SlurmNode(
+                    "queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"
+                ),
+            },
+            [],
+            set(),
+            {"queue1": SlurmPartition("queue1", "queue1-st-c5xlarge-1", "states")},
+            set(),
+        ),
+        (
+            {
+                "queue2-st-c5xlarge-1": SlurmNode(
+                    "queue2-st-c5xlarge-1", "ip-1", "hostname", "ALLOCATED+CLOUD", "queue1"
+                ),
+                "queue1-st-c5xlarge-2": SlurmNode(
+                    "queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"
+                ),
+            },
+            ["queue1", "queue2"],
+            {"queue1"},
+            {"queue2": SlurmPartition("queue2", "queue2-st-c5xlarge-1", "states")},
+            {"queue2"},
+        ),
+        (
+            {
+                "queue1-st-c5xlarge-1": SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+                "queue1-st-c5xlarge-2": SlurmNode(
+                    "queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"
+                ),
+            },
+            ["queue1", "queue2"],
+            {"queue1", "queue2"},
+            {"partition_name": SlurmPartition("name", "node", "states")},
+            set(),
+        ),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_get_partitions_to_disable(
+    nodename_to_slurm_nodes_map,
+    bootstrap_failure_partitions,
+    expected_partitions_to_disable,
+    partitions,
+    partitions_with_active_jobs,
+    mocker,
+):
+    # Mock associated function
+    cluster_manager = ClusterManager(mocker.MagicMock())
+    mock_filter_partitions_with_active_jobs = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._filter_partitions_with_active_jobs",
+        return_value=partitions_with_active_jobs,
+    )
+    # Run test and assert calls
+    partitions_to_disable = cluster_manager._get_partitions_to_disable(
+        nodename_to_slurm_nodes_map, bootstrap_failure_partitions, partitions
+    )
+    assert_that(partitions_to_disable).is_equal_to(expected_partitions_to_disable)
+    mock_filter_partitions_with_active_jobs.assert_called_with(nodename_to_slurm_nodes_map, partitions)
+
+
+@pytest.mark.parametrize(
+    "nodename_to_slurm_nodes_map, partitions, partitions_with_active_jobs",
+    [
+        (
+            {
+                "queue1-st-c5xlarge-1": SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+                "queue1-st-c5xlarge-2": SlurmNode(
+                    "queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"
+                ),
+            },
+            {"queue1": SlurmPartition("queue1", "queue1-st-c5xlarge-1,queue1-st-c5xlarge-2", "states")},
+            set(),
+        ),
+        (
+            {
+                "queue2-st-c5xlarge-1": SlurmNode(
+                    "queue2-st-c5xlarge-1", "ip-1", "hostname", "ALLOCATED+CLOUD", "queue2"
+                ),
+                "queue1-st-c5xlarge-2": SlurmNode(
+                    "queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"
+                ),
+                "queue2-dy-c5xlarge-2": SlurmNode(
+                    "queue2-dy-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue2"
+                ),
+            },
+            {
+                "queue2": SlurmPartition("queue2", "queue2-st-c5xlarge-1,queue2-dy-c5xlarge-1", "states"),
+                "queue1": SlurmPartition("queue1", "queue1-st-c5xlarge-1", "states"),
+            },
+            {"queue2"},
+        ),
+        (
+            {
+                "queue2-st-c5xlarge-1": SlurmNode(
+                    "queue2-st-c5xlarge-1", "ip-1", "hostname", "ALLOCATED+CLOUD", "queue2"
+                ),
+                "queue1-st-c5xlarge-2": SlurmNode(
+                    "queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"
+                ),
+                "queue1-dy-c5xlarge-2": SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "MIXED+CLOUD", "queue1"),
+            },
+            {
+                "queue2": SlurmPartition("queue2", "queue2-st-c5xlarge-1", "states"),
+                "queue1": SlurmPartition("queue1", "queue1-st-c5xlarge-1,queue1-dy-c5xlarge-2", "states"),
+            },
+            {"queue1", "queue2"},
+        ),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_filter_partitions_with_active_jobs(
+    nodename_to_slurm_nodes_map, partitions, partitions_with_active_jobs, mocker
+):
+    cluster_manager = ClusterManager(mocker.MagicMock())
+    result = cluster_manager._filter_partitions_with_active_jobs(nodename_to_slurm_nodes_map, partitions)
+    assert_that(result).is_equal_to(partitions_with_active_jobs)
+
+
+@pytest.mark.parametrize(
+    "slurm_nodes, healthy_nodes, bootstrap_failure_nodes, expected_partitions_above_threshold, partitions_to_disable, "
+    "partitions, partitions_protected_failure_count_map",
+    [
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+            ],
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+            ],
+            [
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5large-2", "ip-2", "hostname", "MIXED", "queue1"),
+            ],
+            ["queue2"],
+            ["queue1", "queue2"],
+            {"queue1": SlurmPartition("queue1", "queue1-st-c5xlarge-1, queue1-st-c5xlarge-[2,3-4]", "states")},
+            {"queue1": 11, "queue2": 12, "queue3": 3},
+        ),
+        (
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+            ],
+            [
+                SlurmNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
+            ],
+            [
+                SlurmNode("queue1-st-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "MIXED", "queue1"),
+            ],
+            [],
+            ["queue1"],
+            {"queue1": SlurmPartition("queue1", "queue1-st-c5xlarge-[1,3-5], queue1-st-c5xlarge-2", "states")},
+            {"queue2": 6, "queue3": 3},
+        ),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_handle_protected_mode_process(
+    slurm_nodes,
+    partitions,
+    bootstrap_failure_nodes,
+    healthy_nodes,
+    expected_partitions_above_threshold,
+    partitions_to_disable,
+    partitions_protected_failure_count_map,
+    mocker,
+    caplog,
+):
+    mock_sync_config = SimpleNamespace(
+        protected_failure_count=10,
+    )
+    caplog.set_level(logging.INFO)
+    cluster_manager = ClusterManager(mock_sync_config)
+    mock_handle_successfully_launched_nodes = mocker.patch.object(
+        cluster_manager, "_handle_successfully_launched_nodes"
+    )
+    mock_handle_bootstrap_failure_nodes = mocker.patch.object(cluster_manager, "_handle_bootstrap_failure_nodes")
+
+    mock_enter_protected_mode = mocker.patch.object(cluster_manager, "_enter_protected_mode")
+    mock_get_partitions_to_disable = mocker.patch(
+        "slurm_plugin.clustermgtd.ClusterManager._get_partitions_to_disable", return_value=partitions_to_disable
+    )
+    cluster_manager._partitions_protected_failure_count_map = partitions_protected_failure_count_map
+    cluster_manager._inactive_partitions = {"queue1"}
+    nodename_to_slurm_nodes_map = {node.name: node for node in slurm_nodes}
+    # Run test
+    cluster_manager._handle_protected_mode_process(slurm_nodes, partitions, bootstrap_failure_nodes, healthy_nodes)
+    # Assert calls
+    if bootstrap_failure_nodes:
+        assert_that(caplog.text).contains("Found the following bootstrap failure nodes")
+        mock_handle_bootstrap_failure_nodes.assert_called_with(bootstrap_failure_nodes)
+
+    mock_handle_successfully_launched_nodes.assert_called_with(healthy_nodes)
+    if expected_partitions_above_threshold:
+        mock_get_partitions_to_disable.assert_called_with(
+            nodename_to_slurm_nodes_map, expected_partitions_above_threshold, partitions
+        )
+        mock_enter_protected_mode.assert_called_with(partitions_to_disable)
+
+
+@pytest.mark.parametrize(
+    "partitions_to_disable, compute_fleet_status",
+    [
+        (
+            set(),
+            ComputeFleetStatus.PROTECTED,
+        ),
+        (
+            {"queue1"},
+            ComputeFleetStatus.RUNNING,
+        ),
+        (
+            {"queue1", "queue2"},
+            ComputeFleetStatus.STOPPED,
+        ),
+    ],
+)
+@pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
+def test_enter_protected_mode(
+    partitions_to_disable,
+    mocker,
+    compute_fleet_status,
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    cluster_manager = ClusterManager(mocker.MagicMock())
+    mock_update_compute_fleet_status = mocker.patch.object(cluster_manager, "_update_compute_fleet_status")
+    cluster_manager._compute_fleet_status = compute_fleet_status
+    cluster_manager._enter_protected_mode(partitions_to_disable)
+    if partitions_to_disable:
+        assert_that(caplog.text).contains("Placing bootstrap failure partitions to INACTIVE")
+        if not compute_fleet_status == ComputeFleetStatus.PROTECTED:
+            assert_that(caplog.text).contains("Setting cluster into protected mode due to failures")
+            mock_update_compute_fleet_status.assert_called_with(ComputeFleetStatus.PROTECTED)
+
+    else:
+        assert_that(caplog.text).contains(
+            "Not entering protected mode since active are jobs running in bootstrap failure partitions"
+        )
 
 
 @pytest.fixture()

--- a/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
+++ b/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/all_options.conf
@@ -24,3 +24,4 @@ master_hostname = master-hostname
 hosted_zone = hosted-zone
 dns_domain = dns.domain
 use_private_hostname = false
+protected_failure_count = 5


### PR DESCRIPTION
* Identify nodes with bootstrap failure.
* Keep count of failures
*  Reset failure when there is a successful launch of the node type have been failed previously
*  Disable queue and put cluster in protected mode if failure > protected_failure_count, which is set to 10.
*  User can check cluster status with pcluster status and manually reactivate queue with pcluster start. When executing `pcluster start`, the protected failure count will be reset.
*  Reduce "node_replacement_timeout" and Resume Timeout to  1800 seconds instead of 3600 seconds