### PR TITLE
Do not replace DRAIN nodes when nodes are in COMPLETING state as Epilog may be still running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **ENHANCEMENTS**
 - Add support for EC2 Fleet as an alternative instance provisioning mechanism that allows greater flexibility in terms of instance diversification and launch strategy.
 
+**CHANGES**
+- Do not replace DRAIN nodes when nodes are in COMPLETING state as Epilog may be still running.
+
 3.2.0
 ------
 

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -82,7 +82,8 @@ class SlurmPartition:
 
 
 class SlurmNode(metaclass=ABCMeta):
-    SLURM_SCONTROL_BUSY_STATES = {"MIXED", "ALLOCATED", "COMPLETING"}
+    SLURM_SCONTROL_COMPLETING_STATE = "COMPLETING"
+    SLURM_SCONTROL_BUSY_STATES = {"MIXED", "ALLOCATED", SLURM_SCONTROL_COMPLETING_STATE}
     SLURM_SCONTROL_IDLE_STATE = "IDLE"
     SLURM_SCONTROL_DOWN_STATE = "DOWN"
     SLURM_SCONTROL_DRAIN_STATE = "DRAIN"
@@ -142,7 +143,15 @@ class SlurmNode(metaclass=ABCMeta):
 
         drained(sinfo) is equivalent to IDLE+DRAIN(scontrol) or DOWN+DRAIN(scontrol)
         """
-        return self._is_drain() and (self.SLURM_SCONTROL_IDLE_STATE in self.states or self.is_down())
+        return (
+            self._is_drain()
+            and (self.SLURM_SCONTROL_IDLE_STATE in self.states or self.is_down())
+            and not self.is_completing()
+        )
+
+    def is_completing(self):
+        """Check if slurm node is in COMPLETING state."""
+        return self.SLURM_SCONTROL_COMPLETING_STATE in self.states
 
     def is_power_down(self):
         """Check if slurm node is in power down state."""

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -100,6 +100,14 @@ def test_slurm_node_has_job(node, expected_output):
             StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN+REBOOT_ISSUED", "queue1"),
             True,
         ),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+DRAIN+COMPLETING", "queue1"),
+            False,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "DOWN+CLOUD+DRAIN+COMPLETING", "queue1"),
+            False,
+        ),
     ],
 )
 def test_slurm_node_is_drained(node, expected_output):


### PR DESCRIPTION
### Description of changes
* Consider drained nodes in COMPLETING state as healthy nodes, do not replace DRAIN nodes when nodes are in COMPLETING state as Epilog may be still running.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.