### PR TITLE
[byos] Add slurm fleet manager program

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ def read(fname):
 console_scripts = [
     "slurm_resume = slurm_plugin.resume:main",
     "slurm_suspend = slurm_plugin.suspend:main",
+    "slurm_fleet_status_manager = slurm_plugin.fleet_status_manager:main",
     "clustermgtd = slurm_plugin.clustermgtd:main",
     "computemgtd = slurm_plugin.computemgtd:main",
 ]

--- a/src/slurm_plugin/fleet_status_manager.py
+++ b/src/slurm_plugin/fleet_status_manager.py
@@ -1,0 +1,159 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import json
+import logging
+import os
+import sys
+from configparser import ConfigParser
+from logging.config import fileConfig
+
+from botocore.config import Config
+from common.schedulers.slurm_commands import resume_powering_down_nodes, update_all_partitions
+from slurm_plugin.clustermgtd import ComputeFleetStatus, ComputeFleetStatusManager
+from slurm_plugin.common import log_exception
+from slurm_plugin.instance_manager import InstanceManager
+from slurm_plugin.slurm_resources import CONFIG_FILE_DIR, PartitionStatus
+
+log = logging.getLogger(__name__)
+
+
+class SlurmFleetManagerConfig:
+    DEFAULTS = {
+        "max_retry": 5,
+        "terminate_max_batch_size": 1000,
+        "proxy": "NONE",
+        "logging_config": os.path.join(
+            os.path.dirname(__file__), "logging", "parallelcluster_fleet_status_manager_logging.conf"
+        ),
+    }
+
+    def __init__(self, config_file_path):
+        self._get_config(config_file_path)
+
+    def __repr__(self):
+        attrs = ", ".join(["{key}={value}".format(key=key, value=repr(value)) for key, value in self.__dict__.items()])
+        return "{class_name}({attrs})".format(class_name=self.__class__.__name__, attrs=attrs)
+
+    @log_exception(log, "reading fleet status manager configuration file", catch_exception=IOError, raise_on_error=True)
+    def _get_config(self, config_file_path):
+        """Get fleetmanager configuration."""
+        log.info("Reading %s", config_file_path)
+
+        config = ConfigParser()
+        try:
+            config.read_file(open(config_file_path, "r"))
+        except IOError:
+            log.error(f"Cannot read slurm fleet manager configuration file: {config_file_path}")
+            raise
+
+        self.region = config.get("slurm_fleet_status_manager", "region")
+        self.cluster_name = config.get("slurm_fleet_status_manager", "cluster_name")
+        self.terminate_max_batch_size = config.getint(
+            "slurm_fleet_status_manager", "terminate_max_batch_size", fallback=self.DEFAULTS.get("terminate_max_batch_size")
+        )
+        self._boto3_retry = config.getint("slurm_fleet_status_manager", "boto3_retry", fallback=self.DEFAULTS.get("max_retry"))
+        self._boto3_config = {"retries": {"max_attempts": self._boto3_retry, "mode": "standard"}}
+        proxy = config.get("slurm_fleet_status_manager", "proxy", fallback=self.DEFAULTS.get("proxy"))
+        if proxy != "NONE":
+            self._boto3_config["proxies"] = {"https": proxy}
+        self.boto3_config = Config(**self._boto3_config)
+
+        self.logging_config = config.get(
+            "slurm_fleet_status_manager", "logging_config", fallback=self.DEFAULTS.get("logging_config")
+        )
+
+        log.info(self.__repr__())
+
+
+def _manage_fleet_status_transition(config, computefleet_status_data_path):
+    computefleet_status = _get_computefleet_status(computefleet_status_data_path)
+
+    if ComputeFleetStatus.is_stop_requested(computefleet_status):
+        _stop_partitions(config)
+    elif ComputeFleetStatus.is_start_requested(computefleet_status):
+        _start_partitions()
+
+
+def _start_partitions():
+    log.info("Setting slurm partitions to UP and resuming nodes...")
+    update_all_partitions(PartitionStatus.UP, reset_node_addrs_hostname=False)
+    resume_powering_down_nodes()
+
+
+def _stop_partitions(config):
+    log.info("Setting slurm partitions to INACTIVE and terminating all compute nodes...")
+    update_all_partitions(PartitionStatus.INACTIVE, reset_node_addrs_hostname=True)
+    instance_manager = InstanceManager(
+        config.region,
+        config.cluster_name,
+        config.boto3_config,
+    )
+    instance_manager.terminate_all_compute_nodes(config.terminate_max_batch_size)
+
+
+def _get_computefleet_status(computefleet_status_data_path):
+    try:
+        with open(computefleet_status_data_path, "r", encoding="utf-8") as computefleet_status_data_file:
+            computefleet_status = ComputeFleetStatus(
+                json.load(computefleet_status_data_file).get(ComputeFleetStatusManager.COMPUTE_FLEET_STATUS_ATTRIBUTE)
+            )
+        log.info("ComputeFleet status is: %s", computefleet_status)
+    except Exception as e:
+        log.error("Cannot read compute fleet status data file: %s.\nException: %s", computefleet_status_data_path, e)
+        raise
+
+    return computefleet_status
+
+
+def main():
+    default_log_file = "/var/log/parallelcluster/slurm_fleet_status_manager.log"
+    logging.basicConfig(
+        filename=default_log_file,
+        level=logging.INFO,
+        format="%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s",
+    )
+    log.info("FleetManager startup.")
+    args = _parse_arguments()
+    try:
+        config_file = os.environ.get(
+            "CONFIG_FILE", os.path.join(CONFIG_FILE_DIR, "parallelcluster_slurm_fleet_status_manager.conf")
+        )
+        fleet_status_manager_config = SlurmFleetManagerConfig(config_file)
+        try:
+            # Configure root logger
+            fileConfig(fleet_status_manager_config.logging_config, disable_existing_loggers=False)
+        except Exception as e:
+            log.warning(
+                "Unable to configure logging from %s, using default settings and writing to %s.\nException: %s",
+                fleet_status_manager_config.logging_config,
+                default_log_file,
+                e,
+            )
+        log.info("FleetManager config: %s", fleet_status_manager_config)
+        _manage_fleet_status_transition(fleet_status_manager_config, args.computefleet_status_data)
+        log.info("FleetManager finished.")
+    except Exception as e:
+        log.exception("Encountered exception when running fleet manager: %s", e)
+        sys.exit(1)
+
+
+def _parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-cf", "--computefleet-status-data", help="Path to compute fleet status data", required=True)
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    main()

--- a/src/slurm_plugin/fleet_status_manager.py
+++ b/src/slurm_plugin/fleet_status_manager.py
@@ -60,9 +60,13 @@ class SlurmFleetManagerConfig:
         self.region = config.get("slurm_fleet_status_manager", "region")
         self.cluster_name = config.get("slurm_fleet_status_manager", "cluster_name")
         self.terminate_max_batch_size = config.getint(
-            "slurm_fleet_status_manager", "terminate_max_batch_size", fallback=self.DEFAULTS.get("terminate_max_batch_size")
+            "slurm_fleet_status_manager",
+            "terminate_max_batch_size",
+            fallback=self.DEFAULTS.get("terminate_max_batch_size"),
         )
-        self._boto3_retry = config.getint("slurm_fleet_status_manager", "boto3_retry", fallback=self.DEFAULTS.get("max_retry"))
+        self._boto3_retry = config.getint(
+            "slurm_fleet_status_manager", "boto3_retry", fallback=self.DEFAULTS.get("max_retry")
+        )
         self._boto3_config = {"retries": {"max_attempts": self._boto3_retry, "mode": "standard"}}
         proxy = config.get("slurm_fleet_status_manager", "proxy", fallback=self.DEFAULTS.get("proxy"))
         if proxy != "NONE":

--- a/src/slurm_plugin/logging/parallelcluster_fleet_status_manager_logging.conf
+++ b/src/slurm_plugin/logging/parallelcluster_fleet_status_manager_logging.conf
@@ -1,0 +1,21 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=fileHandler
+
+[formatters]
+keys=defaultFormatter
+
+[logger_root]
+level=INFO
+handlers=fileHandler
+
+[formatter_defaultFormatter]
+format=%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s
+
+[handler_fileHandler]
+class=FileHandler
+level=INFO
+formatter=defaultFormatter
+args=("/var/log/parallelcluster/slurm_fleet_status_manager.log",)

--- a/tests/slurm_plugin/test_fleet_status_manager.py
+++ b/tests/slurm_plugin/test_fleet_status_manager.py
@@ -1,0 +1,157 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from types import SimpleNamespace
+
+import botocore
+import pytest
+import slurm_plugin
+from assertpy import assert_that
+from slurm_plugin.clustermgtd import ComputeFleetStatus
+from slurm_plugin.fleet_status_manager import (
+    SlurmFleetManagerConfig,
+    _get_computefleet_status,
+    _manage_fleet_status_transition,
+    _start_partitions,
+    _stop_partitions,
+)
+from slurm_plugin.slurm_resources import PartitionStatus
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    # we need to set the region in the environment because the Boto3ClientFactory requires it.
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    return "slurm_plugin.instance_manager.boto3"
+
+
+@pytest.mark.parametrize(
+    ("config_file", "expected_attributes"),
+    [
+        (
+            "default.conf",
+            {
+                "cluster_name": "test",
+                "region": "us-east-2",
+                "terminate_max_batch_size": 1000,
+                "_boto3_config": {"retries": {"max_attempts": 5, "mode": "standard"}},
+                "logging_config": os.path.join(
+                    os.path.dirname(slurm_plugin.__file__),
+                    "logging",
+                    "parallelcluster_fleet_status_manager_logging.conf",
+                ),
+            },
+        ),
+        (
+            "all_options.conf",
+            {
+                "cluster_name": "test_again",
+                "region": "us-east-1",
+                "terminate_max_batch_size": 50,
+                "_boto3_config": {
+                    "retries": {"max_attempts": 10, "mode": "standard"},
+                    "proxies": {"https": "my.resume.proxy"},
+                },
+                "logging_config": "/path/to/fleet_status_manager_logging/config",
+            },
+        ),
+    ],
+)
+def test_fleet_status_manager_config(config_file, expected_attributes, test_datadir):
+    resume_config = SlurmFleetManagerConfig(test_datadir / config_file)
+    for key in expected_attributes:
+        assert_that(resume_config.__dict__.get(key)).is_equal_to(expected_attributes.get(key))
+
+
+@pytest.mark.parametrize(
+    ("computefleet_status_data_path", "status", "action"),
+    [
+        ("path_to_file_1", ComputeFleetStatus.STOPPED, None),
+        ("path_to_file_2", ComputeFleetStatus.RUNNING, None),
+        ("path_to_file_3", ComputeFleetStatus.STOPPING, None),
+        ("path_to_file_4", ComputeFleetStatus.STARTING, None),
+        ("path_to_file_5", ComputeFleetStatus.STOP_REQUESTED, "stop"),
+        ("path_to_file_6", ComputeFleetStatus.START_REQUESTED, "start"),
+        ("path_to_file_7", ComputeFleetStatus.PROTECTED, None),
+    ],
+)
+def test_fleet_status_manager(mocker, test_datadir, computefleet_status_data_path, status, action):
+    # mocks
+    config = SimpleNamespace(some_key_1="some_value_1", some_key_2="some_value_2")
+    get_computefleet_status_mocked = mocker.patch("slurm_plugin.fleet_status_manager._get_computefleet_status")
+    get_computefleet_status_mocked.return_value = status
+    stop_partitions_mocked = mocker.patch("slurm_plugin.fleet_status_manager._stop_partitions")
+    start_partitions_mocked = mocker.patch("slurm_plugin.fleet_status_manager._start_partitions")
+
+    # method to test
+    _manage_fleet_status_transition(config, computefleet_status_data_path)
+
+    # assertions
+    get_computefleet_status_mocked.assert_called_once_with(computefleet_status_data_path)
+    if action == "start":
+        start_partitions_mocked.assert_called_once()
+        stop_partitions_mocked.assert_not_called()
+    elif action == "stop":
+        stop_partitions_mocked.assert_called_once_with(config)
+        start_partitions_mocked.assert_not_called()
+    else:
+        start_partitions_mocked.assert_not_called()
+        stop_partitions_mocked.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("config_file", "expected_status"),
+    [
+        ("correct_status.json", ComputeFleetStatus.RUNNING),
+        ("no_status.json", Exception),
+        ("malformed_status.json", Exception),
+        ("wrong_status.json", Exception),
+        (None, Exception),
+    ],
+)
+def test_get_computefleet_status(test_datadir, config_file, expected_status):
+    if expected_status is Exception:
+        with pytest.raises(Exception):
+            _get_computefleet_status(test_datadir / config_file)
+    else:
+        status = _get_computefleet_status(test_datadir / config_file)
+        assert_that(status).is_equal_to(expected_status)
+
+
+def test_start_partitions(mocker):
+    update_all_partitions_mocked = mocker.patch("slurm_plugin.fleet_status_manager.update_all_partitions")
+    resume_powering_down_nodes_mocked = mocker.patch("slurm_plugin.fleet_status_manager.resume_powering_down_nodes")
+
+    _start_partitions()
+
+    update_all_partitions_mocked.assert_called_once_with(PartitionStatus.UP, reset_node_addrs_hostname=False)
+    resume_powering_down_nodes_mocked.assert_called_once()
+
+
+def test_stop_partitions(mocker):
+    # mocks
+    config = SimpleNamespace(
+        terminate_max_batch_size="3", region="us-east-1", cluster_name="test", boto3_config=botocore.config.Config()
+    )
+    update_all_partitions_mocked = mocker.patch("slurm_plugin.fleet_status_manager.update_all_partitions")
+
+    terminate_all_compute_nodes_mocked = mocker.patch.object(
+        slurm_plugin.instance_manager.InstanceManager, "terminate_all_compute_nodes", auto_spec=True
+    )
+
+    # method to test
+    _stop_partitions(config)
+
+    # assertions
+    update_all_partitions_mocked.assert_called_once_with(PartitionStatus.INACTIVE, reset_node_addrs_hostname=True)
+    terminate_all_compute_nodes_mocked.assert_called_once_with(config.terminate_max_batch_size)

--- a/tests/slurm_plugin/test_fleet_status_manager/test_fleet_status_manager_config/all_options.conf
+++ b/tests/slurm_plugin/test_fleet_status_manager/test_fleet_status_manager_config/all_options.conf
@@ -1,0 +1,7 @@
+[slurm_fleet_status_manager]
+cluster_name = test_again
+region = us-east-1
+proxy = my.resume.proxy
+boto3_retry = 10
+terminate_max_batch_size = 50
+logging_config = /path/to/fleet_status_manager_logging/config

--- a/tests/slurm_plugin/test_fleet_status_manager/test_fleet_status_manager_config/default.conf
+++ b/tests/slurm_plugin/test_fleet_status_manager/test_fleet_status_manager_config/default.conf
@@ -1,0 +1,4 @@
+[slurm_fleet_status_manager]
+cluster_name = test
+region = us-east-2
+proxy = NONE

--- a/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/correct_status.json
+++ b/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/correct_status.json
@@ -1,0 +1,4 @@
+{
+  "status": "RUNNING",
+  "lastStatusUpdatedTime": "2022-01-26T11:08:18.000Z"
+}

--- a/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/malformed_status
+++ b/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/malformed_status
@@ -1,0 +1,1 @@
+RUNNING

--- a/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/no_status.json
+++ b/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/no_status.json
@@ -1,0 +1,3 @@
+{
+  "lastStatusUpdatedTime": "2022-01-26T11:08:18.000Z"
+}

--- a/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/wrong_status.json
+++ b/tests/slurm_plugin/test_fleet_status_manager/test_get_computefleet_status/wrong_status.json
@@ -1,0 +1,4 @@
+{
+  "status": "NO_EXIST",
+  "lastStatusUpdatedTime": "2022-01-26T11:08:18.000Z"
+}


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Add new slurm fleet manager program

The fleet manager is in charge manage slurm partiton and backed EC2 instances based on fleet status request changes.

Fleet status request changes take as input a compute fleet status json file, containing the current fleet status.

Managed status are STOP_REQUESTED and START_REQUESTED

Remove the management of the compute fleet status changes, that are now managed by the new fleet status program.

### Tests
* Added tests for fleet manager and refactored the ones for clustermgtd

### References
* cookbook changes https://github.com/aws/aws-parallelcluster-cookbook/pull/1342
* CLI changes https://github.com/aws/aws-parallelcluster/pull/3708

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.