### PR TITLE
[develop] Remove set of InstanceInitiatedShutdownBehavior from RunInstance call

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -240,11 +240,6 @@ class InstanceManager:
         try:
             ec2_client = boto3.client("ec2", region_name=self._region, config=self._boto3_config)
             run_instances_params = {
-                # Configure instances to be terminated (as opposed to stopped) when they are
-                # shutdown via a command run on the instance. This enables compute nodes to
-                # self-terminate without requiring the inclusion of TerminateInstances permissions
-                # in their instance profiles.
-                "InstanceInitiatedShutdownBehavior": "terminate",
                 # If not all_or_nothing_batch scaling, set MinCount=1
                 # so run_instances call will succeed even if entire count cannot be satisfied
                 # Otherwise set MinCount=current_batch_size so run_instances will fail unless all are launched

--- a/tests/slurm_plugin/slurm_resources/test_instance_manager.py
+++ b/tests/slurm_plugin/slurm_resources/test_instance_manager.py
@@ -114,7 +114,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -134,7 +133,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -161,7 +159,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 2,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -218,7 +215,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -228,7 +224,6 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -256,7 +251,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 2,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -303,7 +297,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -346,7 +339,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -356,7 +348,6 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -367,7 +358,6 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 3,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -421,7 +411,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.xlarge", "Version": "$Latest"},
@@ -431,7 +420,6 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
@@ -452,7 +440,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -462,7 +449,6 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -483,7 +469,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -535,7 +520,6 @@ class TestInstanceManager:
                         ]
                     },
                     expected_params={
-                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 3,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -594,7 +578,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 3,
                             "MaxCount": 3,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -604,7 +587,6 @@ class TestInstanceManager:
                         method="run_instances",
                         response={},
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 2,
                             "MaxCount": 2,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -658,7 +640,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue3-c5.xlarge", "Version": "$Latest"},
@@ -681,7 +662,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue3-c5.2xlarge", "Version": "$Latest"},
@@ -701,7 +681,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 1,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue3-p4d.24xlarge", "Version": "$Latest"},
@@ -731,7 +710,6 @@ class TestInstanceManager:
                             ]
                         },
                         expected_params={
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "MinCount": 1,
                             "MaxCount": 2,
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
@@ -850,7 +828,6 @@ class TestInstanceManager:
                         expected_params={
                             "MinCount": 1,
                             "MaxCount": 5,
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "LaunchTemplate": {
                                 "LaunchTemplateName": "hit-queue-p4d.24xlarge",
                                 "Version": "$Latest",
@@ -881,7 +858,6 @@ class TestInstanceManager:
                         expected_params={
                             "MinCount": 5,
                             "MaxCount": 5,
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "LaunchTemplate": {
                                 "LaunchTemplateName": "hit-queue-c5.xlarge",
                                 "Version": "$Latest",
@@ -916,7 +892,6 @@ class TestInstanceManager:
                         expected_params={
                             "MinCount": 1,
                             "MaxCount": 5,
-                            "InstanceInitiatedShutdownBehavior": "terminate",
                             "LaunchTemplate": {
                                 "LaunchTemplateName": "hit-queue-p4d.24xlarge",
                                 "Version": "$Latest",

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1279,7 +1279,6 @@ def test_manage_cluster(
                         ]
                     },
                     expected_params={
-                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 1,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue-c5xlarge", "Version": "$Latest"},
@@ -1444,7 +1443,6 @@ def test_manage_cluster(
                     method="run_instances",
                     response={"some run_instances error"},
                     expected_params={
-                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue-c5xlarge", "Version": "$Latest"},
                         "MaxCount": 1,
                         "MinCount": 1,

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -128,7 +128,6 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                         ]
                     },
                     expected_params={
-                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 3,
                         "MaxCount": 3,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5xlarge", "Version": "$Latest"},
@@ -138,7 +137,6 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                     method="run_instances",
                     response={},
                     expected_params={
-                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 1,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5xlarge", "Version": "$Latest"},
@@ -191,7 +189,6 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                         ]
                     },
                     expected_params={
-                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 3,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5xlarge", "Version": "$Latest"},
@@ -201,7 +198,6 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                     method="run_instances",
                     response={},
                     expected_params={
-                        "InstanceInitiatedShutdownBehavior": "terminate",
                         "MinCount": 1,
                         "MaxCount": 1,
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5xlarge", "Version": "$Latest"},


### PR DESCRIPTION
This setting has been moved into Launch Template, see https://github.com/aws/aws-parallelcluster/pull/3446

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
