### PR TITLE
3.x: Improve log message of smart capacity failover

### DIFF
--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -3315,7 +3315,7 @@ def test_set_ice_compute_resources_to_down(
     ],
 )
 @pytest.mark.usefixtures("initialize_instance_manager_mock")
-def test_find_unhealthy_slurm_nodesn(
+def test_find_unhealthy_slurm_nodes(
     active_nodes,
     expected_unhealthy_dynamic_nodes,
     expected_unhealthy_static_nodes,


### PR DESCRIPTION
Only log compute resources name instead of node names when detect or reset insuffcient capacity nodes. Don't treat insufficient capacity nodes as unhealthy nodes to not print each ice node message in the logs. The reason is that there may be lots of dynamic nodes in a compute resources. Log all the nodes belong to a compute resource will be a lot.

### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
sinfo
```
[ec2-user@ip-192-168-33-41 ~]$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
queue1*      up   infinite      3  down# queue1-dy-c-1-1,queue1-dy-c-2-1,queue1-dy-c-3-1
queue1*      up   infinite      1   mix~ queue1-dy-c-4-1
queue1*      up   infinite     31  idle~ queue1-dy-c-4-[2-16],queue1-dy-c-5-[1-16]
queue1*      up   infinite     44  down~ queue1-dy-c-1-[2-15],queue1-dy-c-2-[2-16],queue1-dy-c-3-[2-16]
queue2       up   infinite     64  idle~ queue2-dy-c-1-[1-16],queue2-dy-c-2-[1-16],queue2-dy-c-3-[1-16],queue2-dy-c-4-[1-16]
```
* logs when detecting insufficient capacity compute resources:
```
2022-04-14 23:06:04,970 - [slurm_plugin.clustermgtd:_get_config] - INFO - Reading /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf
2022-04-14 23:06:04,971 - [slurm_plugin.common:read_json] - INFO - Unable to read file '/opt/slurm/etc/pcluster/run_instances_overrides.json'. Using default: {}
2022-04-14 23:06:04,975 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Current compute fleet status: RUNNING
2022-04-14 23:06:04,975 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Retrieving nodes info from the scheduler
2022-04-14 23:06:10,059 - [slurm_plugin.clustermgtd:_get_ec2_instances] - INFO - Retrieving list of EC2 instances associated with the cluster
2022-04-14 23:06:10,190 - [slurm_plugin.clustermgtd:_perform_health_check_actions] - INFO - Performing instance health check actions
2022-04-14 23:06:10,190 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Performing node maintenance actions
2022-04-14 23:06:10,190 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Following nodes are currently in replacement: (x0) []
2022-04-14 23:06:10,191 - [slurm_plugin.clustermgtd:_reset_timeout_expired_compute_resources] - INFO - The following compute resources are in down state due to insufficient capacity: {'queue1': {'c-1': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 14, 23, 0, 4, 769380, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity'), 'c-2': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 14, 23, 4, 4, 944552, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity')}}, compute resources will be reset after insufficient capacity timeout (600 seconds) expired
```
Logs when insufficient capacity timeout expired:
```
2022-04-14 23:10:05,176 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Current compute fleet status: RUNNING
2022-04-14 23:10:05,176 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Retrieving nodes info from the scheduler
2022-04-14 23:10:10,268 - [slurm_plugin.clustermgtd:_get_ec2_instances] - INFO - Retrieving list of EC2 instances associated with the cluster
2022-04-14 23:10:10,343 - [slurm_plugin.clustermgtd:_perform_health_check_actions] - INFO - Performing instance health check actions
2022-04-14 23:10:10,344 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Performing node maintenance actions
2022-04-14 23:10:10,344 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Following nodes are currently in replacement: (x0) []
2022-04-14 23:10:10,345 - [slurm_plugin.clustermgtd:_reset_timeout_expired_compute_resources] - INFO - The following compute resources are in down state due to insufficient capacity: {'queue1': {'c-1': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 14, 23, 0, 4, 769380, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity'), 'c-2': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 14, 23, 4, 4, 944552, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity'), 'c-3': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 14, 23, 7, 5, 27379, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity'), 'c-4': ComputeResourceFailureEvent(timestamp=datetime.datetime(2022, 4, 14, 23, 10, 5, 173661, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity')}}, compute resources will be reset after insufficient capacity timeout (600 seconds) expired
2022-04-14 23:10:10,345 - [root:_reset_insufficient_capacity_timeout_expired_nodes] - INFO - Reset the following compute resources because insufficient capacity timeout expired: {'queue1': ['c-1']}
2022-04-14 23:10:10,413 - [slurm_plugin.clustermgtd:_terminate_orphaned_instances] - INFO - Checking for orphaned instance
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.