### PR TITLE
3.x Add 'InstanceLimitExceeded' and 'HostLimitExceeded' to list Fast Failover errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **ENHANCEMENTS**
 - Add support for EC2 Fleet as an alternative instance provisioning mechanism that allows greater flexibility in terms of instance diversification and launch strategy.
 
+**CHANGES**
+- Treat host or instance limit errors the same as insufficient capacity errors when launching compute resources.
+
+
 3.2.0
 ------
 

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -105,6 +105,8 @@ class SlurmNode(metaclass=ABCMeta):
         "MaxSpotInstanceCountExceeded",
         "Unsupported",
         "SpotMaxPriceTooLow",
+        "InstanceLimitExceeded",
+        "HostLimitExceeded",
     }
 
     def __init__(self, name, nodeaddr, nodehostname, state, partitions=None, reason=None, instance=None):

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -404,6 +404,28 @@ def test_slurm_node_is_power_with_job(node, expected_output):
                 "nodehostname",
                 "DOWN+CLOUD",
                 "queue1",
+                "(Code:InstanceLimitExceeded)Failure when resuming nodes",
+            ),
+            True,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD",
+                "queue1",
+                "(Code:HostLimitExceeded)Failure when resuming nodes",
+            ),
+            True,
+        ),
+        (
+            DynamicNode(
+                "queue1-dy-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD",
+                "queue1",
                 "(Code:Unsupported)Failure when resuming nodes",
             ),
             True,


### PR DESCRIPTION

### Description of changes
* This change should result in attempting to launch alternate compute resources when
account host or instance limits are reached if they are configured. This likely won't
accomplish successfully launching compute resources but should not hurt anything by
trying.

### Tests
* Added to unit tests for is_ice to test for new error codes.

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.