### PR TITLE
Set all powered down nodes within ice compute resource to down

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1045,7 +1045,7 @@ class ClusterManager:
             for compute_resource, event in compute_resources.items():
                 nodes = compute_resource_nodes_map.get(queue_name, {}).get(compute_resource, [])
                 for node in nodes:
-                    if not node.is_ice() and node.is_power() and not node.is_nodeaddr_set():
+                    if node.is_power() and not node.is_nodeaddr_set():
                         error_code = event.error_code
                         nodes_to_down.setdefault(error_code, []).append(node.name)
         if nodes_to_down:

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -3070,7 +3070,7 @@ def test_reset_timeout_expired_compute_resources(
                     "capacity",
                 ),
                 call(
-                    ["queue2-dy-c5large-2"],
+                    ["queue2-dy-c5large-1", "queue2-dy-c5large-2"],
                     reason="(Code:InsufficientHostCapacity)Temporarily disabling node due to insufficient capacity",
                 ),
             ],


### PR DESCRIPTION
### Description of changes
* Set all powered down nodes within ice compute resources to down. Previously, only set powered off nodes that doesn't have ice error code to down.
Remove the condition to consider the case when nodes are manually set to power down without resetting the reason.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.