### PR TITLE
Add Unsupported state in the list of EC2 error codes used for fast fail-over

### DIFF
--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -127,6 +127,7 @@ class SlurmNode(metaclass=ABCMeta):
         "InsufficientHostCapacity",
         "InsufficientReservedInstanceCapacity",
         "MaxSpotInstanceCountExceeded",
+        "Unsupported",
     }
 
     def __init__(self, name, nodeaddr, nodehostname, state, partitions=None, reason=None, instance=None):

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -341,6 +341,17 @@ def test_slurm_node_is_power_with_job(node, expected_output):
             ),
             True,
         ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD",
+                "queue1",
+                "(Code:Unsupported)Failure when resuming nodes",
+            ),
+            True,
+        ),
     ],
 )
 def test_slurm_node_is_ice(node, expected_output):


### PR DESCRIPTION
### Description of changes
That error code `Unsupported` happens when using an instance type that is not supported in a specific region/az.
Take this case into consideration so the compute resource will be disabled when the instance type is not supported.

### Tests
* Unit test

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.