### PR TITLE
3.x Update 'black' version in pre-commit hook to v22.6.0

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 line_length=120
-known_third_party=assertpy,boto3,botocore,common,pytest,retrying,setuptools,six,slurm_plugin
+known_third_party=assertpy,boto3,botocore,common,pytest,retrying,setuptools,slurm_plugin
 # 3 - Vertical Hanging Indent
 # from third_party import (
 #     lib1,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: seed-isort-config
 
   - repo: https://github.com/ambv/black
-    rev: 22.6.0
+    rev: stable
     hooks:
       - id: black
         args: ['-l 120']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: seed-isort-config
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
       - id: black
         args: ['-l 120']


### PR DESCRIPTION
### Description of changes
* Version 20.8b1 of black was erroring out for me locally due to this bug: https://github.com/psf/black/issues/2964.
  * Set `rev` to use `stable` version.
* isort also failed when running pre-commit hooks and auto-updated its config file. 

### Tests
* Commited changes with updated version of black successfully.

### References
* [Issue](https://github.com/psf/black/issues/2964)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.