### PR TITLE
3.0: Add support for parameters override when calling EC2 RunInstances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+3.x.x
+------
+**ENHANCEMENTS**
+- Add possibility to override EC2 RunInstances parameters for instances launched in a Slurm cluster.
+
 3.0.0
 ------
 

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -59,18 +59,22 @@ def print_with_count(resource_list):
     return f"(x{len(resource_list)}) {str(resource_list)}"
 
 
-def retrieve_instance_type_mapping(file_path):
-    """Retrieve instance type mapping file content."""
+def read_json(file_path, default=None):
+    """Read json file into a dict."""
     try:
         with open(file_path) as mapping_file:
             return json.load(mapping_file)
     except Exception as e:
-        logging.error(
-            "Unable to get instance_type mapping from '%s'. Failed with exception: %s",
-            file_path,
-            e,
-        )
-        raise
+        if default is None:
+            logging.error(
+                "Unable to read file from '%s'. Failed with exception: %s",
+                file_path,
+                e,
+            )
+            raise
+        else:
+            logging.info("Unable to read file '%s'. Using default: %s", file_path, default)
+            return default
 
 
 def get_clustermgtd_heartbeat(clustermgtd_heartbeat_file_path):

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -55,6 +55,7 @@ class InstanceManager:
         head_node_private_ip=None,
         head_node_hostname=None,
         instance_name_type_mapping=None,
+        run_instances_overrides=None,
     ):
         """Initialize InstanceLauncher with required attributes."""
         self._region = region
@@ -69,6 +70,7 @@ class InstanceManager:
         self._head_node_private_ip = head_node_private_ip
         self._head_node_hostname = head_node_hostname
         self._instance_name_type_mapping = instance_name_type_mapping or {}
+        self._run_instances_overrides = run_instances_overrides or {}
 
     def _clear_failed_nodes(self):
         """Clear and reset failed nodes list."""
@@ -86,8 +88,13 @@ class InstanceManager:
                 logger.info("Launching instances for slurm nodes %s", print_with_count(slurm_node_list))
                 for batch_nodes in grouper(slurm_node_list, launch_batch_size):
                     try:
+                        run_instances_overrides = self._run_instances_overrides.get(queue, {}).get(compute_resource, {})
                         launched_instances = self._launch_ec2_instances(
-                            queue, compute_resource, len(batch_nodes), all_or_nothing_batch=all_or_nothing_batch
+                            queue,
+                            compute_resource,
+                            len(batch_nodes),
+                            all_or_nothing_batch=all_or_nothing_batch,
+                            run_instances_overrides=run_instances_overrides,
                         )
                         if update_node_address:
                             assigned_nodes = self._update_slurm_node_addrs(list(batch_nodes), launched_instances)
@@ -226,29 +233,37 @@ class InstanceManager:
 
         return instances_to_launch
 
-    def _launch_ec2_instances(self, queue, compute_resource, current_batch_size, all_or_nothing_batch=False):
+    def _launch_ec2_instances(
+        self, queue, compute_resource, current_batch_size, all_or_nothing_batch=False, run_instances_overrides=None
+    ):
         """Launch a batch of ec2 instances."""
         try:
             ec2_client = boto3.client("ec2", region_name=self._region, config=self._boto3_config)
-            result = ec2_client.run_instances(
+            run_instances_params = {
                 # Configure instances to be terminated (as opposed to stopped) when they are
                 # shutdown via a command run on the instance. This enables compute nodes to
                 # self-terminate without requiring the inclusion of TerminateInstances permissions
                 # in their instance profiles.
-                InstanceInitiatedShutdownBehavior="terminate",
+                "InstanceInitiatedShutdownBehavior": "terminate",
                 # If not all_or_nothing_batch scaling, set MinCount=1
                 # so run_instances call will succeed even if entire count cannot be satisfied
                 # Otherwise set MinCount=current_batch_size so run_instances will fail unless all are launched
-                MinCount=1 if not all_or_nothing_batch else current_batch_size,
-                MaxCount=current_batch_size,
+                "MinCount": 1 if not all_or_nothing_batch else current_batch_size,
+                "MaxCount": current_batch_size,
                 # LaunchTemplate is different for every instance type in every queue
                 # LaunchTemplate name format: {cluster_name}-{queue_name}-{compute_resource_name}
                 # Sample LT name: hit-queue1-computeres1
-                LaunchTemplate={
+                "LaunchTemplate": {
                     "LaunchTemplateName": f"{self._cluster_name}-{queue}-{compute_resource}",
                     "Version": "$Latest",
                 },
-            )
+            }
+            run_instances_params.update(run_instances_overrides)
+            if run_instances_overrides:
+                logger.info(
+                    "Found RunInstances parameters override. Launching instances with: %s", run_instances_params
+                )
+            result = ec2_client.run_instances(**run_instances_params)
 
             return [
                 EC2Instance(

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -71,7 +71,7 @@ def boto3_stubber_path():
     ],
 )
 def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
-    mocker.patch("slurm_plugin.resume.retrieve_instance_type_mapping", return_value={"c5xlarge": "c5.xlarge"})
+    mocker.patch("slurm_plugin.resume.read_json", return_value={"c5xlarge": "c5.xlarge"})
     resume_config = SlurmResumeConfig(test_datadir / config_file)
     for key in expected_attributes:
         assert_that(resume_config.__dict__.get(key)).is_equal_to(expected_attributes.get(key))
@@ -257,6 +257,7 @@ def test_resume_launch(
         head_node_private_ip="some_ip",
         head_node_hostname="some_hostname",
         instance_name_type_mapping={"queue1": {"c5xlarge": "c5.xlarge"}, "queue2": {"c52xlarge": "c5.2xlarge"}},
+        run_instances_overrides={"dynamic": {"c5.xlarge": {"InstanceType": "t2.micro"}}},
         clustermgtd_heartbeat_file_path="some_path",
         clustermgtd_timeout=600,
         boto3_config=botocore.config.Config(),


### PR DESCRIPTION
Add support for parameters override when calling EC2 RunInstances and add unit tests.
