### PR TITLE
[Dependencies] Set requirement retrying~=1.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 boto3>=1.7.55
-retrying>=1.3.3
+retrying~=1.3


### PR DESCRIPTION
### Description of changes
Set requirement retrying~=1.3

### Tests
1. `pip install -r requirements.txt` installs retrying 1.3.3, like it was before the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>