### PR TITLE
3.1: Set unhealthy nodes static nodes to down with reset node address

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.6 Tests
           - Python 3.7 Tests
           - Python 3.8 Tests
           - Python 3.9 Tests
           - Python 3.9 Tests Coverage
           - Code Checks
         include:
-          - name: Python 3.6 Tests
-            python: 3.6
-            toxenv: py36-nocov
           - name: Python 3.7 Tests
             python: 3.7
             toxenv: py37-nocov
@@ -51,7 +47,7 @@ jobs:
             toxdir: cli
             toxenv: py39-cov
           - name: Code Checks
-            python: 3.6
+            python: 3.7
             toxdir: cli
             toxenv: code-linters
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -27,7 +27,6 @@ from common.schedulers.slurm_commands import (
     get_partition_info,
     reset_nodes,
     resume_powering_down_nodes,
-    set_nodes_down,
     set_nodes_drain,
     set_nodes_power_down,
     update_all_partitions,
@@ -719,7 +718,7 @@ class ClusterManager:
         # Set nodes into down state so jobs can be requeued immediately
         try:
             log.info("Setting unhealthy static nodes to DOWN")
-            set_nodes_down(node_list, reason="Static node maintenance: unhealthy node is being replaced")
+            reset_nodes(node_list, state="down", reason="Static node maintenance: unhealthy node is being replaced")
         except Exception as e:
             log.error("Encountered exception when setting unhealthy static nodes into down state: %s", e)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}
+    py{37,38}
     code-linters
 
 # Default testenv. Used to run tests on all python versions.


### PR DESCRIPTION
Set unhealthy nodes static nodes to down with reset node address in order to fix ice static nodes after a bootstrap failure being treated as bootstrap failure nodes.

Here's the bootstrap failure case that static node in replacement will ice issue will fail with:
```
   def is_bootstrap_failure(self):
        """Check if a slurm node has boostrap failure."""
        if self.is_static_nodes_in_replacement and not self.is_backing_instance_valid(log_warn_if_unhealthy=False):
            # Node is currently in replacement and no backing instance
            logger.warning(
                "Node bootstrap error: Node %s is currently in replacement and no backing instance, node state %s:",
                self,
                self.state_string,
            )
```
Behaviors before the change:
When detect unhealthy static node, static nodes will be set to down when it is unhealthy. In the same iteration, a run_instance call will be performed to launch a new instance for the node, node address will be changed to the new one if the run_instance call is successfully.
If the run_instance call failed, node address will be remained, node will be treat as bootstrap failure node.

After this change, When detect unhealthy static node, static nodes will be set to down with node address reset. If run_instance call is successfully, node will be set to new address. If run_instance call failed, node address will be node_name. Node will not be treated as bootstrap failure.

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.