### PR TITLE
Handle special cases of IDLE~ and DOWN~ nodes

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -649,19 +649,8 @@ class ClusterManager:
             self._instance_manager.delete_instances(
                 instances_to_terminate, terminate_batch_size=self._config.terminate_max_batch_size
             )
-
-        nodes_to_power_down = (
-            [node for node in unhealthy_dynamic_nodes if not node.is_ice()]
-            if self._config.disable_nodes_on_insufficient_capacity
-            else unhealthy_dynamic_nodes
-        )
-
-        if nodes_to_power_down:
-            log.info(
-                "Setting the following unhealthy dynamic nodes to down and power_down: %s",
-                print_with_count(nodes_to_power_down),
-            )
-            set_nodes_power_down([node.name for node in nodes_to_power_down], reason="Scheduler health check failed")
+        log.info("Setting unhealthy dynamic nodes to down and power_down.")
+        set_nodes_power_down([node.name for node in unhealthy_dynamic_nodes], reason="Scheduler health check failed")
 
     @log_exception(log, "maintaining powering down nodes", raise_on_error=False)
     def _handle_powering_down_nodes(self, slurm_nodes):

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -89,6 +89,26 @@ def test_slurm_node_is_drained(node, expected_output):
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+POWER", "queue1"), True),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERING_DOWN", "queue1"), False),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD+POWER_DOWN+POWERED_DOWN",
+                "queue1",
+            ),
+            True,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD+POWERING_DOWN+POWERED_DOWN",
+                "queue1",
+            ),
+            False,
+        ),
     ],
 )
 def test_slurm_node_is_down(node, expected_output):
@@ -647,6 +667,12 @@ def test_slurm_node_is_healthy(node, instance, expected_result):
         ),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+POWERED_DOWN", "queue1"), False),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERED_DOWN", "queue1"), True),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWERED_DOWN+POWER_DOWN", "queue1"
+            ),
+            True,
+        ),
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "POWERING_DOWN", "queue1"), True),
         (
             DynamicNode(

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -691,56 +691,6 @@ def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes
             ["id-1"],
             [
                 "queue1-dy-c5xlarge-1",
-            ],
-            True,
-        ),
-        (
-            [
-                DynamicNode(
-                    "queue1-dy-c5xlarge-1",
-                    "ip-1",
-                    "hostname",
-                    "IDLE+CLOUD",
-                    "queue1",
-                    "(Code:Exception)Failure when resuming nodes",
-                ),
-                DynamicNode(
-                    "queue1-dy-c5xlarge-2",
-                    "ip-1",
-                    "hostname",
-                    "IDLE+CLOUD",
-                    "queue1",
-                    "(Code:InsufficientHostCapacity)Failure when resuming nodes",
-                ),
-                DynamicNode(
-                    "queue1-dy-c5xlarge-3",
-                    "ip-1",
-                    "hostname",
-                    "DOWN+CLOUD+NOT_RESPONDING+POWERING_UP",
-                    "queue1",
-                    "(Code:InsufficientInstanceCapacity)Failure when resuming nodes",
-                ),
-                DynamicNode(
-                    "queue1-dy-c5xlarge-4",
-                    "ip-1",
-                    "hostname",
-                    "DOWN+CLOUD+NOT_RESPONDING+POWERING_UP",
-                    "queue1",
-                    "(Code:InsufficientReservedInstanceCapacity)Failure when resuming nodes",
-                ),
-                DynamicNode(
-                    "queue1-dy-c5xlarge-5",
-                    "ip-1",
-                    "hostname",
-                    "DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING",
-                    "queue1",
-                    "(Code:MaxSpotInstanceCountExceeded)Failure when resuming nodes",
-                ),
-            ],
-            [EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"), None, None, None, None],
-            ["id-1"],
-            [
-                "queue1-dy-c5xlarge-1",
                 "queue1-dy-c5xlarge-2",
                 "queue1-dy-c5xlarge-3",
                 "queue1-dy-c5xlarge-4",
@@ -749,7 +699,7 @@ def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes
             False,
         ),
     ],
-    ids=["basic", "unhealthy ice nodes", "disable smart instance capacity"],
+    ids=["basic", "disable smart instance capacity"],
 )
 @pytest.mark.usefixtures("initialize_instance_manager_mock")
 def test_handle_unhealthy_dynamic_nodes(


### PR DESCRIPTION
Sometimes nodes reset by power_down_force are in (IDLE~) IDLE+CLOUD+POWER_DOWN+POWERED_DOWN state.

Treat IDLE+CLOUD+POWER_DOWN+POWERED_DOWN node as power node.
Treat DOWN~ (DOWN+CLOUD+POWER_DOWN+POWERED_DOWN+NOT_RESPONDING) nodes as unhealthy nodes

Also we don't need to check ice nodes in unhealthy nodes anymore after we separate ices nodes from unhealthy nodes

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Add unit test case

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.