### PR TITLE
Disable fast insufficient capacity failover by default

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -144,7 +144,7 @@ class ClustermgtdConfig:
         "dns_domain": None,
         "use_private_hostname": False,
         "protected_failure_count": 10,
-        "insufficient_capacity_timeout": 600,
+        "insufficient_capacity_timeout": 0,
     }
 
     def __init__(self, config_file_path):

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -77,7 +77,7 @@ class TestClustermgtdConfig:
                     "disable_all_health_checks": False,
                     "health_check_timeout": 180,
                     "protected_failure_count": 10,
-                    "insufficient_capacity_timeout": 600,
+                    "insufficient_capacity_timeout": 0,
                 },
             ),
             (


### PR DESCRIPTION
Set default insufficient_capacity_timeout=0 to disable fast insufficient capacity failover by default

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.