### PR TITLE
 Add `SpotMaxPriceTooLow` to the list of EC2 error codes used for fast fail-over

### DIFF
--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -128,6 +128,7 @@ class SlurmNode(metaclass=ABCMeta):
         "InsufficientReservedInstanceCapacity",
         "MaxSpotInstanceCountExceeded",
         "Unsupported",
+        "SpotMaxPriceTooLow",
     }
 
     def __init__(self, name, nodeaddr, nodehostname, state, partitions=None, reason=None, instance=None):

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -352,6 +352,17 @@ def test_slurm_node_is_power_with_job(node, expected_output):
             ),
             True,
         ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD",
+                "queue1",
+                "(Code:SpotMaxPriceTooLow)Failure when resuming nodes",
+            ),
+            True,
+        ),
     ],
 )
 def test_slurm_node_is_ice(node, expected_output):


### PR DESCRIPTION
### Description of changes
* Add SpotMaxPriceTooLow to the list of EC2 error codes used for fast fail-over
* When specifying CapacityType: SPOT and SPotPrice lower than minimum required Spot request fulfillment price,
```
    - Name: queue1
      CapacityType: SPOT
      ComputeResources:
        - Name: compute1
          InstanceType: c5.large
          MinCount: 0
          MaxCount: 2
          SpotPrice: 0.001
``` 
The error from run_instance is that:
```
ERROR - Encountered exception when launching instances for nodes (x1) ['queue1-dy-compute1-1']: An error occurred (SpotMaxPriceTooLow) when calling the RunInstances operation: Your Spot request price of 0.001 is lower than the minimum required Spot request fulfillment price of 0.0374.
```

### Tests
* Manually test
```
[ec2-user@ip-192-168-45-115 ~]$ scontrol show nodes queue1-dy-compute1-1
NodeName=queue1-dy-compute1-1 CoresPerSocket=1
   CPUAlloc=0 CPUTot=2 CPULoad=N/A
   AvailableFeatures=dynamic,c5.large,compute1
   ActiveFeatures=dynamic,c5.large,compute1
   Gres=(null)
   NodeAddr=queue1-dy-compute1-1 NodeHostName=queue1-dy-compute1-1
   RealMemory=1 AllocMem=0 FreeMem=N/A Sockets=2 Boards=1
   State=DOWN+CLOUD+NOT_RESPONDING+POWERING_UP ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A
   Partitions=queue1
   BootTime=None SlurmdStartTime=None
   LastBusyTime=2022-06-08T00:06:08
   CfgTRES=cpu=2,mem=1M,billing=2
   AllocTRES=
   CapWatts=n/a
   CurrentWatts=0 AveWatts=0
   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s
   Reason=(Code:SpotMaxPriceTooLow)Failure when resuming nodes [root@2022-06-08T00:06:08]
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.