### PR TITLE
Set dynamic ICE nodes down with reason to Errorcode

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -676,7 +676,8 @@ class ClusterManager:
             node_list, self._config.launch_max_batch_size, self._config.update_node_address
         )
         # Add launched nodes to list of nodes being replaced, excluding any nodes that failed to launch
-        launched_nodes = set(node_list) - set(self._instance_manager.failed_nodes)
+        failed_nodes = set().union(*self._instance_manager.failed_nodes.values())
+        launched_nodes = set(node_list) - failed_nodes
         self._static_nodes_in_replacement |= launched_nodes
         log.info(
             "After node maintenance, following nodes are currently in replacement: %s",

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -84,42 +84,44 @@ def test_is_static_node(nodename, expected_is_static):
     [
         (
             (
-                "multiple-st-c5xlarge-1\n"
-                "172.31.10.155\n"
-                "172-31-10-155\n"
-                "MIXED+CLOUD\n"
-                "multiple\n"
-                "---\n"
-                "multiple-dy-c5xlarge-2\n"
-                "172.31.7.218\n"
-                "172-31-7-218\n"
-                "IDLE+CLOUD+POWER\n"
-                "multiple\n"
-                "---\n"
-                "multiple-dy-c5xlarge-3\n"
-                "multiple-dy-c5xlarge-3\n"
-                "multiple-dy-c5xlarge-3\n"
-                "IDLE+CLOUD+POWER\n"
-                "multiple\n"
-                "---\n"
-                "multiple-dy-c5xlarge-4\n"
-                "multiple-dy-c5xlarge-4\n"
-                "multiple-dy-c5xlarge-4\n"
-                "IDLE+CLOUD+POWER\n"
-                "multiple,multiple2\n"
-                "---\n"
-                "multiple-dy-c5xlarge-5\n"
-                "multiple-dy-c5xlarge-5\n"
-                "multiple-dy-c5xlarge-5\n"
-                "IDLE+CLOUD+POWER\n"
+                "NodeName=multiple-st-c5xlarge-1\n"
+                "NodeAddr=172.31.10.155\n"
+                "NodeHostName=172-31-10-155\n"
+                "State=MIXED+CLOUD\n"
+                "Partitions=multiple\n"
+                "######\n"
+                "NodeName=multiple-dy-c5xlarge-2\n"
+                "NodeAddr=172.31.7.218\n"
+                "NodeHostName=172-31-7-218\n"
+                "State=IDLE+CLOUD+POWER\n"
+                "Partitions=multiple\n"
+                "######\n"
+                "NodeName=multiple-dy-c5xlarge-3\n"
+                "NodeAddr=multiple-dy-c5xlarge-3\n"
+                "NodeHostName=multiple-dy-c5xlarge-3\n"
+                "State=IDLE+CLOUD+POWER\n"
+                "Partitions=multiple\n"
+                "Reason=some reason \n"
+                "######\n"
+                "NodeName=multiple-dy-c5xlarge-4\n"
+                "NodeAddr=multiple-dy-c5xlarge-4\n"
+                "NodeHostName=multiple-dy-c5xlarge-4\n"
+                "State=IDLE+CLOUD+POWER\n"
+                "Partitions=multiple,multiple2\n"
+                "Reason=(Code:InsufficientInstanceCapacity)Failure when resuming nodes \n"
+                "######\n"
+                "NodeName=multiple-dy-c5xlarge-5\n"
+                "NodeAddr=multiple-dy-c5xlarge-5\n"
+                "NodeHostName=multiple-dy-c5xlarge-5\n"
+                "State=IDLE+CLOUD+POWER\n"
                 # missing partitions
-                "---"
-                "test-no-partition\n"
-                "test-no-partition\n"
-                "test-no-partition\n"
-                "IDLE+CLOUD+POWER\n"
+                "######"
+                "NodeName=test-no-partition\n"
+                "NodeAddr=test-no-partition\n"
+                "NodeHostName=test-no-partition\n"
+                "State=IDLE+CLOUD+POWER\n"
                 # missing partitions
-                "---"
+                "######"
             ),
             [
                 StaticNode("multiple-st-c5xlarge-1", "172.31.10.155", "172-31-10-155", "MIXED+CLOUD", "multiple"),
@@ -130,6 +132,7 @@ def test_is_static_node(nodename, expected_is_static):
                     "multiple-dy-c5xlarge-3",
                     "IDLE+CLOUD+POWER",
                     "multiple",
+                    "some reason",
                 ),
                 DynamicNode(
                     "multiple-dy-c5xlarge-4",
@@ -137,6 +140,7 @@ def test_is_static_node(nodename, expected_is_static):
                     "multiple-dy-c5xlarge-4",
                     "IDLE+CLOUD+POWER",
                     "multiple,multiple2",
+                    "(Code:InsufficientInstanceCapacity)Failure when resuming nodes",
                 ),
                 DynamicNode(
                     "multiple-dy-c5xlarge-5",

--- a/tests/slurm_plugin/slurm_resources/test_instance_manager.py
+++ b/tests/slurm_plugin/slurm_resources/test_instance_manager.py
@@ -165,7 +165,7 @@ class TestInstanceManager:
                         },
                     ),
                 ],
-                None,
+                {},
                 [
                     call(
                         ["queue1-st-c5xlarge-2"],
@@ -229,6 +229,7 @@ class TestInstanceManager:
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
                         },
                         generate_error=True,
+                        error_code="some_error_code",
                     ),
                     MockedBoto3Request(
                         method="run_instances",
@@ -257,7 +258,7 @@ class TestInstanceManager:
                         },
                     ),
                 ],
-                ["queue1-st-c52xlarge-1"],
+                {"some_error_code": {"queue1-st-c52xlarge-1"}},
                 [
                     call(
                         ["queue1-st-c5xlarge-2"],
@@ -303,7 +304,7 @@ class TestInstanceManager:
                         },
                     ),
                 ],
-                None,
+                {},
                 None,
             ),
             # batch_size1
@@ -353,6 +354,7 @@ class TestInstanceManager:
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
                         },
                         generate_error=True,
+                        error_code="InsufficientHostCapacity",
                     ),
                     MockedBoto3Request(
                         method="run_instances",
@@ -363,14 +365,13 @@ class TestInstanceManager:
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
                         },
                         generate_error=True,
+                        error_code="ServiceUnavailable",
                     ),
                 ],
-                [
-                    "queue1-st-c52xlarge-1",
-                    "queue2-st-c5xlarge-1",
-                    "queue2-st-c5xlarge-2",
-                    "queue2-dy-c5xlarge-1",
-                ],
+                {
+                    "InsufficientHostCapacity": {"queue1-st-c52xlarge-1"},
+                    "ServiceUnavailable": {"queue2-st-c5xlarge-1", "queue2-dy-c5xlarge-1", "queue2-st-c5xlarge-2"},
+                },
                 [
                     call(
                         ["queue1-st-c5xlarge-2"],
@@ -425,6 +426,7 @@ class TestInstanceManager:
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue1-c5.2xlarge", "Version": "$Latest"},
                         },
                         generate_error=True,
+                        error_code="InsufficientVolumeCapacity",
                     ),
                     MockedBoto3Request(
                         method="run_instances",
@@ -454,6 +456,7 @@ class TestInstanceManager:
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
                         },
                         generate_error=True,
+                        error_code="InternalError",
                     ),
                     MockedBoto3Request(
                         method="run_instances",
@@ -475,7 +478,7 @@ class TestInstanceManager:
                         },
                     ),
                 ],
-                ["queue1-st-c52xlarge-1", "queue2-st-c5xlarge-2"],
+                {"InsufficientVolumeCapacity": {"queue1-st-c52xlarge-1"}, "InternalError": {"queue2-st-c5xlarge-2"}},
                 [
                     call(
                         ["queue1-st-c5xlarge-2"],
@@ -525,7 +528,7 @@ class TestInstanceManager:
                         "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
                     },
                 ),
-                ["queue2-st-c5xlarge-2", "queue2-dy-c5xlarge-1"],
+                {"LimitedInstanceCapacity": {"queue2-st-c5xlarge-2", "queue2-dy-c5xlarge-1"}},
                 [
                     call(
                         ["queue2-st-c5xlarge-1", "queue2-st-c5xlarge-2", "queue2-dy-c5xlarge-1"],
@@ -592,9 +595,10 @@ class TestInstanceManager:
                             "LaunchTemplate": {"LaunchTemplateName": "hit-queue2-c5.xlarge", "Version": "$Latest"},
                         },
                         generate_error=True,
+                        error_code="InsufficientInstanceCapacity",
                     ),
                 ],
-                ["queue2-dy-c5xlarge-2", "queue2-dy-c5xlarge-3"],
+                {"InsufficientInstanceCapacity": {"queue2-dy-c5xlarge-2", "queue2-dy-c5xlarge-3"}},
                 [
                     call(
                         ["queue2-st-c5xlarge-1", "queue2-st-c5xlarge-2", "queue2-dy-c5xlarge-1"],
@@ -716,7 +720,7 @@ class TestInstanceManager:
                         },
                     ),
                 ],
-                None,
+                {},
                 [
                     call(
                         ["queue3-st-c5xlarge-2"],
@@ -941,11 +945,18 @@ class TestInstanceManager:
                 ["queue1-st-c5xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 call(["queue1-st-c5xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=None),
-                [],
+                {},
                 False,
                 "dns.domain",
             ),
-            (["queue1-st-c5xlarge-1"], [], None, ["queue1-st-c5xlarge-1"], False, "dns.domain"),
+            (
+                ["queue1-st-c5xlarge-1"],
+                {},
+                None,
+                {"LimitedInstanceCapacity": {"queue1-st-c5xlarge-1"}},
+                False,
+                "dns.domain",
+            ),
             (
                 ["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2", "queue1-st-c5xlarge-3", "queue1-st-c5xlarge-4"],
                 [
@@ -953,7 +964,7 @@ class TestInstanceManager:
                     EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
                 ],
                 call(["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"], nodeaddrs=["ip-1", "ip-2"], nodehostnames=None),
-                ["queue1-st-c5xlarge-3", "queue1-st-c5xlarge-4"],
+                {"LimitedInstanceCapacity": {"queue1-st-c5xlarge-4", "queue1-st-c5xlarge-3"}},
                 False,
                 "dns.domain",
             ),
@@ -961,7 +972,7 @@ class TestInstanceManager:
                 ["queue1-st-c5xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 call(["queue1-st-c5xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=["hostname-1"]),
-                [],
+                {},
                 True,
                 "dns.domain",
             ),
@@ -969,7 +980,7 @@ class TestInstanceManager:
                 ["queue1-st-c5xlarge-1"],
                 [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
                 call(["queue1-st-c5xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=None),
-                [],
+                {},
                 False,
                 "",
             ),
@@ -1306,12 +1317,14 @@ class TestInstanceManager:
                         "u6tb1metal": ["queue2-st-u6tb1metal-1"],
                     },
                 },
-                [
-                    "in-valid/queue.name-st-c5xlarge-2",
-                    "noBrackets-st-c5xlarge-[1-2]",
-                    "queue2-invalidnodetype-c5xlarge-12",
-                    "queuename-with-dash-and_underscore-st-i3enmetal2tb-1",
-                ],
+                {
+                    "InvalidNodenameError": {
+                        "queue2-invalidnodetype-c5xlarge-12",
+                        "noBrackets-st-c5xlarge-[1-2]",
+                        "queuename-with-dash-and_underscore-st-i3enmetal2tb-1",
+                        "in-valid/queue.name-st-c5xlarge-2",
+                    }
+                },
             ),
         ],
     )

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -214,6 +214,74 @@ def test_slurm_node_is_power_with_job(node, expected_output):
 
 
 @pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "somestate", "queue1", "Failed to resume"),
+            False,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "MIXED+CLOUD+DRAIN+POWERING_UP",
+                "queue1",
+                "Some reason",
+            ),
+            False,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "ALLOCATED+CLOUD+DRAIN+NOT_RESPONDING",
+                "queue1",
+                "(Code:RequestLimitExceeded)Failure when resuming nodes",
+            ),
+            False,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "IDLE+CLOUD",
+                "queue1",
+                "(Code:InsufficientInstanceCapacity)Failure when resuming nodes",
+            ),
+            True,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD",
+                "queue1",
+                "(Code:InsufficientHostCapacity)Failure when resuming nodes",
+            ),
+            True,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "COMPLETING+DRAIN",
+                "queue1",
+                "(Code:InsufficientReservedInstanceCapacity)Failure when resuming nodes",
+            ),
+            True,
+        ),
+    ],
+)
+def test_slurm_node_is_ice(node, expected_output):
+    assert_that(node.is_ice()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
     "nodes, expected_output",
     [
         (

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -2115,11 +2115,11 @@ def test_handle_failed_health_check_nodes_in_replacement(
     expected_nodes_in_replacement,
     mocker,
 ):
-    for node, is_static_nodes_in_replacement, is_failing_health_check in zip(
+    for node, is_node_in_replacement, is_node_failing_health_check in zip(
         active_nodes, is_static_nodes_in_replacement, is_failing_health_check
     ):
-        node.is_static_nodes_in_replacement = is_static_nodes_in_replacement
-        node.is_failing_health_check = is_failing_health_check
+        node.is_static_nodes_in_replacement = is_node_in_replacement
+        node.is_failing_health_check = is_node_failing_health_check
 
     cluster_manager = ClusterManager(mocker.MagicMock())
     cluster_manager._static_nodes_in_replacement = current_nodes_in_replacement


### PR DESCRIPTION
### Description of changes
* When setting a dynamic node to down state, set the reason to Error code if the node fail with insufficient capacity.
* Insufficient capacity error code: {"InsufficientInstanceCapacity", "InsufficientHostCapacity", "InsufficientReservedInstanceCapacity"}

### Tests
#### 1. Manually test by launching instance type with ICE and all nodes failed with `all_or_nothing=False`
* slurm resume log:
```
2022-03-10 22:11:46,207 - [slurm_plugin.resume:_resume] - INFO - Launching EC2 instances for the following Slurm nodes: broken-dy-c-2-[1-5]
2022-03-10 22:11:46,271 - [slurm_plugin.instance_manager:add_instances_for_nodes] - INFO - Launching instances for slurm nodes (x5) ['broken-dy-c-2-1', 'broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']
2022-03-10 22:11:48,399 - [slurm_plugin.instance_manager:_launch_ec2_instances] - ERROR - Failed RunInstances request: dcd0c252-90d4-44a7-9c79-ef740f7ecd87
2022-03-10 22:11:48,399 - [slurm_plugin.instance_manager:add_instances_for_nodes] - ERROR - Encountered exception when launching instances for nodes (x5) ['broken-dy-c-2-1', 'broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']: An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation (reached max retries: 1): We currently do not have sufficient p4d.24xlarge capacity in the Availability Zone you requested (us-west-2b). Our system will be working on provisioning additional capacity. You can currently get p4d.24xlarge capacity by not specifying an Availability Zone in your request or choosing us-west-2a, us-west-2c.
2022-03-10 22:11:48,400 - [slurm_plugin.resume:_resume] - INFO - Successfully launched nodes (x0) []
2022-03-10 22:11:48,400 - [slurm_plugin.resume:_handle_ice_nodes] - ERROR - Failed to launch following nodes because of InsufficientInstanceCapacity, setting nodes to down: (x5) ['broken-dy-c-2-1', 'broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']
2022-03-10 22:11:48,401 - [slurm_plugin.resume:_handle_failed_nodes] - INFO - Setting following failed nodes into DOWN state: (x5) ['broken-dy-c-2-1', 'broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']
```
* scontrol show nodes, node reason is `(Code:InsufficientInstanceCapacity)Failure when resuming nodes`
```
[root@ip-10-0-0-219 parallelcluster]# scontrol show nodes broken-dy-c-2-1
NodeName=broken-dy-c-2-1 Arch=x86_64 CoresPerSocket=1 
   CPUAlloc=0 CPUTot=96 CPULoad=0.00
   AvailableFeatures=dynamic,p4d.24xlarge,c-2,gpu
   ActiveFeatures=dynamic,p4d.24xlarge,c-2,gpu
   Gres=gpu:a100:8
   NodeAddr=broken-dy-c-2-1 NodeHostName=broken-dy-c-2-1 Version=21.08.5
   OS=Linux 4.14.262-200.489.amzn2.x86_64 #1 SMP Fri Feb 4 20:34:30 UTC 2022 
   RealMemory=1 AllocMem=0 FreeMem=1146082 Sockets=96 Boards=1
   State=DOWN+CLOUD+NOT_RESPONDING+POWERING_UP ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A
   Partitions=broken 
   BootTime=2022-03-10T06:16:30 SlurmdStartTime=2022-03-10T06:18:54
   LastBusyTime=2022-03-10T22:17:50
   CfgTRES=cpu=96,mem=1M,billing=96
   AllocTRES=
   CapWatts=n/a
   CurrentWatts=0 AveWatts=0
   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s
   Reason=(Code:InsufficientInstanceCapacity)Failure when resuming nodes [root@2022-03-10T22:17:50]
```
#### 2. Manually tests with launching with partially successfully launched with `all_or_nothing=False`
* Slurm resume log
  * Only one node successfully launched, run instance successfully, no nodes are recongnized as ICE nodes in this iteration.
```
2022-03-11 00:47:46,000 - [slurm_plugin.resume:_resume] - INFO - Launching EC2 instances for the following Slurm nodes: broken-dy-c-2-[1-5]
2022-03-11 00:47:46,061 - [slurm_plugin.instance_manager:add_instances_for_nodes] - INFO - Launching instances for slurm nodes (x5) ['broken-dy-c-2-1', 'broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']
2022-03-11 00:47:48,369 - [slurm_plugin.instance_manager:_update_slurm_node_addrs] - INFO - Nodes are now configured with instances: (x1) ["('broken-dy-c-2-1', EC2Instance(id='i-00deb38486491973e', private_ip='10.0.21.19', hostname='ip-10-0-21-19', launch_time=datetime.datetime(2022, 3, 11, 0, 47, 47, tzinfo=tzlocal()), slurm_node=None))"]
2022-03-11 00:47:48,369 - [slurm_plugin.instance_manager:_update_slurm_node_addrs] - INFO - Failed to launch instances for following nodes: (x4) ['broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']
2022-03-11 00:47:48,369 - [slurm_plugin.instance_manager:_store_assigned_hostnames] - INFO - Saving assigned hostnames in DynamoDB
2022-03-11 00:47:48,396 - [slurm_plugin.instance_manager:_store_assigned_hostnames] - INFO - Database update: COMPLETED
2022-03-11 00:47:48,396 - [slurm_plugin.instance_manager:_update_dns_hostnames] - INFO - Updating DNS records for Z02792713P3KPDGU00IW1 - slurmresume1.pcluster.
2022-03-11 00:47:48,977 - [slurm_plugin.instance_manager:_update_dns_hostnames] - INFO - DNS records update: COMPLETED
2022-03-11 00:47:48,978 - [slurm_plugin.resume:_resume] - INFO - Successfully launched nodes (x1) ['broken-dy-c-2-1']
2022-03-11 00:47:48,978 - [slurm_plugin.resume:_resume] - ERROR - Failed to launch following nodes, setting nodes to down: (x4) ['broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']
2022-03-11 00:47:48,978 - [slurm_plugin.resume:_handle_failed_nodes] - INFO - Setting following failed nodes into DOWN state: (x4) ['broken-dy-c-2-2', 'broken-dy-c-2-3', 'broken-dy-c-2-4', 'broken-dy-c-2-5']
2022-03-11 00:47:48,998 - [slurm_plugin.resume:main] - INFO - ResumeProgram finished.

```
* In the next iteration, nodes failed to launched, nodes are treated as ICE nodes
```
022-03-11 00:50:46,016 - [slurm_plugin.common:is_clustermgtd_heartbeat_valid] - INFO - Latest heartbeat from clustermgtd: 2022-03-11 00:49:55.211975+00:00
2022-03-11 00:50:46,016 - [slurm_plugin.resume:_resume] - INFO - Launching EC2 instances for the following Slurm nodes: broken-dy-c-2-[6-9]
2022-03-11 00:50:46,077 - [slurm_plugin.instance_manager:add_instances_for_nodes] - INFO - Launching instances for slurm nodes (x4) ['broken-dy-c-2-6', 'broken-dy-c-2-7', 'broken-dy-c-2-8', 'broken-dy-c-2-9']
2022-03-11 00:50:49,313 - [slurm_plugin.instance_manager:_launch_ec2_instances] - ERROR - Failed RunInstances request: 476118d1-e1ed-4959-8600-52cd841a2de0
2022-03-11 00:50:49,313 - [slurm_plugin.instance_manager:add_instances_for_nodes] - ERROR - Encountered exception when launching instances for nodes (x4) ['broken-dy-c-2-6', 'broken-dy-c-2-7', 'broken-dy-c-2-8', 'broken-dy-c-2-9']: An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation (reached max retries: 1): We currently do not have sufficient p4d.24xlarge capacity in the Availability Zone you requested (us-west-2b). Our system will be working on provisioning additional capacity. You can currently get p4d.24xlarge capacity by not specifying an Availability Zone in your request or choosing us-west-2a, us-west-2c.
2022-03-11 00:50:49,314 - [slurm_plugin.resume:_resume] - INFO - Successfully launched nodes (x0) []
2022-03-11 00:50:49,314 - [slurm_plugin.resume:_handle_ice_nodes] - ERROR - Failed to launch following nodes because of InsufficientInstanceCapacity, setting nodes to down: (x4) ['broken-dy-c-2-6', 'broken-dy-c-2-7', 'broken-dy-c-2-8', 'broken-dy-c-2-9']
2022-03-11 00:50:49,314 - [slurm_plugin.resume:_handle_failed_nodes] - INFO - Setting following failed nodes into DOWN state: (x4) ['broken-dy-c-2-6', 'broken-dy-c-2-7', 'broken-dy-c-2-8', 'broken-dy-c-2-9']
```

### Current behavior
Current behavior is that nodes in down will be detected as unhealthy nodes and set to power_down by clustermgtd
```
2022-03-10 22:12:49,603 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Found the following unhealthy dynamic nodes: (x5) ['broken-dy-c-2-1(broken-dy-c-2-1)', 'broken-dy-c-2-2(broken-dy-c-2-2)', 'broken-dy-c-2-3(broken-dy-c-2-3)', 'broken-dy-c-2-4(broken-dy-c-2-4)', 'broken-dy-c-2-5(broken-dy-c-2-5)']
2022-03-10 22:12:49,603 - [slurm_plugin.clustermgtd:_handle_unhealthy_dynamic_nodes] - INFO - Setting unhealthy dynamic nodes to down and power_down.
```
Next is to modify clustermgtd logic



### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.