### PR TITLE
[Versioning] Fix version bumping script to make it use GNU sed instead of BSD sed on Mac OS.

### DIFF
--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+# On Mac OS, the default implementation of sed is BSD sed, but this script requires GNU sed.
+if [ "$(uname)" == "Darwin" ]; then
+  command -v gsed >/dev/null 2>&1 || { echo >&2 "[ERROR] Mac OS detected: please install GNU sed with 'brew install gnu-sed'"; exit 1; }
+  PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+fi
+
 if [ -z "$1" ]; then
     echo "New version not specified. Usage: bump-version.sh NEW_VERSION"
     exit 1


### PR DESCRIPTION
### Description of changes
Fix version bumping script to make it use GNU sed instead of BSD sed on Mac OS.

### Tests
Script used during MCM to bump the version from Mac OS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>