### PR TITLE
Fix code linters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,7 @@ ignore =
     D104, # Missing docstring in public package
     D107, # Missing docstring in __init__
     W503, # line break before binary operator => Conflicts with black style.
+    N818, # exception name should be named with an Error suffix
 exclude =
     .tox,
     .git,


### PR DESCRIPTION
Exception name should be named with an Error suffix

Signed-off-by: chenwany <chenwany@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
