### PR TITLE
Fix file handler leak in computemgtd

### DIFF
--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -17,7 +17,7 @@ from configparser import ConfigParser
 from datetime import datetime, timezone
 from logging.config import fileConfig
 from subprocess import CalledProcessError
-from tempfile import mkstemp
+from tempfile import NamedTemporaryFile
 
 from botocore.config import Config
 from common.schedulers.slurm_commands import get_nodes_info
@@ -55,7 +55,8 @@ class ComputemgtdConfig:
     }
 
     def __init__(self, config_file_path):
-        _, self._local_config_file = mkstemp()
+        tf = NamedTemporaryFile()
+        self._local_config_file = tf.name
         self._get_config(config_file_path)
 
     def __repr__(self):


### PR DESCRIPTION
Fix for closing filehandle of tempfile and delete it. (mkstemp, is not closing os filehandle automatically)
computemgtd was running into a too many open files issue, every ~8 days. Which made compute node be restarted.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.