### PR TITLE
Implement fast insufficient capacity fail-over with slurm scheduler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.6 Tests
           - Python 3.7 Tests
           - Python 3.8 Tests
           - Python 3.9 Tests
           - Python 3.9 Tests Coverage
           - Code Checks
         include:
-          - name: Python 3.6 Tests
-            python: 3.6
-            toxenv: py36-nocov
           - name: Python 3.7 Tests
             python: 3.7
             toxenv: py37-nocov
@@ -51,7 +47,7 @@ jobs:
             toxdir: cli
             toxenv: py39-cov
           - name: Code Checks
-            python: 3.6
+            python: 3.7
             toxdir: cli
             toxenv: code-linters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+x.x.x
+------
+
+**ENHANCEMENTS**
+- Enable fast insufficient capacity fail-over with slurm scheduler.
+
 3.1.3
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ x.x.x
 ------
 
 **ENHANCEMENTS**
-- Enable fast insufficient capacity fail-over with slurm scheduler.
+- Temporarily disable compute resource when a node launch fails due to insufficient capacity.
+
+**CHANGES**
+- Drop support for python 3.6.
 
 3.1.3
 ------

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache License 2.0",
     packages=find_packages("src", exclude=["tests"]),
     package_dir={"": "src"},
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     install_requires=requires,
     entry_points=dict(console_scripts=console_scripts),
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}
+    py{37,38}
     code-linters
 
 # Default testenv. Used to run tests on all python versions.


### PR DESCRIPTION
### Description of changes
1. Include queue_name in `get_compute_resource_name` method to also consider the case that a node belongs to multiple partition. In different queue, the compute resources name can be the same. Include queue_name in `get_compute_resource_name` helps to keep track of insufficient capacity compute resources.
2. Implement disable insufficient capacity compute nodes logic:
* Collect the ComputeResource name and nodes mapping for all nodes in DOWN state whose reason belongs to one of the following: `InsufficientInstanceCapacity, InsufficientHostCapacity, InsufficientReservedInstanceCapacity, MaxSpotInstanceCountExceeded`.
* For each compute resource failing due to capacity problems check if clustermgtd marked it as disabled in a previous iteration. If so check if the timeout expired and in case restore the nodes to an enabled state and clean-up the reason field. If not, disable all POWERED_DOWN nodes belonging to that compute resource and store this information in clustermgtd.

### Tests
Test with create a cluster and submit job:
```
(cookbook_virtualenv) [root@ip-10-0-0-125 ~]# sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
queue1*      up   infinite     30  idle~ queue1-dy-c-1-[1-15],queue1-dy-c-2-[1-15]
queue2       up   infinite     30  idle~ queue2-dy-c-1-[1-15],queue2-dy-c-2-[1-15]
(cookbook_virtualenv) [root@ip-10-0-0-125 ~]# sbatch --wrap "sleep 30"
Submitted batch job 1
```
`queue1-dy-c-1` is a ice node. all nodes belongs to the compute resources are set to down
```
[ec2-user@ip-10-0-0-164 ~]$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
queue1*      up   infinite      1  down# queue1-dy-c-1-1
queue1*      up   infinite  15  idle~ queue1-dy-c-2-[1-15]
queue1*      up   infinite  14  down~ queue1-dy-c-1-[2-15]
queue2       up   infinite  30  idle~ queue2-dy-c-1-[1-15],queue2-dy-c-2-[1-15]
[ec2-user@ip-10-0-0-164 ~]$ scontrol show nodes queue1-dy-c-1-1
NodeName=queue1-dy-c-1-1 Arch=x86_64 CoresPerSocket=1 
   CPUAlloc=0 CPUTot=96 CPULoad=0.19
   AvailableFeatures=dynamic,p4d.24xlarge,c-1,gpu
   ActiveFeatures=dynamic,p4d.24xlarge,c-1,gpu
   Gres=gpu:a100:8
   NodeAddr=queue1-dy-c-1-1 NodeHostName=queue1-dy-c-1-1 Version=21.08.5
   OS=Linux 4.14.256-197.484.amzn2.x86_64 #1 SMP Tue Nov 30 00:17:50 UTC 2021 
   RealMemory=1 AllocMem=0 FreeMem=1146276 Sockets=96 Boards=1
   State=DOWN+CLOUD+NOT_RESPONDING+POWERING_UP ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A
   Partitions=queue1 
   BootTime=2022-03-31T00:21:00 SlurmdStartTime=2022-03-31T00:24:01
   LastBusyTime=2022-04-01T03:49:50
   CfgTRES=cpu=96,mem=1M,billing=96
   AllocTRES=
   CapWatts=n/a
   CurrentWatts=0 AveWatts=0
   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s
   Reason=(Code:InsufficientInstanceCapacity)Failure when resuming nodes [root@2022-04-01T03:49:50]

# show nodes result belongs to the compute resource
[ec2-user@ip-10-0-0-164 ~]$ scontrol show nodes queue1-dy-c-1-2
NodeName=queue1-dy-c-1-2 CoresPerSocket=1 
   CPUAlloc=0 CPUTot=96 CPULoad=N/A
   AvailableFeatures=dynamic,p4d.24xlarge,c-1,gpu
   ActiveFeatures=dynamic,p4d.24xlarge,c-1,gpu
   Gres=gpu:a100:8
   NodeAddr=queue1-dy-c-1-2 NodeHostName=queue1-dy-c-1-2 
   RealMemory=1 AllocMem=0 FreeMem=N/A Sockets=96 Boards=1
   State=DOWN+CLOUD+POWERED_DOWN ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A
   Partitions=queue1 
   BootTime=None SlurmdStartTime=None
   LastBusyTime=Unknown
   CfgTRES=cpu=96,mem=1M,billing=96
   AllocTRES=
   CapWatts=n/a
   CurrentWatts=0 AveWatts=0
   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s
   Reason=(Code:InsufficientInstanceCapacity)Temporarily disabling node due to insufficient capacity [root@2022-04-01T03:50:05]
```
After that, job is allocated to the second compute resource in the queue.
clustermgtd log:
```
2022-04-01 04:18:24,804 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Found the following unhealthy dynamic nodes: (x1) ['queue1-dy-c-1-1(queue1-dy-c-1-1)']
2022-04-01 04:18:24,804 - [slurm_plugin.clustermgtd:_reset_timeout_expire_compute_resources] - INFO - The following compute resources are in down state due to insufficient capacity: {'queue1-c-1': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 1, 4, 18, 19, 390696, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity')}, compute resources will be reset after insufficient capacity timeout (600 seconds) expire
2022-04-01 04:18:24,805 - [slurm_plugin.clustermgtd:_set_ice_compute_resources_to_down] - INFO - Setting following nodes into DOWN state due to insufficient capacity: (x14) ['queue1-dy-c-1-2', 'queue1-dy-c-1-3', 'queue1-dy-c-1-4', 'queue1-dy-c-1-5', 'queue1-dy-c-1-6', 'queue1-dy-c-1-7', 'queue1-dy-c-1-8', 'queue1-dy-c-1-9', 'queue1-dy-c-1-10', 'queue1-dy-c-1-11', 'queue1-dy-c-1-12', 'queue1-dy-c-1-13', 'queue1-dy-c-1-14', 'queue1-dy-c-1-15']
2022-04-01 04:18:24,838 - [slurm_plugin.clustermgtd:_terminate_orphaned_instances] - INFO - Checking for orphaned instance
```
...
After that, job is submitted to the second compute resources, which is also ice.
```
(cookbook_virtualenv) [root@ip-10-0-0-125 ~]# sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
queue1*      up   infinite      2  down# queue1-dy-c-1-1,queue1-dy-c-2-1
queue1*      up   infinite     28  down~ queue1-dy-c-1-[2-15],queue1-dy-c-2-[2-15]
queue2       up   infinite     30  idle~ queue2-dy-c-1-[1-15],queue2-dy-c-2-[1-15]
```
log:
```
2022-04-01 04:22:19,441 - [slurm_plugin.common:read_json] - INFO - Unable to read file '/opt/slurm/etc/pcluster/run_instances_overrides.json'. Using default: {}
2022-04-01 04:22:19,442 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Managing cluster...
2022-04-01 04:22:19,683 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Current compute fleet status: RUNNING
2022-04-01 04:22:19,683 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Retrieving nodes info from the scheduler
2022-04-01 04:22:24,760 - [slurm_plugin.clustermgtd:_get_ec2_instances] - INFO - Retrieving list of EC2 instances associated with the cluster
2022-04-01 04:22:24,821 - [slurm_plugin.clustermgtd:_perform_health_check_actions] - INFO - Performing instance health check actions
2022-04-01 04:22:24,822 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Performing node maintenance actions
2022-04-01 04:22:24,822 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Following nodes are currently in replacement: (x0) []
2022-04-01 04:22:24,822 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Found the following unhealthy dynamic nodes: (x30) ['queue1-dy-c-1-1(queue1-dy-c-1-1)', 'queue1-dy-c-1-2(queue1-dy-c-1-2)', 'queue1-dy-c-1-3(queue1-dy-c-1-3)', 'queue1-dy-c-1-4(queue1-dy-c-1-4)', 'queue1-dy-c-1-5(queue1-dy-c-1-5)', 'queue1-dy-c-1-6(queue1-dy-c-1-6)', 'queue1-dy-c-1-7(queue1-dy-c-1-7)', 'queue1-dy-c-1-8(queue1-dy-c-1-8)', 'queue1-dy-c-1-9(queue1-dy-c-1-9)', 'queue1-dy-c-1-10(queue1-dy-c-1-10)', 'queue1-dy-c-1-11(queue1-dy-c-1-11)', 'queue1-dy-c-1-12(queue1-dy-c-1-12)', 'queue1-dy-c-1-13(queue1-dy-c-1-13)', 'queue1-dy-c-1-14(queue1-dy-c-1-14)', 'queue1-dy-c-1-15(queue1-dy-c-1-15)', 'queue1-dy-c-2-1(queue1-dy-c-2-1)', 'queue1-dy-c-2-2(queue1-dy-c-2-2)', 'queue1-dy-c-2-3(queue1-dy-c-2-3)', 'queue1-dy-c-2-4(queue1-dy-c-2-4)', 'queue1-dy-c-2-5(queue1-dy-c-2-5)', 'queue1-dy-c-2-6(queue1-dy-c-2-6)', 'queue1-dy-c-2-7(queue1-dy-c-2-7)', 'queue1-dy-c-2-8(queue1-dy-c-2-8)', 'queue1-dy-c-2-9(queue1-dy-c-2-9)', 'queue1-dy-c-2-10(queue1-dy-c-2-10)', 'queue1-dy-c-2-11(queue1-dy-c-2-11)', 'queue1-dy-c-2-12(queue1-dy-c-2-12)', 'queue1-dy-c-2-13(queue1-dy-c-2-13)', 'queue1-dy-c-2-14(queue1-dy-c-2-14)', 'queue1-dy-c-2-15(queue1-dy-c-2-15)']
2022-04-01 04:22:24,823 - [slurm_plugin.clustermgtd:_reset_timeout_expire_compute_resources] - INFO - The following compute resources are in down state due to insufficient capacity: {'queue1-c-1': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 1, 4, 18, 19, 390696, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity'), 'queue1-c-2': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 1, 4, 20, 19, 418394, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity')}, compute resources will be reset after insufficient capacity timeout (600 seconds) expire
```
After 600 seconds, nodes are reset:
```
2022-04-01 04:28:25,117 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Found the following unhealthy dynamic nodes: (x30) ['queue1-dy-c-1-1(queue1-dy-c-1-1)', 'queue1-dy-c-1-2(queue1-dy-c-1-2)', 'queue1-dy-c-1-3(queue1-dy-c-1-3)', 'queue1-dy-c-1-4(queue1-dy-c-1-4)', 'queue1-dy-c-1-5(queue1-dy-c-1-5)', 'queue1-dy-c-1-6(queue1-dy-c-1-6)', 'queue1-dy-c-1-7(queue1-dy-c-1-7)', 'queue1-dy-c-1-8(queue1-dy-c-1-8)', 'queue1-dy-c-1-9(queue1-dy-c-1-9)', 'queue1-dy-c-1-10(queue1-dy-c-1-10)', 'queue1-dy-c-1-11(queue1-dy-c-1-11)', 'queue1-dy-c-1-12(queue1-dy-c-1-12)', 'queue1-dy-c-1-13(queue1-dy-c-1-13)', 'queue1-dy-c-1-14(queue1-dy-c-1-14)', 'queue1-dy-c-1-15(queue1-dy-c-1-15)', 'queue1-dy-c-2-1(queue1-dy-c-2-1)', 'queue1-dy-c-2-2(queue1-dy-c-2-2)', 'queue1-dy-c-2-3(queue1-dy-c-2-3)', 'queue1-dy-c-2-4(queue1-dy-c-2-4)', 'queue1-dy-c-2-5(queue1-dy-c-2-5)', 'queue1-dy-c-2-6(queue1-dy-c-2-6)', 'queue1-dy-c-2-7(queue1-dy-c-2-7)', 'queue1-dy-c-2-8(queue1-dy-c-2-8)', 'queue1-dy-c-2-9(queue1-dy-c-2-9)', 'queue1-dy-c-2-10(queue1-dy-c-2-10)', 'queue1-dy-c-2-11(queue1-dy-c-2-11)', 'queue1-dy-c-2-12(queue1-dy-c-2-12)', 'queue1-dy-c-2-13(queue1-dy-c-2-13)', 'queue1-dy-c-2-14(queue1-dy-c-2-14)', 'queue1-dy-c-2-15(queue1-dy-c-2-15)']
2022-04-01 04:28:25,118 - [slurm_plugin.clustermgtd:_reset_timeout_expire_compute_resources] - INFO - The following compute resources are in down state due to insufficient capacity: {'queue1-c-1': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 1, 4, 18, 19, 390696, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity'), 'queue1-c-2': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 1, 4, 20, 19, 418394, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity')}, compute resources will be reset after insufficient capacity timeout (600 seconds) expire
2022-04-01 04:28:25,118 - [root:_reset_insufficient_capacity_timeout_expire_nodes] - INFO - Reset the following compute resources because insufficient capacity timeout expire: {'queue1-c-1': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 1, 4, 18, 19, 390696, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity')}
2022-04-01 04:28:25,118 - [slurm_plugin.clustermgtd:_reset_insufficient_capacity_timeout_expire_nodes] - INFO - Enabling the following nodes because insufficient capacity timeout expired: (x15) ['queue1-dy-c-1-1(queue1-dy-c-1-1)', 'queue1-dy-c-1-2(queue1-dy-c-1-2)', 'queue1-dy-c-1-3(queue1-dy-c-1-3)', 'queue1-dy-c-1-4(queue1-dy-c-1-4)', 'queue1-dy-c-1-5(queue1-dy-c-1-5)', 'queue1-dy-c-1-6(queue1-dy-c-1-6)', 'queue1-dy-c-1-7(queue1-dy-c-1-7)', 'queue1-dy-c-1-8(queue1-dy-c-1-8)', 'queue1-dy-c-1-9(queue1-dy-c-1-9)', 'queue1-dy-c-1-10(queue1-dy-c-1-10)', 'queue1-dy-c-1-11(queue1-dy-c-1-11)', 'queue1-dy-c-1-12(queue1-dy-c-1-12)', 'queue1-dy-c-1-13(queue1-dy-c-1-13)', 'queue1-dy-c-1-14(queue1-dy-c-1-14)', 'queue1-dy-c-1-15(queue1-dy-c-1-15)']
```
Node reason is reset:
```
(cookbook_virtualenv) [root@ip-10-0-0-125 slurm_plugin]# scontrol show nodes queue1-dy-c-2-1
NodeName=queue1-dy-c-2-1 CoresPerSocket=1 
   CPUAlloc=0 CPUTot=96 CPULoad=N/A
   AvailableFeatures=dynamic,p4d.24xlarge,c-2,gpu
   ActiveFeatures=dynamic,p4d.24xlarge,c-2,gpu
   Gres=gpu:a100:8
   NodeAddr=queue1-dy-c-2-1 NodeHostName=queue1-dy-c-2-1 
   RealMemory=1 AllocMem=0 FreeMem=N/A Sockets=96 Boards=1
   State=IDLE+CLOUD+POWERED_DOWN ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A
   Partitions=queue1 
   BootTime=None SlurmdStartTime=None
   LastBusyTime=Unknown
   CfgTRES=cpu=96,mem=1M,billing=96
   AllocTRES=
   CapWatts=n/a
   CurrentWatts=0 AveWatts=0
   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s
   Reason=Enabling node since insufficient capacity timeout expired [root@2022-04-01T04:30:25]
```


### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.