### PR TITLE
Use new configuration file to share compute resource info required to create fleet API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 boto3>=1.7.55
-PyYAML~=5.3  # TODO remove
 retrying~=1.3

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ console_scripts = [
     "computemgtd = slurm_plugin.computemgtd:main",
 ]
 version = "3.2.0"
-requires = ["boto3>=1.7.55", "PyYAML~=5.3", "retrying>=1.3.3"]
+requires = ["boto3>=1.7.55", "retrying>=1.3.3"]
 
 setup(
     name="aws-parallelcluster-node",

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -54,9 +54,8 @@ class InstanceManager:
         use_private_hostname=False,
         head_node_private_ip=None,
         head_node_hostname=None,
-        instance_name_type_mapping=None,
+        fleet_config=None,
         launch_overrides=None,
-        cluster_config_file=None,
     ):
         """Initialize InstanceLauncher with required attributes."""
         self._region = region
@@ -70,9 +69,8 @@ class InstanceManager:
         self._use_private_hostname = use_private_hostname
         self._head_node_private_ip = head_node_private_ip
         self._head_node_hostname = head_node_hostname
-        self._instance_name_type_mapping = instance_name_type_mapping or {}
+        self._fleet_config = fleet_config
         self._launch_overrides = launch_overrides or {}
-        self._cluster_config_file = cluster_config_file
 
     def _clear_failed_nodes(self):
         """Clear and reset failed nodes list."""
@@ -94,7 +92,7 @@ class InstanceManager:
                     self._cluster_name,
                     self._region,
                     self._boto3_config,
-                    self._cluster_config_file,
+                    self._fleet_config,
                     queue,
                     compute_resource,
                     all_or_nothing_batch,
@@ -243,8 +241,6 @@ class InstanceManager:
         for node in node_list:
             try:
                 queue_name, node_type, compute_resource_name = parse_nodename(node)
-                # In case we need to map the compute resource to the instance type
-                # instance_type = self._instance_name_type_mapping[queue_name][compute_resource_name]
                 instances_to_launch[queue_name][compute_resource_name].append(node)
             except (InvalidNodenameError, KeyError):
                 logger.warning("Discarding NodeName with invalid format: %s", node)

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -38,9 +38,9 @@ class SlurmResumeConfig:
         "hosted_zone": None,
         "dns_domain": None,
         "use_private_hostname": False,
-        "instance_type_mapping": "/opt/slurm/etc/pcluster/instance_name_type_mappings.json",  # TODO remove this file
         "run_instances_overrides": "/opt/slurm/etc/pcluster/run_instances_overrides.json",
         "cluster_config_file": "/opt/parallelcluster/shared/cluster-config.yaml",
+        "fleet_config_file": "/opt/parallelcluster/shared/fleet-config.json",
         "all_or_nothing_batch": False,
     }
 
@@ -81,10 +81,10 @@ class SlurmResumeConfig:
         self.all_or_nothing_batch = config.getboolean(
             "slurm_resume", "all_or_nothing_batch", fallback=self.DEFAULTS.get("all_or_nothing_batch")
         )
-        instance_name_type_mapping_file = config.get(
-            "slurm_resume", "instance_type_mapping", fallback=self.DEFAULTS.get("instance_type_mapping")
+        fleet_config_file = config.get(
+            "slurm_resume", "fleet_config_file", fallback=self.DEFAULTS.get("fleet_config_file")
         )
-        self.instance_name_type_mapping = read_json(instance_name_type_mapping_file)
+        self.fleet_config = read_json(fleet_config_file)
         # run_instances_overrides_file contains a json with the following format:
         # TODO generalize file name to add create-fleet support too.
         # {
@@ -172,9 +172,8 @@ def _resume(arg_nodes, resume_config):
         use_private_hostname=resume_config.use_private_hostname,
         head_node_private_ip=resume_config.head_node_private_ip,
         head_node_hostname=resume_config.head_node_hostname,
-        instance_name_type_mapping=resume_config.instance_name_type_mapping,
+        fleet_config=resume_config.fleet_config,
         launch_overrides=resume_config.launch_overrides,
-        cluster_config_file=resume_config.cluster_config_file,
     )
     instance_manager.add_instances_for_nodes(
         node_list=node_list,

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-
 from collections import namedtuple
 
 from botocore.exceptions import ClientError
@@ -30,3 +29,34 @@ def read_text(path):
 
 def client_error(error_code):
     return ClientError({"Error": {"Code": error_code}}, "failed_operation")
+
+
+FLEET_CONFIG = {
+    "queue": {"c5xlarge": {"InstanceType": "c5.xlarge"}},
+    "queue1": {
+        "c5xlarge": {"InstanceType": "c5.xlarge"},
+        "c52xlarge": {"InstanceType": "c5.2xlarge"},
+        "p4d24xlarge": {"InstanceType": "p4d.24xlarge"},
+        "fleet-spot": {
+            "InstanceTypeList": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
+            "MaxPrice": 10,
+            "AllocationStrategy": "capacity-optimized",
+            "CapacityType": "spot",
+        },
+    },
+    "queue2": {
+        "c5xlarge": {"InstanceType": "c5.xlarge"},
+        "fleet-ondemand": {
+            "InstanceTypeList": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
+            "AllocationStrategy": "lowest-price",
+            "CapacityType": "on-demand",
+        },
+    },
+    "queue3": {
+        "c5xlarge": {"InstanceType": "c5.xlarge"},
+        "c52xlarge": {"InstanceType": "c5.2xlarge"},
+        "p4d24xlarge": {"InstanceType": "p4d.24xlarge"},
+    },
+}
+
+LAUNCH_OVERRIDES = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 import boto3
 import pytest
-import slurm_plugin
 from botocore.stub import Stubber
 
 
@@ -89,60 +88,3 @@ def boto3_stubber(mocker, boto3_stubber_path):
     for stubber in created_stubbers:
         stubber.assert_no_pending_responses()
         stubber.deactivate()
-
-
-@pytest.fixture
-def fleet_manager_factory(mocker):
-    """Mock FleetManagerFactury returning a cluter config with queues/compute resources required by all the tests."""
-    return mocker.patch.object(
-        slurm_plugin.fleet_manager.FleetManagerFactory,
-        "_load_cluster_config",
-        auto_spec=True,
-        return_value={
-            "Scheduling": {
-                "SlurmQueues": [
-                    {
-                        "Name": "queue",
-                        "ComputeResources": [
-                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
-                        ],
-                    },
-                    {
-                        "Name": "queue1",
-                        "ComputeResources": [
-                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
-                            {"Name": "c52xlarge", "InstanceType": "c5.2xlarge"},
-                            {"Name": "p4d24xlarge", "InstanceType": "p4d.24xlarge"},
-                            {
-                                "Name": "fleet-spot",
-                                "InstanceTypeList": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
-                                "SpotPrice": 10,
-                            },
-                        ],
-                        "AllocationStrategy": "capacity-optimized",
-                        "CapacityType": "SPOT",
-                    },
-                    {
-                        "Name": "queue2",
-                        "ComputeResources": [
-                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
-                            {
-                                "Name": "fleet-ondemand",
-                                "InstanceTypeList": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
-                            },
-                        ],
-                        "AllocationStrategy": "lowest-price",
-                        "CapacityType": "ONDEMAND",
-                    },
-                    {
-                        "Name": "queue3",
-                        "ComputeResources": [
-                            {"Name": "c5xlarge", "InstanceType": "c5.xlarge"},
-                            {"Name": "c52xlarge", "InstanceType": "c5.2xlarge"},
-                            {"Name": "p4d24xlarge", "InstanceType": "p4d.24xlarge"},
-                        ],
-                    },
-                ]
-            }
-        },
-    )

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -26,7 +26,7 @@ from slurm_plugin.slurm_resources import (
     EC2InstanceHealthState,
 )
 
-from tests.common import MockedBoto3Request, client_error
+from tests.common import FLEET_CONFIG, MockedBoto3Request, client_error
 
 
 @pytest.fixture()
@@ -58,7 +58,7 @@ class TestInstanceManager:
             hosted_zone="hosted_zone",
             dns_domain="dns.domain",
             use_private_hostname=False,
-            instance_name_type_mapping={"c5xlarge": "c5.xlarge"},
+            fleet_config=FLEET_CONFIG,
             launch_overrides={
                 "queue3": {
                     "p4d.24xlarge": {
@@ -581,7 +581,6 @@ class TestInstanceManager:
         expected_update_nodes_calls,
         mocker,
         instance_manager,
-        fleet_manager_factory,
     ):
         mocker.patch("slurm_plugin.instance_manager.update_nodes")
 
@@ -1012,16 +1011,6 @@ class TestInstanceManager:
     def test_parse_requested_instances(
         self, node_list, expected_results, expected_failed_nodes, instance_manager, mocker
     ):
-        # Mock instance name/type mapping
-        instance_name_type_mapping = {
-            "queue1": {"c5xlarge": "c5.xlarge"},
-            "queue2": {"g34xlarge": "g3.4xlarge", "g38xlarge": "g3.8xlarge", "u6tb1metal": "u-6tb1.metal"},
-            "queuename-with-dash-and_underscore": {
-                "i3enmetal2tb": "i3en.metal-2tb",
-            },
-        }
-        instance_manager._instance_name_type_mapping = instance_name_type_mapping
-
         assert_that(instance_manager._parse_requested_instances(node_list)).is_equal_to(expected_results)
         assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
 


### PR DESCRIPTION
### Description of changes

We were using the `cluster-config.yaml` file to pass the queue/compute-resource configuration parameters
to the create-fleet api. With this patch we're using a new json configuration file.

The new `/opt/parallelcluster/shared/fleet-config.json` file contains info for all the compute resources
(both run-instances and create-fleet compute resources) and has the following structure:
```
{
    "my-create-fleet-queue": {
        "my-compute-resource": {
            "CapacityType": "on-demand|spot",
            "AllocationStrategy": "lowest-price"
            "InstanceTypeList": [
                { "InstanceType": ... }
            ],
            "MaxPrice": ...
        }
    },
    "my-run-instances-queue": {
        "my-compute-resource": {
            "CapacityType": "on-demand|spot",
            "AllocationStrategy": "lowest-price"
            "InstanceType": ...,
            "MaxPrice": ...
        }
    }
}
```
All the information are stored at compute resource level.
`Ec2CreateFleetManager`only will use them if `InstanceTypeList` is present in the compute resource.

The `pcluster_fleet_config_generator.py` in the cookbook will generate it
by moving all the required info from cluster config file.

Note: I added this json content in the `__eq__` method of the `ClustermgtdConfig` class
to be sure it is reloaded if fleet-config content changes.

#### Instance types mapping
Removed instance type mapping usage. This was used in past when we were using
sanitized instance type in the node name.
This approach has been already modified to use compute resource name instead.
This means this mapping file was useless.

### Tests
Manually tested by updating the node package in a running cluster and reloading clustermgtd daemon
(slurm_resume changes don't require any reload).

#### Integration testss
Executed a small set of tests, to be sure previous behaviour is working. We still have to add new tests using flexible instance types.

test_awsbatch[eu-west-1-c5.xlarge-alinux2-awsbatch] – schedulers.test_awsbatch
test_mpi[eu-west-1-c5.xlarge-ubuntu2004-slurm] – scaling.test_mpi
test_mpi[eu-west-1-c5.xlarge-centos7-slurm] – scaling.test_mpi
test_mpi[eu-west-1-c5.xlarge-alinux2-slurm] – scaling.test_mpi
test_mpi[eu-west-1-c5.xlarge-ubuntu1804-slurm] – scaling.test_mpi


#### Unit tests
* Added unit tests for all the error cases when parsing the configuration file.
* Added unit test to verify equality of ClustermgtdConfig according to fleet config content
* Modified read_json mocking because right now there are 2 methods calling it at Clustermtd config initialization time.
* Modified tests to use the new file format

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1505

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.