### PR TITLE
Implement computemgtd self-termination via shutdown instead of TerminateInstances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 - Drop support for SGE and Torque schedulers.
 - Use tags prefix `parallelcluster:`.
 - Run Slurm command `scontrol` with sudo because clustermgtd is run as cluster admin user (not root).
+- Implement `computemgtd` self-termination via `shutdown` command instead of calling TerminateInstances.
 
 2.x.x
 -----

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -283,6 +283,11 @@ class InstanceManager:
         try:
             ec2_client = boto3.client("ec2", region_name=self._region, config=self._boto3_config)
             result = ec2_client.run_instances(
+                # Configure instances to be terminated (as opposed to stopped) when they are
+                # shutdown via a command run on the instance. This enables compute nodes to
+                # self-terminate without requiring the inclusion of TerminateInstances permissions
+                # in their instance profiles.
+                InstanceInitiatedShutdownBehavior="terminate",
                 # If not all_or_nothing_batch scaling, set MinCount=1
                 # so run_instances call will succeed even if entire count cannot be satisfied
                 # Otherwise set MinCount=current_batch_size so run_instances will fail unless all are launched

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1611,6 +1611,7 @@ def test_manage_cluster(
                         ]
                     },
                     expected_params={
+                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 1,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue-c5.xlarge", "Version": "$Latest"},
@@ -1775,6 +1776,7 @@ def test_manage_cluster(
                     method="run_instances",
                     response={"some run_instances error"},
                     expected_params={
+                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue-c5.xlarge", "Version": "$Latest"},
                         "MaxCount": 1,
                         "MinCount": 1,

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -105,6 +105,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -124,6 +125,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -150,6 +152,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 2,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -206,6 +209,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -215,6 +219,7 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -242,6 +247,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 2,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -288,6 +294,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -330,6 +337,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -339,6 +347,7 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -349,6 +358,7 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 3,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -402,6 +412,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -411,6 +422,7 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -431,6 +443,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -440,6 +453,7 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -460,6 +474,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -511,6 +526,7 @@ class TestInstanceManager:
                         ]
                     },
                     expected_params={
+                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 3,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -569,6 +585,7 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 3,
                             "MaxCount": 3,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -578,6 +595,7 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
+                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 2,
                             "MaxCount": 2,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},

--- a/tests/slurm_plugin/test_computemgtd.py
+++ b/tests/slurm_plugin/test_computemgtd.py
@@ -10,13 +10,14 @@
 # limitations under the License.
 
 
+import logging
 import os
 
 import pytest
 import slurm_plugin
 from assertpy import assert_that
 from common.schedulers.slurm_commands import SlurmNode
-from slurm_plugin.computemgtd import ComputemgtdConfig, _is_self_node_down
+from slurm_plugin.computemgtd import ComputemgtdConfig, _is_self_node_down, _self_terminate
 
 
 @pytest.mark.parametrize(
@@ -99,3 +100,18 @@ def test_is_self_node_down(mock_node_info, expected_result, mocker):
         mocker.patch("slurm_plugin.computemgtd._get_nodes_info_with_retry", return_value=mock_node_info)
 
     assert_that(_is_self_node_down("queue1-st-c5xlarge-1")).is_equal_to(expected_result)
+
+
+def test_self_terminate(mocker, caplog):
+    """Verify self-termination is implemented via a shutdown command rather than calling TerminateInstances."""
+    fake_instance_id = "i-1"
+    run_command_patch = mocker.patch("slurm_plugin.computemgtd.run_command")
+    get_metadata_patch = mocker.patch("slurm_plugin.computemgtd.get_metadata", return_value=fake_instance_id)
+    sleep_patch = mocker.patch("slurm_plugin.computemgtd.time.sleep")
+    with caplog.at_level(logging.INFO):
+        _self_terminate()
+    assert_that(caplog.text).contains(f"Preparing to self terminate the instance {fake_instance_id} in 10 seconds!")
+    assert_that(caplog.text).contains(f"Self terminating instance {fake_instance_id} now!")
+    run_command_patch.assert_called_with("sudo shutdown")
+    get_metadata_patch.assert_called_with("instance-id")
+    sleep_patch.assert_called_with(10)

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -128,6 +128,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                         ]
                     },
                     expected_params={
+                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 3,
                         "MaxCount": 3,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -137,6 +138,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                     method="run_instances",
                     response={},
                     expected_params={
+                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 1,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -189,6 +191,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                         ]
                     },
                     expected_params={
+                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 3,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -198,6 +201,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                     method="run_instances",
                     response={},
                     expected_params={
+                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 1,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},


### PR DESCRIPTION
This enables compute nodes to self-terminate without requiring the inclusion of TerminateInstances permissions in their instance profiles.

These changes depend on [Cookbook PR #1009](https://github.com/aws/aws-parallelcluster-cookbook/pull/1009).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
