### PR TITLE
3.0: Execute Slurm command scontrol with sudo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ build/
 .tox/
 .coverage
 coverage.xml
+
+aws-parallelcluster-node-*.tgz
+aws-parallelcluster-node-*.md5
+aws-parallelcluster-node-*.date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 
 - Drop support for SGE and Torque schedulers.
 - Change tags prefix from `aws-parallelcluster-` to `parallelcluster:`.
+- Run Slurm command `scontrol` with sudo because clustermgtd is run as cluster admin user (not root).
 
 2.x.x
 -----
@@ -34,7 +35,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 - Improve error handling in slurm plugin processes when clustermgtd is down.
 
 **CHANGES**
-- Increase max attempts when retrying on Route53 API call failures. 
+- Increase max attempts when retrying on Route53 API call failures.
 
 2.10.0
 -----

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -43,7 +43,7 @@ _SQUEUE_FIELDS = [
     "cpus-per-tres",
 ]
 SQUEUE_FIELD_STRING = ",".join([field + ":{size}" for field in _SQUEUE_FIELDS]).format(size=SQUEUE_FIELD_SIZE)
-SCONTROL = "/opt/slurm/bin/scontrol"
+SCONTROL = "sudo /opt/slurm/bin/scontrol"
 SINFO = "/opt/slurm/bin/sinfo"
 
 SlurmPartition = collections.namedtuple("SlurmPartition", ["name", "nodes", "state"])

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -379,13 +379,13 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
             False,
             [
                 call(
-                    "/opt/slurm/bin/scontrol update nodename=queue1-st-c5xlarge-1",
+                    "sudo /opt/slurm/bin/scontrol update nodename=queue1-st-c5xlarge-1",
                     raise_on_error=False,
                     timeout=60,
                     shell=True,
                 ),
                 call(
-                    "/opt/slurm/bin/scontrol update nodename=queue1-st-c5xlarge-2,queue1-st-c5xlarge-3",
+                    "sudo /opt/slurm/bin/scontrol update nodename=queue1-st-c5xlarge-2,queue1-st-c5xlarge-3",
                     raise_on_error=False,
                     timeout=60,
                     shell=True,
@@ -402,14 +402,14 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
             True,
             [
                 call(
-                    "/opt/slurm/bin/scontrol update state=power_down "
+                    "sudo /opt/slurm/bin/scontrol update state=power_down "
                     "nodename=queue1-st-c5xlarge-1 nodehostname=hostname-1",
                     raise_on_error=True,
                     timeout=60,
                     shell=True,
                 ),
                 call(
-                    "/opt/slurm/bin/scontrol update state=power_down "
+                    "sudo /opt/slurm/bin/scontrol update state=power_down "
                     "nodename=queue1-st-c5xlarge-2,queue1-st-c5xlarge-3 nodeaddr=addr-2,addr-3",
                     raise_on_error=True,
                     timeout=60,
@@ -428,7 +428,7 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
             [
                 call(
                     (
-                        '/opt/slurm/bin/scontrol update state=down reason="debugging"'
+                        'sudo /opt/slurm/bin/scontrol update state=down reason="debugging"'
                         + " nodename=queue1-st-c5xlarge-1 nodehostname=hostname-1"
                     ),
                     raise_on_error=True,
@@ -437,7 +437,7 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                 ),
                 call(
                     (
-                        '/opt/slurm/bin/scontrol update state=down reason="debugging"'
+                        'sudo /opt/slurm/bin/scontrol update state=down reason="debugging"'
                         + " nodename=queue1-st-c5xlarge-[3-6] nodeaddr=addr-[3-6] nodehostname=hostname-[3-6]"
                     ),
                     raise_on_error=True,
@@ -551,12 +551,12 @@ def test_slurm_node_is_up(node, expected_output):
             PartitionStatus.INACTIVE,
             [
                 call(
-                    "/opt/slurm/bin/scontrol update partitionname=part-1 state=INACTIVE",
+                    "sudo /opt/slurm/bin/scontrol update partitionname=part-1 state=INACTIVE",
                     raise_on_error=True,
                     shell=True,
                 ),
                 call(
-                    "/opt/slurm/bin/scontrol update partitionname=part-2 state=INACTIVE",
+                    "sudo /opt/slurm/bin/scontrol update partitionname=part-2 state=INACTIVE",
                     raise_on_error=True,
                     shell=True,
                 ),
@@ -568,8 +568,12 @@ def test_slurm_node_is_up(node, expected_output):
             ["part-1", "part-2"],
             "UP",
             [
-                call("/opt/slurm/bin/scontrol update partitionname=part-1 state=UP", raise_on_error=True, shell=True),
-                call("/opt/slurm/bin/scontrol update partitionname=part-2 state=UP", raise_on_error=True, shell=True),
+                call(
+                    "sudo /opt/slurm/bin/scontrol update partitionname=part-1 state=UP", raise_on_error=True, shell=True
+                ),
+                call(
+                    "sudo /opt/slurm/bin/scontrol update partitionname=part-2 state=UP", raise_on_error=True, shell=True
+                ),
             ],
             [Exception, None],
             ["part-2"],


### PR DESCRIPTION
### Changes
1. Make daemons execute Slurm commands with sudo. This change is related to [PR in cookbook](https://github.com/aws/aws-parallelcluster-cookbook/pull/961)
2. Added to gitignore the files generated by the upload-node script

### Testing
1. Tested on a pc3 cluster: creation, stop, start, deletion
2. Integration tests succeeded


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
