### PR TITLE
Revert "Use cloud_reg_addrs option and do not manually reset nodeaddr on power_down"

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -292,13 +292,8 @@ def set_nodes_drain(nodes, reason):
 
 
 def set_nodes_power_down(nodes, reason=None):
-    """
-    Place slurm node into power_down state.
-
-    Do not reset the nodeaddr/nodehostname manually.
-    Nodeaddr/nodehostname will be reset automatically after power_down with cloud_reg_addrs.
-    """
-    update_nodes(nodes=nodes, state="power_down", reason=reason, raise_on_error=True)
+    """Place slurm node into power_down state and reset nodeaddr/nodehostname."""
+    reset_nodes(nodes=nodes, state="power_down", reason=reason, raise_on_error=True)
 
 
 def reset_nodes(nodes, state=None, reason=None, raise_on_error=False):

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -757,13 +757,8 @@ class ClusterManager:
                 and self._is_node_state_healthy(node, private_ip_to_instance_map)
             )
         else:
-            # Do not handle powering_down nodes
-            # powering_down nodes should be already handled by _handle_powering_down_nodes
-            return (
-                node.is_powering_down()
-                or ClusterManager._is_backing_instance_valid(
-                    node, instance_ips_in_cluster=list(private_ip_to_instance_map.keys())
-                )
+            return ClusterManager._is_backing_instance_valid(
+                node, instance_ips_in_cluster=list(private_ip_to_instance_map.keys())
             ) and self._is_node_state_healthy(node, private_ip_to_instance_map)
 
     @log_exception(log, "maintaining unhealthy dynamic nodes", raise_on_error=False)
@@ -794,21 +789,16 @@ class ClusterManager:
         Handle nodes that are powering down.
 
         Terminate instances backing the powering down node if any.
-        Do not reset the nodeaddr/nodehostname manually.
-        Nodeaddr/nodehostname will be reset automatically after power_down with cloud_reg_addrs.
-        Node state is not changed.
+        Reset the nodeaddr for the powering down node. Node state is not changed.
         """
         powering_down_nodes = []
         for node in slurm_nodes:
-            # Nodes in powering_down(i.e. down%) state will still have the nodeaddr of the backing instance.
-            # Nodeaddr is reset to nodename automatically by slurm after the power_down process,
-            # when node goes back into power_saving(i.e. idle~).
-            # If instance is not terminated during powering_down for some reason,
-            # it becomes orphaned once the nodeaddr is reset, and will be handled as an orphaned node.
             if not node.is_static and node.is_nodeaddr_set() and (node.is_power() or node.is_powering_down()):
                 powering_down_nodes.append(node)
 
         if powering_down_nodes:
+            log.info("Resetting powering down nodes: %s", print_with_count(powering_down_nodes))
+            reset_nodes(nodes=[node.name for node in powering_down_nodes])
             instances_to_terminate = ClusterManager._get_backing_instance_ids(
                 powering_down_nodes, private_ip_to_instance_map
             )

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -341,7 +341,7 @@ def test_set_nodes_down(nodes, reason, reset_addrs, update_call_kwargs, mocker):
     ],
 )
 def test_set_nodes_power_down(nodes, reason, reset_addrs, update_call_kwargs, mocker):
-    update_mock = mocker.patch("common.schedulers.slurm_commands.update_nodes", autospec=True)
+    update_mock = mocker.patch("common.schedulers.slurm_commands.reset_nodes", autospec=True)
     set_nodes_power_down(nodes, reason)
     update_mock.assert_called_with(**update_call_kwargs)
 

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -852,7 +852,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
 
 
 @pytest.mark.parametrize(
-    "node, private_ip_to_instance_map, expected_result",
+    "node, private_ip_to_instance_map, instance_ips_in_cluster, expected_result",
     [
         (
             SlurmNode("queue-st-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD", "queue"),
@@ -860,6 +860,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             },
+            ["ip-1", "ip-2"],
             True,
         ),
         (
@@ -868,6 +869,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             },
+            ["ip-1", "ip-2"],
             False,
         ),
         (
@@ -876,6 +878,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             },
+            ["ip-1", "ip-2"],
             True,
         ),
         (
@@ -884,6 +887,7 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             },
+            ["ip-1", "ip-2"],
             False,
         ),
         (
@@ -892,56 +896,14 @@ def test_is_node_state_healthy(node, mock_sync_config, mock_is_node_being_replac
                 "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             },
+            ["ip-1", "ip-2"],
             False,
-        ),
-        # Powering_down nodes are handled separately, always considered healthy by this workflow
-        (
-            SlurmNode("queue-dy-c5xlarge-1", "ip-2", "hostname", "DOWN+CLOUD+POWERING_DOWN", "queue"),
-            {
-                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-                "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-            },
-            True,
-        ),
-        # Node in POWER_SAVE, but still has ip associated should be considered unhealthy
-        (
-            SlurmNode("queue-dy-c5xlarge-1", "ip-2", "hostname", "IDLE+CLOUD+POWER", "queue"),
-            {
-                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-            },
-            False,
-        ),
-        # Node in POWER_SAVE, but also in DOWN should be considered unhealthy
-        (
-            SlurmNode("queue-dy-c5xlarge-1", "queue-dy-c5xlarge-1", "hostname", "DOWN+CLOUD+POWER", "queue"),
-            {
-                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-                "ip-2": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-            },
-            False,
-        ),
-        (
-            SlurmNode("queue-dy-c5xlarge-1", "queue-dy-c5xlarge-1", "queue-dy-c5xlarge-1", "IDLE+CLOUD+POWER", "queue"),
-            {
-                "ip-1": EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-            },
-            True,
         ),
     ],
-    ids=[
-        "basic",
-        "static_nodeaddr_not_set",
-        "dynamic_nodeaddr_not_set",
-        "dynamic_unhealthy",
-        "static_unhealthy",
-        "powering_down",
-        "power_unhealthy1",
-        "power_unhealthy2",
-        "power_healthy",
-    ],
+    ids=["basic", "static_nodeaddr_not_set", "dynamic_nodeaddr_not_set", "dynamic_unhealthy", "static_unhealthy"],
 )
 @pytest.mark.usefixtures("initialize_instance_manager_mock", "initialize_compute_fleet_status_manager_mock")
-def test_is_node_healthy(node, private_ip_to_instance_map, expected_result, mocker):
+def test_is_node_healthy(node, private_ip_to_instance_map, instance_ips_in_cluster, expected_result, mocker):
     mock_sync_config = SimpleNamespace(terminate_down_nodes=True)
     cluster_manager = ClusterManager(mock_sync_config)
     assert_that(cluster_manager._is_node_healthy(node, private_ip_to_instance_map)).is_equal_to(expected_result)
@@ -985,7 +947,7 @@ def test_handle_unhealthy_dynamic_nodes(
         (
             [
                 SlurmNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD", "queue1"),
-                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "IDLE+CLOUD+POWERING_DOWN", "queue1"),
+                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "POWERING_DOWN", "queue1"),
                 SlurmNode("queue1-dy-c5xlarge-3", "ip-3", "hostname", "IDLE+CLOUD+POWER", "queue1"),
                 SlurmNode("queue1-dy-c5xlarge-4", "ip-4", "hostname", "IDLE+CLOUD+POWER_", "queue1"),
                 SlurmNode(
@@ -994,10 +956,7 @@ def test_handle_unhealthy_dynamic_nodes(
                 SlurmNode("queue1-st-c5xlarge-6", "ip-6", "hostname", "POWERING_DOWN", "queue1"),
             ],
             ["id-1", "id-2"],
-            [
-                SlurmNode("queue1-dy-c5xlarge-2", "ip-2", "hostname", "IDLE+CLOUD+POWERING_DOWN", "queue1"),
-                SlurmNode("queue1-dy-c5xlarge-3", "ip-3", "hostname", "IDLE+CLOUD+POWER", "queue1"),
-            ],
+            ["queue1-dy-c5xlarge-2", "queue1-dy-c5xlarge-3"],
         )
     ],
     ids=["basic"],
@@ -1007,17 +966,15 @@ def test_handle_powering_down_nodes(slurm_nodes, mock_backing_instances, expecte
     mock_sync_config = SimpleNamespace(terminate_max_batch_size=4)
     cluster_manager = ClusterManager(mock_sync_config)
     mock_instance_manager = mocker.patch.object(cluster_manager, "_instance_manager", auto_spec=True)
-    get_backing_instance_mock = mocker.patch(
+    mocker.patch(
         "slurm_plugin.clustermgtd.ClusterManager._get_backing_instance_ids",
         return_value=mock_backing_instances,
         auto_spec=True,
     )
     reset_nodes_mock = mocker.patch("slurm_plugin.clustermgtd.reset_nodes", auto_spec=True)
     cluster_manager._handle_powering_down_nodes(slurm_nodes, {"placeholder": "map"})
-    get_backing_instance_mock.assert_called_with(expected_powering_down_nodes, {"placeholder": "map"})
     mock_instance_manager.delete_instances.assert_called_with(["id-1", "id-2"], terminate_batch_size=4)
-    # We don't need to reset nodes manually because cloud_reg_addrs option is specified
-    reset_nodes_mock.assert_not_called()
+    reset_nodes_mock.assert_called_with(nodes=expected_powering_down_nodes)
 
 
 @pytest.mark.parametrize(
@@ -1467,10 +1424,6 @@ def test_manage_cluster(
                 SlurmNode("queue-dy-c5xlarge-2", "ip-2", "hostname", "DOWN+CLOUD", "queue"),
                 # This node is good and should not be touched by clustermgtd
                 SlurmNode("queue-dy-c5xlarge-3", "ip-3", "hostname", "IDLE+CLOUD", "queue"),
-                # This node is in power_saving state but still has running backing instance, it should be terminated
-                SlurmNode("queue-dy-c5xlarge-6", "ip-6", "hostname", "IDLE+CLOUD+POWER", "queue"),
-                # This node is in powering_down but still has no valid backing instance, no boto3 call
-                SlurmNode("queue-dy-c5xlarge-8", "ip-8", "hostname", "IDLE+CLOUD+POWERING_DOWN", "queue"),
             ],
             [
                 SlurmNode("queue-st-c5xlarge-4", "ip-4", "hostname", "IDLE+CLOUD", "queue"),
@@ -1505,12 +1458,6 @@ def test_manage_cluster(
                                     {
                                         "InstanceId": "i-4",
                                         "PrivateIpAddress": "ip-4",
-                                        "PrivateDnsName": "hostname",
-                                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                                    },
-                                    {
-                                        "InstanceId": "i-6",
-                                        "PrivateIpAddress": "ip-6",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
                                     },
@@ -1576,14 +1523,8 @@ def test_manage_cluster(
                     },
                     generate_error=False,
                 ),
-                # _maintain_nodes: _handle_powering_down_nodes
-                MockedBoto3Request(
-                    method="terminate_instances",
-                    response={},
-                    expected_params={"InstanceIds": ["i-6"]},
-                    generate_error=False,
-                ),
                 # _maintain_nodes/delete_instances: terminate dynamic down nodes
+                # dynamic down nodes are handled with suspend script, and its boto3 call should not be reflected here
                 MockedBoto3Request(
                     method="terminate_instances",
                     response={},
@@ -1591,6 +1532,7 @@ def test_manage_cluster(
                     generate_error=False,
                 ),
                 # _maintain_nodes/delete_instances: terminate static down nodes
+                # dynamic down nodes are handled with suspend script, and its boto3 call should not be reflected here
                 MockedBoto3Request(
                     method="terminate_instances",
                     response={},


### PR DESCRIPTION
* When specifying `cloud_reg_addrs`, compute node hostname is automatically updated when slurmd starts and compute node comes online. However, the updated hostname(i.e. ip-172-31-4-136) is not consistent with the hostname return by running `hostname` command on the machine, which should be the compute nodename(i.e. q1-dy-c5xlarge-1). This can cause DNS resolution issues when using custom DNS. Reverting commit to use `cloud_reg_addrs` in order to restore old behavior.

This reverts commit e68842a4d93a1a9524847bfc587eabc07ca53321.

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
