### PR TITLE
Resume POWERING_DOWN nodes after enabling partitions 

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -26,6 +26,7 @@ from common.schedulers.slurm_commands import (
     get_nodes_info,
     get_partition_info,
     reset_nodes,
+    resume_powering_down_nodes,
     set_nodes_down,
     set_nodes_drain,
     set_nodes_power_down,
@@ -394,6 +395,7 @@ class ClusterManager:
                 partitions_activated_successfully = update_all_partitions(
                     PartitionStatus.UP, reset_node_addrs_hostname=False
                 )
+                resume_powering_down_nodes()
                 if partitions_activated_successfully:
                     self._update_compute_fleet_status(ComputeFleetStatus.RUNNING)
                     # Reset protected failure

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1038,7 +1038,9 @@ def _run_clustermgtd(config_file):
 
 @retry(wait_fixed=seconds(LOOP_TIME))
 def main():
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s"
+    )
     log.info("ClusterManager Startup")
     try:
         clustermgtd_config_file = os.environ.get(

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -217,7 +217,9 @@ def _run_computemgtd(config_file):
 
 @retry(wait_fixed=seconds(LOOP_TIME))
 def main():
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(module)s:%(funcName)s] %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s"
+    )
     log.info("Computemgtd Startup")
     try:
         clustermgtd_config_file = os.environ.get("CONFIG_FILE", COMPUTEMGTD_CONFIG_PATH)

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1682,6 +1682,9 @@ def test_manage_compute_fleet_status_transitions(
     compute_fleet_status_manager_mock.get_status.return_value = fleet_initial_status
     instance_manager_mock = mocker.patch.object(cluster_manager, "_instance_manager", auto_spec=True)
     instance_manager_mock.terminate_all_compute_nodes.return_value = nodes_terminated_successfully
+    resume_powering_down_nodes_mock = mocker.patch(
+        "slurm_plugin.clustermgtd.resume_powering_down_nodes", auto_spec=True
+    )
 
     cluster_manager._manage_compute_fleet_status_transitions()
 
@@ -1689,6 +1692,7 @@ def test_manage_compute_fleet_status_transitions(
     if update_partition_status:
         if update_partition_status == PartitionStatus.UP:
             update_all_partitions_spy.assert_called_with(update_partition_status, reset_node_addrs_hostname=False)
+            resume_powering_down_nodes_mock.assert_called_once()
         else:
             update_all_partitions_spy.assert_called_with(update_partition_status, reset_node_addrs_hostname=True)
     else:


### PR DESCRIPTION
This makes CLOUD nodes available to be powered up immediately after partitions are enabled. 
Without this a node will stay in POWERING_DOWN for the SuspendTimeout (120secs). Also we noticed that in some cases Slurm is not even able to properly reset a node. This change should address such edge case too.

Note that in case you try to set nodes that are not in POWERING_DOWN to RESUME state Slurm will complain. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
