### PR TITLE
Use CreateFleet API when multiple instance types are specified in the compute resource configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+3.x.x
+------
+
+**ENHANCEMENTS**
+- Add support for EC2 Fleet as an alternative instance provisioning mechanism that allows greater flexibility in terms of instance diversification and launch strategy.
+
 3.2.0
 ------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3>=1.7.55
+PyYAML~=5.3  # TODO remove
 retrying~=1.3

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ console_scripts = [
     "computemgtd = slurm_plugin.computemgtd:main",
 ]
 version = "3.2.0"
-requires = ["boto3>=1.7.55", "retrying>=1.3.3"]
+requires = ["boto3>=1.7.55", "PyYAML~=5.3", "retrying>=1.3.3"]
 
 setup(
     name="aws-parallelcluster-node",

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -1,0 +1,361 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import logging
+import time
+from abc import ABC, abstractmethod
+
+import boto3
+import yaml
+from botocore.exceptions import ClientError
+from slurm_plugin.slurm_resources import EC2Instance
+
+logger = logging.getLogger(__name__)
+
+
+class FleetManagerException(Exception):
+    """Represent an error during the execution of an action with the FleetManager or FleetManagerFactory."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class FleetManagerFactory:
+    @staticmethod
+    def get_manager(cluster_name, region, boto3_config, cluster_config_file, queue, compute_resource, all_or_nothing):
+        try:
+            cluster_config = FleetManagerFactory._load_cluster_config(cluster_config_file)
+
+            queue_config = next(
+                q_config for q_config in cluster_config["Scheduling"]["SlurmQueues"] if q_config["Name"] == queue
+            )
+            compute_resource_config = next(
+                cr_config for cr_config in queue_config["ComputeResources"] if cr_config["Name"] == compute_resource
+            )
+        except FileNotFoundError as e:
+            message = f"Unable to read {cluster_config_file}, {e}"
+            logger.error(message)
+            raise FleetManagerException(message)
+        except StopIteration:
+            message = (
+                f"Unable to found queue {queue} or compute resource {compute_resource} in the {cluster_config_file}"
+            )
+            logger.error(message)
+            raise FleetManagerException(message)
+
+        if compute_resource_config.get("InstanceTypeList"):
+            return Ec2CreateFleetManager(
+                cluster_name,
+                region,
+                boto3_config,
+                queue_config,
+                compute_resource_config,
+                all_or_nothing,
+            )
+        elif compute_resource_config.get("InstanceType"):
+            return Ec2RunInstancesManager(
+                cluster_name,
+                region,
+                boto3_config,
+                queue_config,
+                compute_resource_config,
+                all_or_nothing,
+            )
+        else:
+            raise Exception(
+                "InstanceTypeList or InstanceType field not found "
+                f"in queue: {queue}, compute resource: {compute_resource}"
+            )
+
+    @staticmethod
+    def _load_cluster_config(config_file_path):
+        """
+        Load cluster configuration.
+
+        Cluster config is required to retrieve queue/compute-resource settings to be used in create-fleet call.
+        """
+        with open(config_file_path) as config_file:
+            return yaml.load(config_file, Loader=yaml.SafeLoader)
+
+
+class FleetManager(ABC):
+    """Abstract Fleet Manager."""
+
+    @abstractmethod
+    def __init__(
+        self,
+        cluster_name,
+        region,
+        boto3_config,
+        queue_config,
+        compute_resource_config,
+        all_or_nothing=False,
+    ):
+        self._cluster_name = cluster_name
+        self._region = region
+        self._boto3_config = boto3_config
+        self._queue_config = queue_config
+        self._queue = queue_config["Name"]
+        self._compute_resource_config = compute_resource_config
+        self._compute_resource = compute_resource_config["Name"]
+        self._all_or_nothing = all_or_nothing
+
+    @abstractmethod
+    def _evaluate_launch_params(self, count, launch_overrides):
+        pass
+
+    @abstractmethod
+    def _launch_instances(self, launch_params):
+        pass
+
+    def launch_ec2_instances(self, count, launch_overrides):
+        """
+        Launch EC2 instances.
+
+        :raises ClientError in case of failures with Boto3 calls (run_instances, create_fleet, describe_instances)
+        :raises FleetManagerException in case of missing required instance type info (e.g. private-ip) after 3 retries.
+        """
+        launch_params = self._evaluate_launch_params(count, launch_overrides)
+        assigned_nodes = self._launch_instances(launch_params)
+        logger.info(f"Launched the following instances: {assigned_nodes.get('Instances')}")
+        return [EC2Instance.from_describe_instance_data(instance_info) for instance_info in assigned_nodes["Instances"]]
+
+
+class Ec2RunInstancesManager(FleetManager):
+    """Manager to create EC2 instances fleet using EC2 run_instances API."""
+
+    def __init__(
+        self,
+        cluster_name,
+        region,
+        boto3_config,
+        queue_config,
+        compute_resource_config,
+        all_or_nothing,
+    ):
+        super().__init__(
+            cluster_name,
+            region,
+            boto3_config,
+            queue_config,
+            compute_resource_config,
+            all_or_nothing,
+        )
+
+    def _evaluate_launch_params(self, count, launch_overrides):
+        """Evaluate parameters to be passed to run_instances call."""
+        launch_params = {
+            # Set MinCount to "count" to make the run_instances call fail if entire count cannot be satisfied
+            "MinCount": 1 if not self._all_or_nothing else count,
+            "MaxCount": count,
+            # LaunchTemplate is different for every compute resources in every queue
+            "LaunchTemplate": {
+                "LaunchTemplateName": f"{self._cluster_name}-{self._queue}-{self._compute_resource}",
+                "Version": "$Latest",
+            },
+        }
+
+        launch_params.update(launch_overrides)
+        if launch_overrides:
+            logger.info("Found RunInstances parameters override. Launching instances with: %s", launch_params)
+        return launch_params
+
+    def _launch_instances(self, launch_params):
+        """Launch a batch of ec2 instances."""
+        try:
+            return run_instances(self._region, self._boto3_config, launch_params)
+        except ClientError as e:
+            logger.error("Failed RunInstances request: %s", e.response.get("ResponseMetadata").get("RequestId"))
+            raise e
+
+
+class Ec2CreateFleetManager(FleetManager):
+    """Manager to create EC2 instances fleet using create_fleet API."""
+
+    def __init__(
+        self,
+        cluster_name,
+        region,
+        boto3_config,
+        queue_config,
+        compute_resource_config,
+        all_or_nothing,
+    ):
+        super().__init__(
+            cluster_name,
+            region,
+            boto3_config,
+            queue_config,
+            compute_resource_config,
+            all_or_nothing,
+        )
+
+    def _evaluate_launch_params(self, count, launch_overrides):
+        """Evaluate parameters to be passed to create_fleet call."""
+        template_overrides = []
+        try:
+            queue_overrides = {}
+            if self._queue_config["CapacityType"] == "SPOT" and self._compute_resource_config["SpotPrice"]:
+                queue_overrides = {"MaxPrice": str(self._compute_resource_config["SpotPrice"])}
+
+            for instance_type in self._compute_resource_config["InstanceTypeList"]:
+                override = copy.deepcopy(queue_overrides)
+                override["InstanceType"] = instance_type["InstanceType"]
+                template_overrides.append(override)
+
+            launch_params = {
+                "LaunchTemplateConfigs": [
+                    {
+                        "LaunchTemplateSpecification": {
+                            # LaunchTemplate is different for every compute resources in every queue
+                            "LaunchTemplateName": f"{self._cluster_name}-{self._queue}-{self._compute_resource}",
+                            "Version": "$Latest",
+                        },
+                        "Overrides": template_overrides,
+                    }
+                ],
+                "TargetCapacitySpecification": {
+                    "TotalTargetCapacity": count,
+                    "DefaultTargetCapacityType": "on-demand"
+                    if self._queue_config["CapacityType"] == "ONDEMAND"
+                    else "spot",
+                },
+                "Type": "instant",
+                "SpotOptions": {
+                    "AllocationStrategy": self._queue_config["AllocationStrategy"],
+                    "SingleInstanceType": False,
+                    "SingleAvailabilityZone": True,  # Set to False for Multi-AZ support
+                    # If the minimum target capacity is not reached, the fleet launches no instances
+                    "MinTargetCapacity": 1 if not self._all_or_nothing else count,
+                },
+                "OnDemandOptions": {
+                    "AllocationStrategy": self._queue_config["AllocationStrategy"],
+                    "CapacityReservationOptions": {"UsageStrategy": "use-capacity-reservations-first"},
+                    "SingleInstanceType": False,
+                    "SingleAvailabilityZone": True,  # Set to False for Multi-AZ support
+                    # If the minimum target capacity is not reached, the fleet launches no instances
+                    "MinTargetCapacity": 1 if not self._all_or_nothing else count,
+                },
+                # TODO verify if we need to add user's tag in "TagSpecifications": []
+            }
+        except KeyError as e:
+            message = (
+                f"Unable to find key {e} in the configuration of queue: {self._queue}, "
+                f"compute resource {self._compute_resource}"
+            )
+            logger.error(message)
+            raise FleetManagerException(message)
+
+        launch_params.update(launch_overrides)
+        if launch_overrides:
+            logger.info("Found CreateFleet parameters override. Launching instances with: %s", launch_params)
+        return launch_params
+
+    def _launch_instances(self, launch_params):
+        """Launch a batch of ec2 instances."""
+        try:
+            response = create_fleet(self._region, self._boto3_config, launch_params)
+            logger.debug("CreateFleet response: %s", response)
+
+            instances = response.get("Instances", [])
+            log_level = logging.WARNING if instances else logging.ERROR
+            for err in response.get("Errors", []):
+                logger.log(
+                    log_level, "Error in CreateFleet request: %s - %s", err.get("ErrorCode"), err.get("ErrorMessage")
+                )
+
+            instance_ids = [inst_id for instance in instances for inst_id in instance["InstanceIds"]]
+            instances, partial_instance_ids = self._get_instances_info(instance_ids)
+            if partial_instance_ids:
+                logger.error(f"Unable to retrieve instance info for instances: {partial_instance_ids}")
+
+            return {"Instances": instances}
+        except ClientError as e:
+            logger.error("Failed CreateFleet request: %s", e.response.get("ResponseMetadata").get("RequestId"))
+            raise e
+
+    def _get_instances_info(self, instance_ids: list):
+        """
+        Describe instances to retrieve info not available from create-fleet response.
+
+        :raises ClientError in case of boto3 failure
+        :return list of instances with complete information and list of IDs for instances with incomplete information
+        """
+        instances = []
+        partial_instance_ids = instance_ids
+
+        retry = 3
+        while retry > 0 and partial_instance_ids:
+            # Wait for instances to be available in EC2
+            time.sleep(5)
+            complete_instances, partial_instance_ids = self._retrieve_instances_info_from_ec2(partial_instance_ids)
+            instances.extend(complete_instances)
+            retry = retry - 1
+
+        return instances, partial_instance_ids
+
+    def _retrieve_instances_info_from_ec2(self, instance_ids: list):
+        """
+        Retrieve instance info from EC2 by Instance Ids and verify to have required info.
+
+        :raises ClientError in case of boto3 failure
+        :return list of instances with complete information and list of IDs for instances with incomplete information
+        """
+        complete_instances = []
+        partial_instance_ids = []
+
+        if instance_ids:
+            ec2_client = boto3.client("ec2", region_name=self._region, config=self._boto3_config)
+            paginator = ec2_client.get_paginator("describe_instances")
+            response_iterator = paginator.paginate(InstanceIds=instance_ids)
+            filtered_iterator = response_iterator.search("Reservations[].Instances[]")
+
+            for instance_info in filtered_iterator:
+                try:
+                    # Try to build EC2Instance objects using all the required fields
+                    EC2Instance.from_describe_instance_data(instance_info)
+                    complete_instances.append(instance_info)
+                except KeyError:
+                    partial_instance_ids.append(instance_info["InstanceId"])
+
+        return complete_instances, partial_instance_ids
+
+
+def run_instances(region, boto3_config, run_instances_kwargs):
+    """
+    Check whether to override ec2 run_instances.
+
+    This function is defined here to be able to overwrite it when executing manual tests or in integration tests.
+    """
+    try:
+        from slurm_plugin.overrides import run_instances
+
+        return run_instances(region=region, boto3_config=boto3_config, **run_instances_kwargs)
+    except ImportError:
+        logger.info(f"Launching instances with Boto3 run_instances API. Parameters: {run_instances_kwargs}")
+        ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
+        return ec2_client.run_instances(**run_instances_kwargs)
+
+
+def create_fleet(region, boto3_config, create_fleet_kwargs):
+    """
+    Check whether to override ec2 create_fleet.
+
+    This function is defined here to be able to overwrite it when executing manual tests or in integration tests.
+    """
+    try:
+        from slurm_plugin.overrides import create_fleet
+
+        return create_fleet(region=region, boto3_config=boto3_config, **create_fleet_kwargs)
+    except ImportError:
+        logger.info(f"Launching instances with Boto3 create_fleet API. Parameters: {create_fleet_kwargs}")
+        ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
+        return ec2_client.create_fleet(**create_fleet_kwargs)

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -18,12 +18,11 @@ from botocore.exceptions import ClientError
 from common.schedulers.slurm_commands import update_nodes
 from common.utils import grouper
 from slurm_plugin.common import log_exception, print_with_count
-from slurm_plugin.fleet_manager import FleetManagerFactory
+from slurm_plugin.fleet_manager import EC2Instance, FleetManagerFactory
 from slurm_plugin.slurm_resources import (
     EC2_HEALTH_STATUS_UNHEALTHY_STATES,
     EC2_INSTANCE_ALIVE_STATES,
     EC2_SCHEDULED_EVENT_CODES,
-    EC2Instance,
     EC2InstanceHealthState,
     InvalidNodenameError,
     parse_nodename,

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -37,8 +37,9 @@ class SlurmResumeConfig:
         "hosted_zone": None,
         "dns_domain": None,
         "use_private_hostname": False,
-        "instance_type_mapping": "/opt/slurm/etc/pcluster/instance_name_type_mappings.json",
+        "instance_type_mapping": "/opt/slurm/etc/pcluster/instance_name_type_mappings.json",  # TODO remove this file
         "run_instances_overrides": "/opt/slurm/etc/pcluster/run_instances_overrides.json",
+        "cluster_config_file": "/opt/parallelcluster/shared/cluster-config.yaml",
         "all_or_nothing_batch": False,
     }
 
@@ -84,6 +85,7 @@ class SlurmResumeConfig:
         )
         self.instance_name_type_mapping = read_json(instance_name_type_mapping_file)
         # run_instances_overrides_file contains a json with the following format:
+        # TODO generalize file name to add create-fleet support too.
         # {
         #     "queue_name": {
         #         "compute_resource_name": {
@@ -96,7 +98,10 @@ class SlurmResumeConfig:
         run_instances_overrides_file = config.get(
             "slurm_resume", "run_instances_overrides", fallback=self.DEFAULTS.get("run_instances_overrides")
         )
-        self.run_instances_overrides = read_json(run_instances_overrides_file, default={})
+        self.launch_overrides = read_json(run_instances_overrides_file, default={})
+        self.cluster_config_file = config.get(
+            "slurm_resume", "cluster_config_file", fallback=self.DEFAULTS.get("cluster_config_file")
+        )
         self.clustermgtd_timeout = config.getint(
             "slurm_resume",
             "clustermgtd_timeout",
@@ -167,7 +172,8 @@ def _resume(arg_nodes, resume_config):
         head_node_private_ip=resume_config.head_node_private_ip,
         head_node_hostname=resume_config.head_node_hostname,
         instance_name_type_mapping=resume_config.instance_name_type_mapping,
-        run_instances_overrides=resume_config.run_instances_overrides,
+        launch_overrides=resume_config.launch_overrides,
+        cluster_config_file=resume_config.cluster_config_file,
     )
     instance_manager.add_instances_for_nodes(
         node_list=node_list,

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -63,6 +63,19 @@ class EC2Instance:
     def __hash__(self):
         return hash(self.id)
 
+    @staticmethod
+    def from_describe_instance_data(instance_info):
+        try:
+            return EC2Instance(
+                instance_info["InstanceId"],
+                instance_info["PrivateIpAddress"],
+                instance_info["PrivateDnsName"].split(".")[0],
+                instance_info["LaunchTime"],
+            )
+        except KeyError as e:
+            logger.error("Unable to retrieve EC2 instance info: %s", e)
+            raise e
+
 
 class PartitionStatus(Enum):
     UP = "UP"

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -38,45 +38,6 @@ EC2_SCHEDULED_EVENT_CODES = [
 CONFIG_FILE_DIR = "/etc/parallelcluster/slurm_plugin"
 
 
-class EC2Instance:
-    def __init__(self, id, private_ip, hostname, launch_time):
-        """Initialize slurm node with attributes."""
-        self.id = id
-        self.private_ip = private_ip
-        self.hostname = hostname
-        self.launch_time = launch_time
-        self.slurm_node = None
-
-    def __eq__(self, other):
-        """Compare 2 SlurmNode objects."""
-        if isinstance(other, EC2Instance):
-            return self.__dict__ == other.__dict__
-        return False
-
-    def __repr__(self):
-        attrs = ", ".join(["{key}={value}".format(key=key, value=repr(value)) for key, value in self.__dict__.items()])
-        return "{class_name}({attrs})".format(class_name=self.__class__.__name__, attrs=attrs)
-
-    def __str__(self):
-        return f"{self.id}"
-
-    def __hash__(self):
-        return hash(self.id)
-
-    @staticmethod
-    def from_describe_instance_data(instance_info):
-        try:
-            return EC2Instance(
-                instance_info["InstanceId"],
-                instance_info["PrivateIpAddress"],
-                instance_info["PrivateDnsName"].split(".")[0],
-                instance_info["LaunchTime"],
-            )
-        except KeyError as e:
-            logger.error("Unable to retrieve EC2 instance info: %s", e)
-            raise e
-
-
 class PartitionStatus(Enum):
     UP = "UP"
     DOWN = "DOWN"

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,6 +11,8 @@
 
 from collections import namedtuple
 
+from botocore.exceptions import ClientError
+
 MockedBoto3Request = namedtuple(
     "MockedBoto3Request", ["method", "response", "expected_params", "generate_error", "error_code"]
 )
@@ -24,3 +26,7 @@ def read_text(path):
     """Read the content of a file."""
     with path.open() as f:
         return f.read()
+
+
+def client_error(error_code):
+    return ClientError({"Error": {"Code": error_code}}, "failed_operation")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 import boto3
 import pytest
+import slurm_plugin
 from botocore.stub import Stubber
 
 
@@ -88,3 +89,60 @@ def boto3_stubber(mocker, boto3_stubber_path):
     for stubber in created_stubbers:
         stubber.assert_no_pending_responses()
         stubber.deactivate()
+
+
+@pytest.fixture
+def fleet_manager_factory(mocker):
+    """Mock FleetManagerFactury returning a cluter config with queues/compute resources required by all the tests."""
+    return mocker.patch.object(
+        slurm_plugin.fleet_manager.FleetManagerFactory,
+        "_load_cluster_config",
+        auto_spec=True,
+        return_value={
+            "Scheduling": {
+                "SlurmQueues": [
+                    {
+                        "Name": "queue",
+                        "ComputeResources": [
+                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
+                        ],
+                    },
+                    {
+                        "Name": "queue1",
+                        "ComputeResources": [
+                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
+                            {"Name": "c52xlarge", "InstanceType": "c5.2xlarge"},
+                            {"Name": "p4d24xlarge", "InstanceType": "p4d.24xlarge"},
+                            {
+                                "Name": "fleet-spot",
+                                "InstanceTypeList": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
+                                "SpotPrice": 10,
+                            },
+                        ],
+                        "AllocationStrategy": "capacity-optimized",
+                        "CapacityType": "SPOT",
+                    },
+                    {
+                        "Name": "queue2",
+                        "ComputeResources": [
+                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
+                            {
+                                "Name": "fleet-ondemand",
+                                "InstanceTypeList": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
+                            },
+                        ],
+                        "AllocationStrategy": "lowest-price",
+                        "CapacityType": "ONDEMAND",
+                    },
+                    {
+                        "Name": "queue3",
+                        "ComputeResources": [
+                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
+                            {"Name": "c52xlarge", "InstanceType": "c5.2xlarge"},
+                            {"Name": "p4d24xlarge", "InstanceType": "p4d.24xlarge"},
+                        ],
+                    },
+                ]
+            }
+        },
+    )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,8 @@
+assertpy
 pytest
 pytest-cov
 pytest-datadir
 pytest-html
 pytest-mock
 pytest-xdist
-assertpy
+retrying

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -13,7 +13,8 @@ from datetime import datetime
 
 import pytest
 from assertpy import assert_that
-from slurm_plugin.slurm_resources import DynamicNode, EC2Instance, EC2InstanceHealthState, SlurmPartition, StaticNode
+from slurm_plugin.fleet_manager import EC2Instance
+from slurm_plugin.slurm_resources import DynamicNode, EC2InstanceHealthState, SlurmPartition, StaticNode
 
 
 @pytest.mark.parametrize(

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -21,13 +21,13 @@ import pytest
 import slurm_plugin
 from assertpy import assert_that
 from slurm_plugin.clustermgtd import ClusterManager, ClustermgtdConfig, ComputeFleetStatus, ComputeFleetStatusManager
+from slurm_plugin.fleet_manager import EC2Instance
 from slurm_plugin.slurm_resources import (
     EC2_HEALTH_STATUS_UNHEALTHY_STATES,
     EC2_INSTANCE_ALIVE_STATES,
     EC2_SCHEDULED_EVENT_CODES,
     ComputeResourceFailureEvent,
     DynamicNode,
-    EC2Instance,
     EC2InstanceHealthState,
     PartitionStatus,
     SlurmPartition,

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -1,0 +1,722 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+from datetime import datetime, timezone
+
+import pytest
+import slurm_plugin
+from assertpy import assert_that
+from botocore.exceptions import ClientError
+from slurm_plugin.fleet_manager import Ec2CreateFleetManager, Ec2RunInstancesManager, FleetManagerFactory
+
+from tests.common import MockedBoto3Request
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    # we need to set the region in the environment because the Boto3ClientFactory requires it.
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-2"
+    return "slurm_plugin.fleet_manager.boto3"
+
+
+class TestFleetManagerFactory:
+    @pytest.mark.parametrize(
+        ("config_file_content", "expected_failure", "expected_manager"),
+        [
+            (
+                None,
+                "Unable to read",
+                None,
+            ),
+            (
+                {"Scheduling": {"SlurmQueues": [{"Name": "bad_queue", "ComputeResources": [{"Name": "cr1"}]}]}},
+                "Unable to found queue .* or compute resource .* in the .*",
+                None,
+            ),
+            (
+                {"Scheduling": {"SlurmQueues": [{"Name": "q1", "ComputeResources": [{"Name": "bad_cr"}]}]}},
+                "Unable to found queue .* or compute resource .* in the .*",
+                None,
+            ),
+            (
+                {"Scheduling": {"SlurmQueues": [{"Name": "q1", "ComputeResources": [{"Name": "cr1"}]}]}},
+                "InstanceTypeList or InstanceType field not found .*",
+                None,
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [{"Name": "q1", "ComputeResources": [{"Name": "cr1", "InstanceType": "x"}]}]
+                    }
+                },
+                None,
+                Ec2RunInstancesManager,
+            ),
+            (
+                {
+                    "Scheduling": {
+                        "SlurmQueues": [{"Name": "q1", "ComputeResources": [{"Name": "cr1", "InstanceTypeList": "x"}]}]
+                    }
+                },
+                None,
+                Ec2CreateFleetManager,
+            ),
+        ],
+        ids=[
+            "not_existing_config_file",
+            "missing_queue_in_config_file",
+            "missing_cr_in_config_file",
+            "missing_instance_type_in_config_file",
+            "right_config_file_run_instances",
+            "right_config_file_create_fleet",
+        ],
+    )
+    def test_get_manager(self, mocker, config_file_content, expected_failure, expected_manager):
+        if config_file_content:
+            # patch fleet manager
+            mocker.patch.object(
+                slurm_plugin.fleet_manager.FleetManagerFactory,
+                "_load_cluster_config",
+                auto_spec=True,
+                return_value=config_file_content,
+            )
+
+        if expected_failure:
+            with pytest.raises(Exception, match=expected_failure):
+                FleetManagerFactory.get_manager(
+                    "cluster_name", "region", "boto3_config", "config_file", "q1", "cr1", all_or_nothing=False
+                )
+        else:
+            manager = FleetManagerFactory.get_manager(
+                "cluster_name", "region", "boto3_config", "config_file", "q1", "cr1", all_or_nothing=False
+            )
+            assert_that(manager).is_instance_of(expected_manager)
+
+
+# -------- Ec2RunInstancesManager ------
+
+
+class TestEc2RunInstancesManager:
+    @pytest.mark.parametrize(
+        (
+            "batch_size",
+            "compute_resource",
+            "all_or_nothing",
+            "launch_overrides",
+            "expected_params",
+        ),
+        [
+            (
+                5,
+                "p4d24xlarge",
+                False,
+                {},
+                {
+                    "MinCount": 1,
+                    "MaxCount": 5,
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "hit-queue1-p4d24xlarge",
+                        "Version": "$Latest",
+                    },
+                },
+            ),
+            (
+                5,
+                "c5xlarge",
+                True,
+                {},
+                {
+                    "MinCount": 5,
+                    "MaxCount": 5,
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "hit-queue1-c5xlarge",
+                        "Version": "$Latest",
+                    },
+                },
+            ),
+            (
+                5,
+                "p4d24xlarge",
+                False,
+                {
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationTarget": {"CapacityReservationId": "cr-12345"}
+                    }
+                },
+                {
+                    "MinCount": 1,
+                    "MaxCount": 5,
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "hit-queue1-p4d24xlarge",
+                        "Version": "$Latest",
+                    },
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationTarget": {"CapacityReservationId": "cr-12345"}
+                    },
+                },
+            ),
+        ],
+        ids=["normal", "all_or_nothing_batch", "launch_overrides"],
+    )
+    def test_evaluate_launch_params(
+        self,
+        batch_size,
+        compute_resource,
+        all_or_nothing,
+        launch_overrides,
+        expected_params,
+        fleet_manager_factory,
+        caplog,
+    ):
+        caplog.set_level(logging.INFO)
+        # run test
+        fleet_manager = FleetManagerFactory.get_manager(
+            "hit", "region", "boto3_config", "config_file", "queue1", compute_resource, all_or_nothing
+        )
+        launch_params = fleet_manager._evaluate_launch_params(batch_size, launch_overrides=launch_overrides)
+        if launch_overrides:
+            assert_that(caplog.text).contains("Found RunInstances parameters override")
+        assert_that(launch_params).is_equal_to(expected_params)
+
+    @pytest.mark.parametrize(
+        ("launch_params", "mocked_boto3_request", "expected_assigned_nodes"),
+        [
+            (
+                {
+                    "MinCount": 1,
+                    "MaxCount": 5,
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "hit-queue1-p4d24xlarge",
+                        "Version": "$Latest",
+                    },
+                },
+                [
+                    MockedBoto3Request(
+                        method="run_instances",
+                        response={
+                            "Instances": [
+                                {
+                                    "InstanceId": "i-12345",
+                                    "PrivateIpAddress": "ip-2",
+                                    "PrivateDnsName": "hostname",
+                                    "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                }
+                            ]
+                        },
+                        expected_params={
+                            "MinCount": 1,
+                            "MaxCount": 5,
+                            "LaunchTemplate": {
+                                "LaunchTemplateName": "hit-queue1-p4d24xlarge",
+                                "Version": "$Latest",
+                            },
+                        },
+                    ),
+                ],
+                [
+                    {
+                        "InstanceId": "i-12345",
+                        "PrivateIpAddress": "ip-2",
+                        "PrivateDnsName": "hostname",
+                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                    }
+                ],
+            ),
+        ],
+        ids=["normal"],
+    )
+    def test_launch_instances(
+        self,
+        boto3_stubber,
+        launch_params,
+        mocked_boto3_request,
+        expected_assigned_nodes,
+        fleet_manager_factory,
+    ):
+        # patch boto3 call
+        boto3_stubber("ec2", mocked_boto3_request)
+        # run test
+        fleet_manager = FleetManagerFactory.get_manager(
+            "hit", "region", "boto3_config", "config_file", "queue1", "p4d24xlarge", all_or_nothing=False
+        )
+        assigned_nodes = fleet_manager._launch_instances(launch_params)
+        assert_that(assigned_nodes.get("Instances", [])).is_equal_to(expected_assigned_nodes)
+
+
+# -------- Ec2CreateFleetManager ------
+
+
+def _mocked_create_fleet_params(
+    queue, compute_resource, min_capacity, allocation_strategy, capacity_type, overrides=None
+):
+    template_overrides = []
+    for instance_type in ["t2.medium", "t2.large"]:
+        override = {"InstanceType": instance_type}
+        if capacity_type == "spot":
+            override["MaxPrice"] = str(10)
+        template_overrides.append(override)
+
+    params = {
+        "LaunchTemplateConfigs": [
+            {
+                "LaunchTemplateSpecification": {
+                    "LaunchTemplateName": f"hit-{queue}-{compute_resource}",
+                    "Version": "$Latest",
+                },
+                "Overrides": template_overrides,
+            }
+        ],
+        "TargetCapacitySpecification": {
+            "TotalTargetCapacity": 5,
+            "DefaultTargetCapacityType": capacity_type,
+        },
+        "Type": "instant",
+        "SpotOptions": {
+            "AllocationStrategy": allocation_strategy,
+            "SingleInstanceType": False,
+            "SingleAvailabilityZone": True,
+            "MinTargetCapacity": min_capacity,
+        },
+        "OnDemandOptions": {
+            "AllocationStrategy": allocation_strategy,
+            "CapacityReservationOptions": {"UsageStrategy": "use-capacity-reservations-first"},
+            "SingleInstanceType": False,
+            "SingleAvailabilityZone": True,
+            "MinTargetCapacity": min_capacity,
+        },
+    }
+    if overrides:
+        params.update(overrides)
+    return params
+
+
+class TestCreateFleetManager:
+    @pytest.mark.parametrize(
+        (
+            "batch_size",
+            "queue",
+            "compute_resource",
+            "all_or_nothing",
+            "launch_overrides",
+            "expected_params",
+        ),
+        [
+            # normal - spot
+            (
+                5,
+                "queue1",
+                "fleet-spot",
+                False,
+                {},
+                _mocked_create_fleet_params("queue1", "fleet-spot", 1, "capacity-optimized", "spot"),
+            ),
+            # normal - on-demand
+            (
+                5,
+                "queue2",
+                "fleet-ondemand",
+                False,
+                {},
+                _mocked_create_fleet_params("queue2", "fleet-ondemand", 1, "lowest-price", "on-demand"),
+            ),
+            # all or nothing
+            (
+                5,
+                "queue1",
+                "fleet-spot",
+                True,
+                {},
+                _mocked_create_fleet_params("queue1", "fleet-spot", 5, "capacity-optimized", "spot"),
+            ),
+            # launch_overrides
+            (
+                5,
+                "queue2",
+                "fleet-ondemand",
+                False,
+                {
+                    "TagSpecifications": [
+                        {"ResourceType": "capacity-reservation", "Tags": [{"Key": "string", "Value": "string"}]}
+                    ]
+                },
+                _mocked_create_fleet_params(
+                    "queue2",
+                    "fleet-ondemand",
+                    1,
+                    "lowest-price",
+                    "on-demand",
+                    {
+                        "TagSpecifications": [
+                            {"ResourceType": "capacity-reservation", "Tags": [{"Key": "string", "Value": "string"}]}
+                        ]
+                    },
+                ),
+            ),
+        ],
+        ids=["fleet_spot", "fleet_ondemand", "all_or_nothing", "launch_overrides"],
+    )
+    def test_evaluate_launch_params(
+        self,
+        batch_size,
+        queue,
+        compute_resource,
+        all_or_nothing,
+        launch_overrides,
+        expected_params,
+        fleet_manager_factory,
+        caplog,
+    ):
+        caplog.set_level(logging.INFO)
+        # run tests
+        fleet_manager = FleetManagerFactory.get_manager(
+            "hit", "region", "boto3_config", "config_file", queue, compute_resource, all_or_nothing
+        )
+        launch_params = fleet_manager._evaluate_launch_params(batch_size, launch_overrides)
+        assert_that(launch_params).is_equal_to(expected_params)
+        if launch_overrides:
+            assert_that(caplog.text).contains("Found CreateFleet parameters override")
+
+    @pytest.mark.parametrize(
+        ("launch_params", "mocked_boto3_request", "expected_assigned_nodes"),
+        [
+            # normal - spot
+            (
+                _mocked_create_fleet_params("queue1", "fleet-spot", 1, "capacity-optimized", "spot"),
+                [
+                    MockedBoto3Request(
+                        method="create_fleet",
+                        response={"Instances": [{"InstanceIds": ["i-12345", "i-23456"]}]},
+                        expected_params=_mocked_create_fleet_params(
+                            "queue1", "fleet-spot", 1, "capacity-optimized", "spot"
+                        ),
+                    ),
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            "InstanceId": "i-12345",
+                                            "PrivateIpAddress": "ip-2",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                        {
+                                            "InstanceId": "i-23456",
+                                            "PrivateIpAddress": "ip-3",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345", "i-23456"]},
+                        generate_error=False,
+                    ),
+                ],
+                [
+                    {
+                        "InstanceId": "i-12345",
+                        "PrivateIpAddress": "ip-2",
+                        "PrivateDnsName": "hostname",
+                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                    },
+                    {
+                        "InstanceId": "i-23456",
+                        "PrivateIpAddress": "ip-3",
+                        "PrivateDnsName": "hostname",
+                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                    },
+                ],
+            ),
+            # normal - on-demand
+            (
+                _mocked_create_fleet_params("queue2", "fleet-ondemand", 1, "lowest-price", "on-demand"),
+                [
+                    MockedBoto3Request(
+                        method="create_fleet",
+                        response={"Instances": [{"InstanceIds": ["i-12345"]}]},
+                        expected_params=_mocked_create_fleet_params(
+                            "queue2", "fleet-ondemand", 1, "lowest-price", "on-demand"
+                        ),
+                    ),
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            "InstanceId": "i-12345",
+                                            "PrivateIpAddress": "ip-2",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345"]},
+                        generate_error=False,
+                    ),
+                ],
+                [
+                    {
+                        "InstanceId": "i-12345",
+                        "PrivateIpAddress": "ip-2",
+                        "PrivateDnsName": "hostname",
+                        "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                    }
+                ],
+            ),
+        ],
+        ids=["fleet_spot", "fleet_ondemand"],
+    )
+    def test_launch_instances(
+        self,
+        boto3_stubber,
+        launch_params,
+        mocked_boto3_request,
+        expected_assigned_nodes,
+        fleet_manager_factory,
+        mocker,
+    ):
+        mocker.patch("time.sleep")
+        # patch boto3 call
+        boto3_stubber("ec2", mocked_boto3_request)
+        # run test
+        fleet_manager = FleetManagerFactory.get_manager(
+            "hit", "region", "boto3_config", "config_file", "queue2", "fleet-ondemand", all_or_nothing=False
+        )
+
+        assigned_nodes = fleet_manager._launch_instances(launch_params)
+        assert_that(assigned_nodes.get("Instances", [])).is_equal_to(expected_assigned_nodes)
+
+    @pytest.mark.parametrize(
+        ("instance_ids", "mocked_boto3_request", "expected_exception", "expected_error", "expected_result"),
+        [
+            # normal - on-demand
+            (
+                ["i-12345"],
+                [
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            "InstanceId": "i-12345",
+                                            "PrivateIpAddress": "ip-2",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345"]},
+                        generate_error=False,
+                    ),
+                ],
+                False,
+                None,
+                (
+                    [
+                        {
+                            "InstanceId": "i-12345",
+                            "PrivateIpAddress": "ip-2",
+                            "PrivateDnsName": "hostname",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        },
+                    ],
+                    [],
+                ),
+            ),
+            # incomplete instance info
+            (
+                ["i-12345", "i-23456"],
+                [
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            # no private dns and address info
+                                            "InstanceId": "i-12345",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                        {
+                                            "InstanceId": "i-23456",
+                                            "PrivateIpAddress": "ip-3",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345", "i-23456"]},
+                        generate_error=False,
+                    ),
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            "InstanceId": "i-12345",
+                                            "PrivateIpAddress": "ip-2",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345"]},
+                        generate_error=False,
+                    ),
+                ],
+                False,
+                None,
+                (
+                    [
+                        {
+                            "InstanceId": "i-23456",
+                            "PrivateIpAddress": "ip-3",
+                            "PrivateDnsName": "hostname",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        },
+                        {
+                            "InstanceId": "i-12345",
+                            "PrivateIpAddress": "ip-2",
+                            "PrivateDnsName": "hostname",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        },
+                    ],
+                    [],
+                ),
+            ),
+            # too many incomplete instance info
+            (
+                ["i-12345", "i-23456"],
+                [
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            # no private dns and address info
+                                            "InstanceId": "i-12345",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                        {
+                                            "InstanceId": "i-23456",
+                                            "PrivateIpAddress": "ip-3",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345", "i-23456"]},
+                        generate_error=False,
+                    ),
+                ]
+                + 2
+                * [
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            # no private dns and address info
+                                            "InstanceId": "i-12345",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345"]},
+                        generate_error=False,
+                    ),
+                ],
+                False,
+                "Unable to retrieve instance info for instances: ['i-12345']",
+                (
+                    [
+                        {
+                            "InstanceId": "i-23456",
+                            "PrivateIpAddress": "ip-3",
+                            "PrivateDnsName": "hostname",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        },
+                    ],
+                    ["i-12345"],
+                ),
+            ),
+            # client error
+            (
+                ["i-12345"],
+                [
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={},
+                        expected_params={"InstanceIds": ["i-12345"]},
+                        generate_error=True,
+                    ),
+                ],
+                True,
+                "An error occurred .* when calling the DescribeInstances operation",
+                ([], []),
+            ),
+        ],
+        ids=["fleet_ondemand", "incomplete_instance_info", "too_many_incomplete_instance_info", "client_error"],
+    )
+    def test_get_instances_info(  # Note: some tests cases are covered by test_launch_instances too.
+        self,
+        boto3_stubber,
+        mocker,
+        fleet_manager_factory,
+        instance_ids,
+        mocked_boto3_request,
+        expected_exception,
+        expected_error,
+        expected_result,
+        caplog,
+    ):
+        # patch boto3 call
+        mocker.patch("time.sleep")
+        boto3_stubber("ec2", mocked_boto3_request)
+        # run test
+        fleet_manager = FleetManagerFactory.get_manager(
+            "hit", "region", "boto3_config", "config_file", "queue2", "fleet-ondemand", True
+        )
+
+        if expected_exception:
+            with pytest.raises(ClientError, match=expected_error):
+                fleet_manager._get_instances_info(instance_ids)
+        else:
+            complete_instances, partial_instance_ids = fleet_manager._get_instances_info(instance_ids)
+            assert_that(expected_result).is_equal_to((complete_instances, partial_instance_ids))

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -17,12 +17,12 @@ import botocore
 import pytest
 import slurm_plugin
 from assertpy import assert_that
+from slurm_plugin.fleet_manager import EC2Instance
 from slurm_plugin.instance_manager import InstanceManager
 from slurm_plugin.slurm_resources import (
     EC2_HEALTH_STATUS_UNHEALTHY_STATES,
     EC2_INSTANCE_ALIVE_STATES,
     EC2_SCHEDULED_EVENT_CODES,
-    EC2Instance,
     EC2InstanceHealthState,
 )
 

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -19,8 +19,8 @@ import botocore
 import pytest
 import slurm_plugin
 from assertpy import assert_that
+from slurm_plugin.fleet_manager import EC2Instance
 from slurm_plugin.resume import SlurmResumeConfig, _resume
-from slurm_plugin.slurm_resources import EC2Instance
 
 from tests.common import client_error
 


### PR DESCRIPTION
## Description of changes

This patch permits to call boto3 `create-fleet` API when `InstanceTypeList` is specified in the cluster configuration.
The create-fleet response just contain the instance-id list, so we need to execute an additional describe-instances call
to retrieve other information like ip address to be saved in DynamoDB.

To pass the queue/compute-resource configuration parameters to the create-fleet api I'm using the `cluster-config.yaml` file.
This file contains the settings from the user and default values (e.g. `AllocationStrategy`).

The create-fleet api can return a list of Errors,
they will be logged as errors if there are no returned instances, as warning otherwise.

### New class hierarchy: `*FleetManager`
Within this patch we're moving responsibility to launch the EC2 instances from `InstanceManager` to `*FleetManager`.
The fleet manager will be selected (`Ec2InstanceManager` - `run-instances` API vs `Ec2FleetManager` - `create-fleet` API)
according to the configuration of the given compute resource.

### Run-instances-overrides
This patch renames internal variables from `run_instances_overrides` to `launch_overrides` to clarify
the code is able to pass the overridden parameters to both the APIs.
The configuration parameter and the file has not been renamed to preserve back-word compatibility.

### All or nothing
I'm adding a basic support for All-or-nothing feature, setting `MinTargetCapacity` to 1
when all_or_nothing is not configured.
If the minimum target capacity is not reached, the fleet launches no instances,
this might differ from run-instances approach where the run-instances call fails, to be verified.

### Multi-AZ support
In the create-fleet API we're explicitly setting `SingleAvailabilityZone` to `True`, the multi-AZ support is not included.

## Tests
Manually tested by updating the node package in a running cluster and reloading clustermgtd daemon
(slurm_resume changes don't require any reload).
To test this package I had to manually modify the `cluster-config.yaml` by adding `AllocationStrategy` and `InstanceTypeList` params
and adding some required policies to the Role attached to the head node.
Required policies are: `ec2:CreateFleet`, `ec2:RunInstances`, `ec2:DescribeCapacityReservations` and `ec2:CreateTags`.
* Manually tested config file with `SpotPrice: null` and with a value of 10. In the log I see `'Overrides': [{'MaxPrice': '10', 'InstanceType': 't2.medium'}]}],` if value is set, `'Overrides': [{'InstanceType': 't2.medium'}]}],` otherwise
* TODO: integration tests

## References
* https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.create_fleet

## Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.