### PR TITLE
Force nodes to down and power_save when stopping the cluster

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -235,7 +235,7 @@ def update_all_partitions(state, reset_node_addrs_hostname):
                 logging.info(f"Setting partition {part.name} state from {part.state} to {state}")
                 if reset_node_addrs_hostname:
                     logging.info(f"Resetting partition nodes {part.nodes}")
-                    reset_nodes(part.nodes, state="power_down", reason="stopping cluster")
+                    set_nodes_down_and_power_save(part.nodes, reason="stopping cluster")
                 partition_to_update.append(part.name)
         succeeded_partitions = update_partitions(partition_to_update, state)
         return succeeded_partitions == partition_to_update


### PR DESCRIPTION
If a cluster is stopped while a node is powering-up (alloc#-idle#),
node is kept in the powering-up state on cluster start.
This makes the node unavailable for the entire ResumeTimeout which is 60 minutes.
Slurm is ignoring the transition to power_down if we don't put the node to down first.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
