### PR TITLE
Allow override of config file and Slurm binaries location

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import logging
+import os
 import re
 
 from common.utils import check_command_output, grouper, run_command
@@ -50,8 +51,9 @@ _SQUEUE_FIELDS = [
     "cpus-per-tres",
 ]
 SQUEUE_FIELD_STRING = ",".join([field + ":{size}" for field in _SQUEUE_FIELDS]).format(size=SQUEUE_FIELD_SIZE)
-SCONTROL = "sudo /opt/slurm/bin/scontrol"
-SINFO = "/opt/slurm/bin/sinfo"
+SLURM_BINARIES_DIR = os.environ.get("SLURM_BINARIES_DIR", "/opt/slurm/bin")
+SCONTROL = f"sudo {SLURM_BINARIES_DIR}/scontrol"
+SINFO = f"{SLURM_BINARIES_DIR}/sinfo"
 
 # Set default timeouts for running different slurm commands.
 # These timeouts might be needed when running on large scale

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1005,22 +1005,21 @@ class ClusterManager:
         return False
 
 
-def _run_clustermgtd():
+def _run_clustermgtd(config_file):
     """Run clustermgtd actions."""
-    clustermgtd_config_file = os.path.join(CONFIG_FILE_DIR, "parallelcluster_clustermgtd.conf")
-    config = ClustermgtdConfig(clustermgtd_config_file)
+    config = ClustermgtdConfig(config_file)
     cluster_manager = ClusterManager(config=config)
     while True:
         # Get loop start time
         start_time = datetime.now(tz=timezone.utc)
         # Get program config
         try:
-            config = ClustermgtdConfig(clustermgtd_config_file)
+            config = ClustermgtdConfig(config_file)
             cluster_manager.set_config(config)
         except Exception as e:
             log.warning(
                 "Unable to reload daemon config from %s, using previous one.\nException: %s",
-                clustermgtd_config_file,
+                config_file,
                 e,
             )
         # Configure root logger
@@ -1042,7 +1041,10 @@ def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
     log.info("ClusterManager Startup")
     try:
-        _run_clustermgtd()
+        clustermgtd_config_file = os.environ.get(
+            "CONFIG_FILE", os.path.join(CONFIG_FILE_DIR, "parallelcluster_clustermgtd.conf")
+        )
+        _run_clustermgtd(clustermgtd_config_file)
     except Exception as e:
         log.exception("An unexpected error occurred: %s", e)
         raise

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -197,7 +197,8 @@ def main():
     parser.add_argument("nodes", help="Nodes to burst")
     args = parser.parse_args()
     try:
-        resume_config = SlurmResumeConfig(os.path.join(CONFIG_FILE_DIR, "parallelcluster_slurm_resume.conf"))
+        config_file = os.environ.get("CONFIG_FILE", os.path.join(CONFIG_FILE_DIR, "parallelcluster_slurm_resume.conf"))
+        resume_config = SlurmResumeConfig(config_file)
         try:
             # Configure root logger
             fileConfig(resume_config.logging_config, disable_existing_loggers=False)

--- a/src/slurm_plugin/suspend.py
+++ b/src/slurm_plugin/suspend.py
@@ -60,7 +60,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("nodes", help="Nodes to release")
     args = parser.parse_args()
-    suspend_config = SlurmSuspendConfig(os.path.join(CONFIG_FILE_DIR, "parallelcluster_slurm_suspend.conf"))
+    config_file = os.environ.get("CONFIG_FILE", os.path.join(CONFIG_FILE_DIR, "parallelcluster_slurm_suspend.conf"))
+    suspend_config = SlurmSuspendConfig(config_file)
     try:
         # Configure root logger
         fileConfig(suspend_config.logging_config, disable_existing_loggers=False)

--- a/util/upload-node.sh
+++ b/util/upload-node.sh
@@ -109,7 +109,7 @@ main() {
     echo "Done. Add the following configuration to the pcluster create config file:"
     echo ""
     echo "DevSettings:"
-    echo "  NodePackage: s3://${_bucket}/${_key_path}/node/aws-parallelcluster-node-${_version}.tgz"
+    echo "  NodePackage: s3://${_bucket}/${_key_path}/aws-parallelcluster-node-${_version}.tgz"
 }
 
 main "$@"


### PR DESCRIPTION
Allow overriding the Slurm binaries dir by setting the SLURM_BINARIES_DIR environment variable and daemon/scripts config file by setting CONFIG_FILE.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
