### PR TITLE
[develop] manage cluster loop improvements

### DIFF
--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -39,7 +39,7 @@ def log_exception(
             try:
                 return function(*args, **kwargs)
             except catch_exception as e:
-                logger.log(log_level, "Failed when %s with exception %s", action_desc, e)
+                logger.log(log_level, "Failed when %s with exception %s, message: %s", action_desc, type(e).__name__, e)
                 if raise_on_error:
                     if exception_to_raise:
                         raise exception_to_raise


### PR DESCRIPTION
### Description of changes
* Handle case when instances don't have all EC2 info yet

  Handle corner case when instance is just launched and the describe doesn't report yet all the EC2 info like the private IP address.
  In this case, the get_cluster_instances must not completely fail, but only skip the instance for which there aren't all the info yet.
  
  The get_cluster_instances is used in the compute fleet stopped loop to keep the nodes to down and in the manage cluster loop to update slurm nodes with EC2 info and to terminate orphaned nodes.

Log example

```
2022-05-16 13:17:20,092 - [slurm_plugin.clustermgtd:_get_ec2_instances] - INFO - Retrieving list of EC2 instances associated with the cluster
2022-05-16 13:17:55,704 - [slurm_plugin.instance_manager:get_cluster_instances] - ERROR - Unable to retrieve EC2 info for instance i-05d108608b02ee146, exception: KeyError, message: 'PrivateIpAddress'
```

* Improve exception logging

  Improve exception logging printing exception class nam

### Tests
* unit tests passing and manually tested

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.