### PR TITLE
release-2.11: Add support for parameters override when calling EC2 RunInstances

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -42,7 +42,7 @@ from slurm_plugin.common import (
     InstanceManager,
     log_exception,
     print_with_count,
-    retrieve_instance_type_mapping,
+    read_json,
     time_is_up,
 )
 
@@ -124,6 +124,7 @@ class ClustermgtdConfig:
             os.path.dirname(__file__), "logging", "parallelcluster_clustermgtd_logging.conf"
         ),
         "instance_type_mapping": "/opt/slurm/etc/pcluster/instance_name_type_mappings.json",
+        "run_instances_overrides": "/opt/slurm/etc/pcluster/run_instances_overrides.json",  # TODO: in PC3 we might use /etc/parallelcluster/slurm_plugin/run_instances_overrides.json
         # Launch configs
         "launch_max_batch_size": 500,
         "update_node_address": True,
@@ -154,7 +155,11 @@ class ClustermgtdConfig:
 
     def __eq__(self, other):
         if type(other) is type(self):
-            return self._config == other._config and self.instance_name_type_mapping == other.instance_name_type_mapping
+            return (
+                self._config == other._config
+                and self.instance_name_type_mapping == other.instance_name_type_mapping
+                and self.run_instances_overrides == other.run_instances_overrides
+            )
         return False
 
     def __ne__(self, other):
@@ -170,7 +175,22 @@ class ClustermgtdConfig:
         instance_name_type_mapping_file = config.get(
             "clustermgtd", "instance_type_mapping", fallback=self.DEFAULTS.get("instance_type_mapping")
         )
-        self.instance_name_type_mapping = retrieve_instance_type_mapping(instance_name_type_mapping_file)
+        self.instance_name_type_mapping = read_json(instance_name_type_mapping_file)
+
+        # run_instances_overrides_file contains a json with the following format:
+        # {
+        #     "queue_name": {
+        #         "instance_type": {   # TODO: in PC3 this is the compute_resource_name
+        #             "RunInstancesCallParam": "Value"
+        #         },
+        #         ...
+        #     },
+        #     ...
+        # }
+        run_instances_overrides_file = config.get(
+            "clustermgtd", "run_instances_overrides", fallback=self.DEFAULTS.get("run_instances_overrides")
+        )
+        self.run_instances_overrides = read_json(run_instances_overrides_file, default={})
 
         # Configure boto3 to retry 1 times by default
         self._boto3_retry = config.getint("clustermgtd", "boto3_retry", fallback=self.DEFAULTS.get("max_retry"))
@@ -315,6 +335,7 @@ class ClusterManager:
             head_node_private_ip=config.head_node_private_ip,
             head_node_hostname=config.head_node_hostname,
             instance_name_type_mapping=config.instance_name_type_mapping,
+            run_instances_overrides=config.run_instances_overrides,
         )
 
     @staticmethod

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -24,7 +24,7 @@ from slurm_plugin.common import (
     InstanceManager,
     is_clustermgtd_heartbeat_valid,
     print_with_count,
-    retrieve_instance_type_mapping,
+    read_json,
 )
 
 log = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ class SlurmResumeConfig:
         "dns_domain": None,
         "use_private_hostname": False,
         "instance_type_mapping": "/opt/slurm/etc/pcluster/instance_name_type_mappings.json",
+        "run_instances_overrides": "/opt/slurm/etc/pcluster/run_instances_overrides.json",  # TODO: in PC3 we might use /etc/parallelcluster/slurm_plugin/run_instances_overrides.json
         "all_or_nothing_batch": False,
     }
 
@@ -85,7 +86,21 @@ class SlurmResumeConfig:
         instance_name_type_mapping_file = config.get(
             "slurm_resume", "instance_type_mapping", fallback=self.DEFAULTS.get("instance_type_mapping")
         )
-        self.instance_name_type_mapping = retrieve_instance_type_mapping(instance_name_type_mapping_file)
+        self.instance_name_type_mapping = read_json(instance_name_type_mapping_file)
+        # run_instances_overrides_file contains a json with the following format:
+        # {
+        #     "queue_name": {
+        #         "instance_type": {   # TODO: in PC3 this is the compute_resource_name
+        #             "RunInstancesCallParam": "Value"
+        #         },
+        #         ...
+        #     },
+        #     ...
+        # }
+        run_instances_overrides_file = config.get(
+            "slurm_resume", "run_instances_overrides", fallback=self.DEFAULTS.get("run_instances_overrides")
+        )
+        self.run_instances_overrides = read_json(run_instances_overrides_file, default={})
         self.clustermgtd_timeout = config.getint(
             "slurm_resume",
             "clustermgtd_timeout",
@@ -156,6 +171,7 @@ def _resume(arg_nodes, resume_config):
         head_node_private_ip=resume_config.head_node_private_ip,
         head_node_hostname=resume_config.head_node_hostname,
         instance_name_type_mapping=resume_config.instance_name_type_mapping,
+        run_instances_overrides=resume_config.run_instances_overrides,
     )
     instance_manager.add_instances_for_nodes(
         node_list=node_list,


### PR DESCRIPTION
To test this:

1. Install the new node version on the headnode:
```
sudo /opt/parallelcluster/pyenv/versions/node_virtualenv/bin/pip install --upgrade https://github.com/demartinofra/aws-parallelcluster-node/tarball/refs/heads/runinstances-overrides
```
2. Write config with overrides in `/opt/slurm/etc/pcluster/run_instances_overrides.json` and  add read all, e.g.:
```
{
    "ondemand": {
        "t2.large": {
            "ImageId": "ami-xxxx",
            # you can override any param included CapacityReservationSpecification
        }
    }
}
```
3. Reload clustermgtd:
```
/opt/parallelcluster/pyenv/versions/cookbook_virtualenv/bin/supervisorctl restart clustermgtd
```
4. Launch an instance and see from logs if overrides took effect


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
