### PR TITLE
[SlurmPlugin] Log exceptions raised when reading json files

### DIFF
--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -73,7 +73,7 @@ def read_json(file_path, default=None):
             )
             raise
         else:
-            logger.info("Unable to read file '%s'. Using default: %s", file_path, default)
+            logger.info("Unable to read file '%s' due to an exception: %s. Using default: %s", file_path, e, default)
             return default
 
 

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from assertpy import assert_that
 from common.utils import time_is_up
-from slurm_plugin.common import TIMESTAMP_FORMAT, get_clustermgtd_heartbeat
+from slurm_plugin.common import TIMESTAMP_FORMAT, get_clustermgtd_heartbeat, read_json
 
 
 @pytest.mark.parametrize(
@@ -76,3 +76,17 @@ def test_get_clustermgtd_heartbeat(time, expected_parsed_time, mocker):
         return_value=f"some_random_stdout\n{time.strftime(TIMESTAMP_FORMAT)}",
     )
     assert_that(get_clustermgtd_heartbeat("some file path")).is_equal_to(expected_parsed_time)
+
+
+@pytest.mark.parametrize(
+    "json_file, log_assertion",
+    [
+        ("test_read_json/faulty.json", lambda logs: "Failed with exception:" in logs),
+        ("test_read_json/standard.json", lambda logs: "Failed with exception:" not in logs),
+    ],
+)
+def test_read_json(test_datadir, caplog, json_file, log_assertion):
+    json_file_path = str(test_datadir.joinpath(json_file))
+    with pytest.raises(Exception):
+        read_json(json_file_path)
+    assert log_assertion

--- a/tests/slurm_plugin/test_common/test_read_json/faulty.json
+++ b/tests/slurm_plugin/test_common/test_read_json/faulty.json
@@ -1,0 +1,5 @@
+{
+    "test_property_1": {
+                    "test_property_2": "test_value"
+                }
+}

--- a/tests/slurm_plugin/test_common/test_read_json/standard.json
+++ b/tests/slurm_plugin/test_common/test_read_json/standard.json
@@ -1,0 +1,5 @@
+{
+    "test_property_1": {
+      "test_property_2": "test_value"
+    }
+}


### PR DESCRIPTION
### Description of changes
* While reading json files such as `run_instances_overrides.json`, the read operation may fail due to use of non-standard characters. This is difficult to debug since at the moment we use a default value when there is an error and furthermore the error is not logged.
* This commit logs the exception in situations where we fallback to a default value.

### Tests
* Manually tested by using a `run_instances_overrides.json` file with non-standard characters

*Before:*

```
2022-07-07 10:28:23,967 - [slurm_plugin.clustermgtd:_get_config] - INFO - Reading /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf
2022-07-07 10:28:23,968 - [slurm_plugin.common:read_json] - INFO - Unable to read file '/opt/slurm/etc/pcluster/run_instances_overrides.json'. Using default: {}
```

*After:*

```
2022-07-07 10:33:56,653 - [slurm_plugin.clustermgtd:_get_config] - INFO - Reading /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf
2022-07-07 10:33:56,654 - [slurm_plugin.common:read_json] - INFO - Unable to read file '/opt/slurm/etc/pcluster/run_instances_overrides.json' due to an exception: Expecting property name enclosed in double quotes: line 2 column 1 (char 2). Using default: {}
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.