### PR TITLE
Added support for rebooting compute nodes via Slurm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ x.x.x
 
 **ENHANCEMENTS**
 - Temporarily disable compute resource when a node launch fails due to insufficient capacity.
+- Add support for rebooting compute nodes via Slurm.
 
 **CHANGES**
 - Drop support for python 3.6.

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -124,7 +124,6 @@ class SlurmNode(metaclass=ABCMeta):
     SLURM_SCONTROL_REBOOT_REQUESTED_STATE = "REBOOT_REQUESTED"
     SLURM_SCONTROL_REBOOT_ISSUED_STATE = "REBOOT_ISSUED"
 
-
     EC2_ICE_ERROR_CODES = {
         "InsufficientInstanceCapacity",
         "InsufficientHostCapacity",

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -239,26 +239,16 @@ class SlurmNode(metaclass=ABCMeta):
         """
         Check if the node is rebooting via scontrol reboot.
 
-        Check that the node is in a state consistent with the scontrol reboot request, which could trigger
-        the health checks.
+        Check that the node is in a state consistent with the scontrol reboot request.
         """
         cond = False
-        if self._is_drain():
-            if self.is_reboot_issued() or self.is_reboot_requested():
-                logger.debug(
-                    "Node state check: node %s in DRAINED but is currently rebooting, ignoring, node state: %s",
-                    self,
-                    self.state_string,
-                )
-                cond = True
-        elif self.is_down():
-            if self.is_reboot_issued():
-                logger.debug(
-                    "Node state check: node %s in DOWN but is currently rebooting, ignoring, node state: %s",
-                    self,
-                    self.state_string,
-                )
-                cond = True
+        if self.is_reboot_issued() or self.is_reboot_requested():
+            logger.debug(
+                "Node state check: node %s is currently rebooting, ignoring, node state: %s",
+                self,
+                self.state_string,
+            )
+            cond = True
         return cond
 
     @abstractmethod

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -108,6 +108,33 @@ def test_slurm_node_is_drained(node, expected_output):
 @pytest.mark.parametrize(
     "node, expected_output",
     [
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+REBOOT_REQUESTED", "queue1"),
+            False,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+REBOOT_ISSUED", "queue1"),
+            True,
+        ),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DRAIN+REBOOT_REQUESTED", "queue1"
+            ),
+            True,
+        ),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN+REBOOT_ISSUED", "queue1"),
+            True,
+        ),
+    ],
+)
+def test_slurm_node_is_rebooting(node, expected_output):
+    assert_that(node.is_rebooting()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "somestate", "queue1"), False),
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DOWN+POWERING_UP", "queue1"), True),
         (

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -538,7 +538,7 @@ def test_partition_is_inactive(nodes, expected_output):
             True,
             False,
             True,
-            id="scontrol_reboot_asap_issued_static"
+            id="scontrol_reboot_asap_issued_static",
         ),
         pytest.param(
             DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue"),
@@ -546,7 +546,7 @@ def test_partition_is_inactive(nodes, expected_output):
             True,
             False,
             True,
-            id="scontrol_reboot_asap_issued_dynamic"
+            id="scontrol_reboot_asap_issued_dynamic",
         ),
     ],
 )

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -110,7 +110,7 @@ def test_slurm_node_is_drained(node, expected_output):
     [
         (
             DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+REBOOT_REQUESTED", "queue1"),
-            False,
+            True,
         ),
         (
             DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+REBOOT_ISSUED", "queue1"),

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -86,15 +86,17 @@ def test_slurm_node_has_job(node, expected_output):
             True,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+REBOOT_ISSUED", "queue1"),
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+REBOOT_ISSUED", "queue1"),
             False,
         ),
         (
-            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+DRAIN+REBOOT_REQUESTED", "queue1"),
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DRAIN+REBOOT_REQUESTED", "queue1"
+            ),
             False,
         ),
         (
-            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue1"),
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN+REBOOT_ISSUED", "queue1"),
             True,
         ),
     ],
@@ -168,15 +170,17 @@ def test_slurm_node_is_drained(node, expected_output):
             False,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+REBOOT_ISSUED", "queue1"),
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+REBOOT_ISSUED", "queue1"),
             True,
         ),
         (
-            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+DRAIN+REBOOT_REQUESTED", "queue1"),
+            StaticNode(
+                "queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+DRAIN+REBOOT_REQUESTED", "queue1"
+            ),
             False,
         ),
         (
-            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue1"),
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN+REBOOT_ISSUED", "queue1"),
             True,
         ),
     ],
@@ -525,7 +529,7 @@ def test_partition_is_inactive(nodes, expected_output):
             id="power_dynamic_node",
         ),
         pytest.param(
-            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+REBOOT_ISSUED", "queue"),
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+CLOUD+REBOOT_ISSUED", "queue"),
             True,
             True,
             False,
@@ -533,7 +537,7 @@ def test_partition_is_inactive(nodes, expected_output):
             id="scontrol_reboot_issued_static",
         ),
         pytest.param(
-            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+REBOOT_ISSUED", "queue"),
+            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+CLOUD+REBOOT_ISSUED", "queue"),
             True,
             True,
             False,
@@ -541,7 +545,7 @@ def test_partition_is_inactive(nodes, expected_output):
             id="scontrol_reboot_issued_dynamic",
         ),
         pytest.param(
-            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DRAIN+REBOOT_REQUESTED", "queue"),
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DRAIN+CLOUD+REBOOT_REQUESTED", "queue"),
             True,
             True,
             False,
@@ -549,7 +553,7 @@ def test_partition_is_inactive(nodes, expected_output):
             id="scontrol_reboot_asap_requested_static",
         ),
         pytest.param(
-            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DRAIN+REBOOT_REQUESTED", "queue"),
+            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DRAIN+CLOUD+REBOOT_REQUESTED", "queue"),
             True,
             True,
             False,
@@ -557,7 +561,7 @@ def test_partition_is_inactive(nodes, expected_output):
             id="scontrol_reboot_asap_requested_dynamic",
         ),
         pytest.param(
-            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue"),
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+CLOUD+DRAIN+REBOOT_ISSUED", "queue"),
             True,
             True,
             False,
@@ -565,7 +569,7 @@ def test_partition_is_inactive(nodes, expected_output):
             id="scontrol_reboot_asap_issued_static",
         ),
         pytest.param(
-            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue"),
+            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+CLOUD+DRAIN+REBOOT_ISSUED", "queue"),
             True,
             True,
             False,

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -500,6 +500,30 @@ def test_partition_is_inactive(nodes, expected_output):
             True,
             id="power_dynamic_node",
         ),
+        pytest.param(
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+REBOOT_ISSUED", "queue"),
+            True,
+            True,
+            False,
+            True,
+            id="scontrol_reboot_issued",
+        ),
+        pytest.param(
+            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DRAIN+REBOOT_REQUESTED", "queue"),
+            True,
+            True,
+            False,
+            True,
+            id="scontrol_reboot_asap_requested",
+        ),
+        pytest.param(
+            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue"),
+            True,
+            True,
+            False,
+            True,
+            id="scontrol_reboot_asap_issued"
+        ),
     ],
 )
 def test_slurm_node_is_state_healthy(

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -66,7 +66,7 @@ def test_slurm_node_has_job(node, expected_output):
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+DRAIN+POWER_DOWN", "queue1"),
-            False,
+            True,
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+DRAIN+POWERING_DOWN", "queue1"),
@@ -79,10 +79,22 @@ def test_slurm_node_has_job(node, expected_output):
         (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN", "queue1"), True),
         (
             DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+DRAIN+POWER_DOWN", "queue1"),
-            False,
+            True,
         ),
         (
             DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+DRAIN+POWERING_DOWN", "queue1"),
+            True,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+REBOOT_ISSUED", "queue1"),
+            False,
+        ),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+DRAIN+REBOOT_REQUESTED", "queue1"),
+            False,
+        ),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue1"),
             True,
         ),
     ],
@@ -154,6 +166,18 @@ def test_slurm_node_is_drained(node, expected_output):
                 "queue1",
             ),
             False,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+REBOOT_ISSUED", "queue1"),
+            True,
+        ),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "MIXED+DRAIN+REBOOT_REQUESTED", "queue1"),
+            False,
+        ),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue1"),
+            True,
         ),
     ],
 )

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -506,7 +506,23 @@ def test_partition_is_inactive(nodes, expected_output):
             True,
             False,
             True,
-            id="scontrol_reboot_issued",
+            id="scontrol_reboot_issued_static",
+        ),
+        pytest.param(
+            DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+REBOOT_ISSUED", "queue"),
+            True,
+            True,
+            False,
+            True,
+            id="scontrol_reboot_issued_dynamic",
+        ),
+        pytest.param(
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DRAIN+REBOOT_REQUESTED", "queue"),
+            True,
+            True,
+            False,
+            True,
+            id="scontrol_reboot_asap_requested_static",
         ),
         pytest.param(
             DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DRAIN+REBOOT_REQUESTED", "queue"),
@@ -514,7 +530,15 @@ def test_partition_is_inactive(nodes, expected_output):
             True,
             False,
             True,
-            id="scontrol_reboot_asap_requested",
+            id="scontrol_reboot_asap_requested_dynamic",
+        ),
+        pytest.param(
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue"),
+            True,
+            True,
+            False,
+            True,
+            id="scontrol_reboot_asap_issued_static"
         ),
         pytest.param(
             DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "DOWN+DRAIN+REBOOT_ISSUED", "queue"),
@@ -522,7 +546,7 @@ def test_partition_is_inactive(nodes, expected_output):
             True,
             False,
             True,
-            id="scontrol_reboot_asap_issued"
+            id="scontrol_reboot_asap_issued_dynamic"
         ),
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38}
+    py{37,38}-cov
     code-linters
 
 # Default testenv. Used to run tests on all python versions.


### PR DESCRIPTION
### Description of changes
* Added support for rebooting compute nodes via Slurm without having clustermgtd marking nodes as unhealthy during the reboot.

### Tests
* Manual tests with `scontrol reboot` and `scontrol reboot asap` with both static and dynamic nodes.
* Manual tests with `scontrol update Node=<> State=POWER_DOWN_ASAP`.

### References
* https://github.com/aws/aws-parallelcluster/pull/4133
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1463

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
