### PR TITLE
Upgrade to slurm21.08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 - Add possibility to override EC2 RunInstances parameters for instances launched in a Slurm cluster.
 
 **CHANGES**
-- Upgrade Slurm to version 21.08.3.
+- Update Slurm plugin to support version 21.08.
 
 3.0.2
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **ENHANCEMENTS**
 - Add possibility to override EC2 RunInstances parameters for instances launched in a Slurm cluster.
 
+**CHANGES**
+- Upgrade Slurm to version 21.08.3.
+
 3.0.2
 ------
 

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -196,7 +196,7 @@ def set_nodes_drain(nodes, reason):
 
 def set_nodes_power_down(nodes, reason=None):
     """Place slurm node into power_down state and reset nodeaddr/nodehostname."""
-    reset_nodes(nodes=nodes, state="power_down", reason=reason, raise_on_error=True)
+    reset_nodes(nodes=nodes, state="power_down_force", reason=reason, raise_on_error=True)
 
 
 def reset_nodes(nodes, state=None, reason=None, raise_on_error=False):
@@ -231,7 +231,8 @@ def set_nodes_down_and_power_save(node_list, reason):
 
     This is the standard failure recovery procedure to reset a CLOUD node.
     """
-    set_nodes_down(node_list, reason=reason)
+    # TODO: check if still required especially when partitions are INACTIVE (stop)
+    # set_nodes_down(node_list, reason=reason)
     set_nodes_power_down(node_list, reason=reason)
 
 

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -231,8 +231,6 @@ def set_nodes_down_and_power_save(node_list, reason):
 
     This is the standard failure recovery procedure to reset a CLOUD node.
     """
-    # TODO: check if still required especially when partitions are INACTIVE (stop)
-    # set_nodes_down(node_list, reason=reason)
     set_nodes_power_down(node_list, reason=reason)
 
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -27,8 +27,8 @@ from common.schedulers.slurm_commands import (
     get_partition_info,
     reset_nodes,
     set_nodes_down,
-    set_nodes_down_and_power_save,
     set_nodes_drain,
+    set_nodes_power_down,
     update_all_partitions,
     update_partitions,
 )
@@ -686,9 +686,7 @@ class ClusterManager:
                 instances_to_terminate, terminate_batch_size=self._config.terminate_max_batch_size
             )
         log.info("Setting unhealthy dynamic nodes to down and power_down.")
-        set_nodes_down_and_power_save(
-            [node.name for node in unhealthy_dynamic_nodes], reason="Scheduler health check failed"
-        )
+        set_nodes_power_down([node.name for node in unhealthy_dynamic_nodes], reason="Scheduler health check failed")
 
     @log_exception(log, "maintaining powering down nodes", raise_on_error=False)
     def _handle_powering_down_nodes(self, slurm_nodes):

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -320,7 +320,7 @@ class ClusterManager:
 
     def set_config(self, config):
         if self._config != config:
-            logging.info("Applying new clustermgtd config: %s", config)
+            log.info("Applying new clustermgtd config: %s", config)
             self._config = config
             self._compute_fleet_status_manager = self._initialize_compute_fleet_status_manager(config)
             self._instance_manager = self._initialize_instance_manager(config)

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -66,14 +66,14 @@ def read_json(file_path, default=None):
             return json.load(mapping_file)
     except Exception as e:
         if default is None:
-            logging.error(
+            logger.error(
                 "Unable to read file from '%s'. Failed with exception: %s",
                 file_path,
                 e,
             )
             raise
         else:
-            logging.info("Unable to read file '%s'. Using default: %s", file_path, default)
+            logger.info("Unable to read file '%s'. Using default: %s", file_path, default)
             return default
 
 

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -196,6 +196,10 @@ class SlurmNode(metaclass=ABCMeta):
         """Check if node resume timeout expires."""
         return self.state == self.SLURM_SCONTROL_RESUME_FAILED_STATE
 
+    def is_poweing_up_idle(self):
+        """Check if node is in IDEL# state."""
+        return self.SLURM_SCONTROL_IDLE_STATE in self.state and self.is_powering_up()
+
     @abstractmethod
     def is_state_healthy(self, terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=True):
         """Check if a slurm node's scheduler state is considered healthy."""
@@ -385,7 +389,9 @@ class DynamicNode(SlurmNode):
     def is_bootstrap_failure(self):
         """Check if a slurm node has boostrap failure."""
         # no backing instance + [working state]# in node state
-        if self.is_configuring_job() and not self.is_backing_instance_valid(log_warn_if_unhealthy=False):
+        if (self.is_configuring_job() or self.is_poweing_up_idle()) and not self.is_backing_instance_valid(
+            log_warn_if_unhealthy=False
+        ):
             logger.warning(
                 "Node bootstrap error: Node %s is in power up state without valid backing instance, node state: %s",
                 self,

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -325,13 +325,13 @@ def test_set_nodes_down(nodes, reason, reset_addrs, update_call_kwargs, mocker):
             "nodes-1,nodes[2-6]",
             None,
             False,
-            {"nodes": "nodes-1,nodes[2-6]", "state": "power_down", "reason": None, "raise_on_error": True},
+            {"nodes": "nodes-1,nodes[2-6]", "state": "power_down_force", "reason": None, "raise_on_error": True},
         ),
         (
             "nodes-1,nodes[2-6]",
             "debugging",
             True,
-            {"nodes": "nodes-1,nodes[2-6]", "state": "power_down", "reason": "debugging", "raise_on_error": True},
+            {"nodes": "nodes-1,nodes[2-6]", "state": "power_down_force", "reason": "debugging", "raise_on_error": True},
         ),
         (
             ["nodes-1", "nodes[2-4]", "nodes-5"],
@@ -339,7 +339,7 @@ def test_set_nodes_down(nodes, reason, reset_addrs, update_call_kwargs, mocker):
             True,
             {
                 "nodes": ["nodes-1", "nodes[2-4]", "nodes-5"],
-                "state": "power_down",
+                "state": "power_down_force",
                 "reason": "debugging",
                 "raise_on_error": True,
             },

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -604,9 +604,7 @@ def test_update_all_partitions(
     expected_results,
     mocker,
 ):
-    set_nodes_down_and_power_save_spy = mocker.patch(
-        "common.schedulers.slurm_commands.set_nodes_down_and_power_save", auto_spec=True
-    )
+    set_nodes_power_down_spy = mocker.patch("common.schedulers.slurm_commands.set_nodes_power_down", auto_spec=True)
     update_partitions_spy = mocker.patch(
         "common.schedulers.slurm_commands.update_partitions", return_value=mock_succeeded_partitions, auto_spec=True
     )
@@ -616,7 +614,7 @@ def test_update_all_partitions(
     assert_that(update_all_partitions(state, reset_node_addrs_hostname=reset_node_info)).is_equal_to(expected_results)
     get_part_spy.assert_called_with(get_all_nodes=True)
     if expected_reset_nodes_calls:
-        set_nodes_down_and_power_save_spy.assert_has_calls(expected_reset_nodes_calls)
+        set_nodes_power_down_spy.assert_has_calls(expected_reset_nodes_calls)
     else:
-        set_nodes_down_and_power_save_spy.assert_not_called()
+        set_nodes_power_down_spy.assert_not_called()
     update_partitions_spy.assert_called_with(partitions_to_update, state)

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -34,8 +34,13 @@ def test_slurm_node_is_nodeaddr_set(node, expected_output):
     "node, expected_output",
     [
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "somestate", "queue1"), False),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN", "queue1"), True),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN", "queue1"), True),
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DRAIN+POWERING_UP", "queue1"), True),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD+DRAIN+NOT_RESPONDING", "queue1"
+            ),
+            True,
+        ),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD", "queue1"), False),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD", "queue1"), False),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+DRAIN", "queue1"), True),
@@ -49,9 +54,20 @@ def test_slurm_node_has_job(node, expected_output):
     "node, expected_output",
     [
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "somestate", "queue1"), False),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN", "queue1"), False),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE*+CLOUD+DRAIN", "queue1"), True),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DRAIN+POWERING_UP", "queue1"),
+            False,
+        ),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD+DRAIN+NOT_RESPONDING", "queue1"
+            ),
+            False,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+DRAIN+NOT_RESPONDING", "queue1"),
+            True,
+        ),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN", "queue1"), True),
     ],
 )
@@ -63,11 +79,16 @@ def test_slurm_node_is_drained(node, expected_output):
     "node, expected_output",
     [
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "somestate", "queue1"), False),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DOWN", "queue1"), True),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DRAIN", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN*+CLOUD", "queue1"), True),
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DOWN+POWERING_UP", "queue1"), True),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD+DRAIN+NOT_RESPONDING", "queue1"
+            ),
+            False,
+        ),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+POWER", "queue1"), True),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE~+CLOUD+POWERING_DOWN", "queue1"), False),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERING_DOWN", "queue1"), False),
     ],
 )
 def test_slurm_node_is_down(node, expected_output):
@@ -78,10 +99,23 @@ def test_slurm_node_is_down(node, expected_output):
     "node, expected_output",
     [
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), True),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DRAIN", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED*+CLOUD+DOWN", "queue1"), False),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DRAIN+POWERING_UP", "queue1"),
+            False,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD+DOWN+NOT_RESPONDING", "queue1"
+            ),
+            False,
+        ),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERING_DOWN", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE#+CLOUD", "queue1"), True),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+            ),
+            True,
+        ),
     ],
 )
 def test_slurm_node_is_up(node, expected_output):
@@ -92,7 +126,12 @@ def test_slurm_node_is_up(node, expected_output):
     "node, expected_output",
     [
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), True),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+            ),
+            True,
+        ),
     ],
 )
 def test_slurm_node_is_powering_up(node, expected_output):
@@ -106,8 +145,16 @@ def test_slurm_node_is_powering_up(node, expected_output):
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), True),
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue1"), True),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE*+CLOUD+DRAIN", "queue1"), False),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+            ),
+            False,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+DRAIN+NOT_RESPONDING", "queue1"),
+            False,
+        ),
     ],
 )
 def test_slurm_node_is_online(node, expected_output):
@@ -117,8 +164,13 @@ def test_slurm_node_is_online(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), True),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE#+CLOUD", "queue1"), False),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+            ),
+            True,
+        ),
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERING_UP", "queue1"), False),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), False),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD", "queue1"), False),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue1"), False),
@@ -131,14 +183,19 @@ def test_slurm_node_is_configuring_job(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), False),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DOWN", "queue1"), False),
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDEL#+CLOUD", "queue1"), False),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+            ),
+            False,
+        ),
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DOWN+POWERING_UP", "queue1"), False),
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDEL+CLOUD+POWERING_UP", "queue1"), False),
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "ALLOCATED+CLOUD", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "COMPLETING+CLOUD", "queue1"), True),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWER", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED*+CLOUD", "queue1"), True),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWERED_DOWN", "queue1"), False),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING", "queue1"), True),
     ],
 )
 def test_slurm_node_is_running_job(node, expected_output):
@@ -148,7 +205,7 @@ def test_slurm_node_is_running_job(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWER", "queue1"), True),
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWERED_DOWN", "queue1"), True),
         (DynamicNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"), False),
     ],
 )
@@ -161,19 +218,21 @@ def test_slurm_node_is_power_with_job(node, expected_output):
     [
         (
             [
-                StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"),
+                StaticNode(
+                    "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+                ),
                 StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD", "queue1"),
             ],
             True,
         ),
         (
             [
-                DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWER", "queue1"),
-                StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD+DOWN", "queue1"),
+                DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWERED_DOWN", "queue1"),
+                StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DOWN+POWERING_UP", "queue1"),
             ],
             False,
         ),
-        ([DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED*+CLOUD", "queue1")], True),
+        ([DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING", "queue1")], True),
     ],
 )
 def test_partition_is_inactive(nodes, expected_output):
@@ -257,7 +316,7 @@ def test_slurm_node_is_state_healthy(
     "is_failing_health_check, is_node_bootstrap_failure",
     [
         (
-            StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN*+CLOUD", "queue1"),
+            StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"),
             None,
             True,
             False,
@@ -266,7 +325,7 @@ def test_slurm_node_is_state_healthy(
             True,
         ),
         (
-            StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN*+CLOUD", "queue1"),
+            StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"),
             EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             True,
             True,
@@ -275,7 +334,7 @@ def test_slurm_node_is_state_healthy(
             True,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "MIXED#+CLOUD", "queue1"),
+            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"),
             None,
             False,
             False,
@@ -284,7 +343,7 @@ def test_slurm_node_is_state_healthy(
             True,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN*+CLOUD+POWER", "queue1"),
+            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING", "queue1"),
             EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
             False,
             False,
@@ -293,7 +352,7 @@ def test_slurm_node_is_state_healthy(
             True,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN#+CLOUD", "queue1"),
+            DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN+CLOUD+POWERING_UP", "queue1"),
             None,
             False,
             False,
@@ -302,7 +361,9 @@ def test_slurm_node_is_state_healthy(
             False,
         ),
         (
-            StaticNode("queue1-st-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN*+CLOUD", "queue1"),
+            StaticNode(
+                "queue1-st-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"
+            ),
             None,
             False,
             False,
@@ -311,7 +372,7 @@ def test_slurm_node_is_state_healthy(
             False,
         ),
         (
-            StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN*+CLOUD", "queue1"),
+            StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"),
             EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
             False,
             False,
@@ -320,7 +381,9 @@ def test_slurm_node_is_state_healthy(
             False,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN+CLOUD+POWER", "queue1"),
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN+CLOUD+POWERED_DOWN", "queue1"
+            ),
             EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
             False,
             False,
@@ -356,7 +419,7 @@ def test_slurm_node_is_state_healthy(
             True,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "MIXED#+CLOUD", "queue1"),
+            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"),
             EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
             False,
             False,
@@ -365,7 +428,13 @@ def test_slurm_node_is_state_healthy(
             True,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN*+CLOUD+POWER", "queue1"),
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "queue1-dy-c5xlarge-1",
+                "hostname",
+                "DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING",
+                "queue1",
+            ),
             EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
             False,
             False,
@@ -492,12 +561,22 @@ def test_slurm_node_is_healthy(node, instance, expected_result):
 @pytest.mark.parametrize(
     "node, expected_result",
     [
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWER", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), True),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+            ),
+            False,
+        ),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWERED_DOWN", "queue1"), False),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERED_DOWN", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "POWERING_DOWN", "queue1"), True),
-        (DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "nodehostname", "MIXED*+CLOUD", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED*+CLOUD", "queue1"), False),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING", "queue1"
+            ),
+            False,
+        ),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING", "queue1"), False),
     ],
 )
 def test_slurm_node_is_powering_down_with_nodeaddr(node, expected_result):
@@ -538,16 +617,28 @@ def test_slurm_node_is_backing_instance_valid(node, instance, expected_result):
 @pytest.mark.parametrize(
     "node, expected_result",
     [
-        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED#+CLOUD", "queue1"), True),
         (
-            StaticNode("queue1-st-c5xlarge-1", "queue1-st-c5xlarge-1", "nodehostname", "MIXED+CLOUD+POWER", "queue1"),
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
+            ),
+            True,
+        ),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "queue1-st-c5xlarge-1", "nodehostname", "MIXED+CLOUD+POWERED_DOWN", "queue1"
+            ),
             False,
         ),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "nodehostname", "POWERING_DOWN", "queue1"), False),
         (DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "nodehostname", "DOWN+CLOUD", "queue1"), False),
-        (DynamicNode("queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "nodehostname", "MIXED*+CLOUD", "queue1"), True),
-        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED*+CLOUD", "queue1"), True),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING", "queue1"
+            ),
+            True,
+        ),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING", "queue1"), True),
     ],
 )
 def test_slurm_node_needs_reset_when_inactive(node, expected_result):

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -442,6 +442,15 @@ def test_slurm_node_is_state_healthy(
             False,
             False,
         ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"),
+            None,
+            False,
+            False,
+            "Node bootstrap error: Node queue1-dy-c5xlarge-1(ip-1) is in power up state without valid backing instance",
+            False,
+            True,
+        ),
     ],
     ids=[
         "static_self_terminate",
@@ -457,6 +466,7 @@ def test_slurm_node_is_state_healthy(
         "static_fail_health_check",
         "dynamic_fail_health_check",
         "dynamic_pcluster_stop",
+        "idle_powering_up",
     ],
 )
 def test_slurm_node_is_bootstrap_failure(

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -635,7 +635,7 @@ def test_handle_unhealthy_dynamic_nodes(
     cluster_manager = ClusterManager(mock_sync_config)
     mock_instance_manager = mocker.patch.object(cluster_manager, "_instance_manager", auto_spec=True)
 
-    power_save_mock = mocker.patch("slurm_plugin.clustermgtd.set_nodes_down_and_power_save", auto_spec=True)
+    power_save_mock = mocker.patch("slurm_plugin.clustermgtd.set_nodes_power_down", auto_spec=True)
     cluster_manager._handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes)
     mock_instance_manager.delete_instances.assert_called_with(instances_to_terminate, terminate_batch_size=4)
     power_save_mock.assert_called_with(expected_power_save_node_list, reason="Scheduler health check failed")

--- a/tests/slurm_plugin/test_computemgtd.py
+++ b/tests/slurm_plugin/test_computemgtd.py
@@ -73,7 +73,7 @@ def test_computemgtd_config(config_file, expected_attributes, test_datadir, mock
     "mock_node_info, expected_result",
     [
         (
-            [DynamicNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN*+CLOUD", "queue1")],
+            [DynamicNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "DOWN+CLOUD+NOT_RESPONDING", "queue1")],
             True,
         ),
         (
@@ -85,7 +85,7 @@ def test_computemgtd_config(config_file, expected_attributes, test_datadir, mock
             True,
         ),
         (
-            [DynamicNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "IDLE+CLOUD+POWER", "queue1")],
+            [DynamicNode("queue1-st-c5xlarge-1", "ip-1", "host-1", "IDLE+CLOUD+POWERED_DOWN", "queue1")],
             True,
         ),
         (


### PR DESCRIPTION
* when `set_nodes_down_and_power_save`, update node state to `power_down_force` instead of setting nodes to DOWN and then POWER_DOWN
    * `set_nodes_down_and_power_sav`e is used when terminate unhealthy nodes and reset nodes in `INACTIVE` partition. 
    * `POWER_DOWN_FORCE` cancels all jobs on the node and suspends the node immediately, placing the node in `IDLE` and `POWER_DOWN (!)` state and then `POWERING_DOWN (%)` state. 
    * Previously, we set Node to `DOWN` then `POWER_DOWN`, node will be `DOWN` state, then in `IDLE` and `POWER_DOWN (!)` state, and then `POWERING_DOWN (%)` state. These two steps are equivalent to `POWER_DOWN_FORCE`


* When Slurm Resume Failed, the state is `DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING`
    * Previously in slurm 20, the state is `DOWN*+CLOUD+POWER`
* State reported by scontrol does not contain anymore symbols
    * `*` in slurm20 becomes `Not_RESPONDING` in slurm21
    * `#` in slurm20 becomes `POWERING_UP` in slurm21
    * sinfo: `down*` scontrol slurm20: `DOWN*+CLOUD` →scontrol slurm21: `DOWN+CLOUD+NOT_RESPONDING` 
    * sinfo: `mix#` scontrol slurm20: `MIXED#+CLOUD` →scontrol slurm21: `MIXED+CLOUD+NOT_RESPONDING+POWERING_UP`
    * sinfo: `mix~` scontrol slurm20: `MIXED+CLOUD+POWER` →scontrol slurm21: `MIXED+CLOUD+POWERED_DOWN`
    * sinfo: `idle~` scontrol slurm20: `IDLE+CLOUD+POWER`  scontrol slurm21: `IDLE+CLOUD+POWERED_DOWN`
    * sinfo: `idle` scontrol slurm20: `IDLE+CLOUD`  scontrol slurm21: `IDLE+CLOUD`
    * sinfo:`idle%` scontrol same in slurm20 and 21: `IDLE+CLOUD+POWERING_DOWN`
* Consider Nodes with `IDLE+CLOUD+NOT_RESPONDING+POWERING_UP` node without backing instance as bootstrap failure nodes