### PR TITLE
[FIT] Differentiate run-instances and create-fleet overrides json files

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -263,5 +263,6 @@ def read_json(file_path, default=None):
             log.error("Unable to read file from '%s'. Failed with exception: %s", file_path, e)
             raise
         else:
-            log.info("Unable to read file '%s' due to an exception: %s. Using default: %s", file_path, e, default)
+            if not isinstance(e, FileNotFoundError):
+                log.info("Unable to read file '%s' due to an exception: %s. Using default: %s", file_path, e, default)
             return default

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -126,7 +126,6 @@ class ClustermgtdConfig:
         "launch_max_batch_size": 500,
         "update_node_address": True,
         "run_instances_overrides": "/opt/slurm/etc/pcluster/run_instances_overrides.json",
-        "cluster_config_file": "/opt/parallelcluster/shared/cluster-config.yaml",
         "fleet_config_file": "/etc/parallelcluster/slurm_plugin/fleet-config.json",
         # Terminate configs
         "terminate_max_batch_size": 1000,
@@ -199,9 +198,6 @@ class ClustermgtdConfig:
         )
         self.update_node_address = config.getboolean(
             "clustermgtd", "update_node_address", fallback=self.DEFAULTS.get("update_node_address")
-        )
-        self.cluster_config_file = config.get(
-            "clustermgtd", "cluster_config_file", fallback=self.DEFAULTS.get("cluster_config_file")
         )
         fleet_config_file = config.get(
             "clustermgtd", "fleet_config_file", fallback=self.DEFAULTS.get("fleet_config_file")

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -55,7 +55,8 @@ class InstanceManager:
         head_node_private_ip=None,
         head_node_hostname=None,
         fleet_config=None,
-        launch_overrides=None,
+        run_instances_overrides=None,
+        create_fleet_overrides=None,
     ):
         """Initialize InstanceLauncher with required attributes."""
         self._region = region
@@ -70,7 +71,8 @@ class InstanceManager:
         self._head_node_private_ip = head_node_private_ip
         self._head_node_hostname = head_node_hostname
         self._fleet_config = fleet_config
-        self._launch_overrides = launch_overrides or {}
+        self._run_instances_overrides = run_instances_overrides or {}
+        self._create_fleet_overrides = create_fleet_overrides or {}
 
     def _clear_failed_nodes(self):
         """Clear and reset failed nodes list."""
@@ -96,12 +98,12 @@ class InstanceManager:
                     queue,
                     compute_resource,
                     all_or_nothing_batch,
+                    self._run_instances_overrides,
+                    self._create_fleet_overrides,
                 )
-                launch_overrides = self._launch_overrides.get(queue, {}).get(compute_resource, {})
-
                 for batch_nodes in grouper(slurm_node_list, launch_batch_size):
                     try:
-                        launched_instances = fleet_manager.launch_ec2_instances(len(batch_nodes), launch_overrides)
+                        launched_instances = fleet_manager.launch_ec2_instances(len(batch_nodes))
 
                         if update_node_address:
                             assigned_nodes = self._update_slurm_node_addrs(list(batch_nodes), launched_instances)

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -39,7 +39,6 @@ class SlurmResumeConfig:
         "dns_domain": None,
         "use_private_hostname": False,
         "run_instances_overrides": "/opt/slurm/etc/pcluster/run_instances_overrides.json",
-        "cluster_config_file": "/opt/parallelcluster/shared/cluster-config.yaml",
         "fleet_config_file": "/etc/parallelcluster/slurm_plugin/fleet-config.json",
         "all_or_nothing_batch": False,
     }
@@ -100,9 +99,6 @@ class SlurmResumeConfig:
             "slurm_resume", "run_instances_overrides", fallback=self.DEFAULTS.get("run_instances_overrides")
         )
         self.launch_overrides = read_json(run_instances_overrides_file, default={})
-        self.cluster_config_file = config.get(
-            "slurm_resume", "cluster_config_file", fallback=self.DEFAULTS.get("cluster_config_file")
-        )
         self.clustermgtd_timeout = config.getint(
             "slurm_resume",
             "clustermgtd_timeout",

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -914,7 +914,6 @@ def test_handle_unhealthy_static_nodes(
         protected_failure_count=10,
         insufficient_capacity_timeout=600,
         launch_overrides={"dynamic": {"c5.xlarge": {"InstanceType": "t2.micro"}}},
-        cluster_config_file="/path/of/config-file.yaml",
     )
     for node, instance in zip(unhealthy_static_nodes, instances):
         node.instance = instance

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -59,20 +59,8 @@ class TestInstanceManager:
             dns_domain="dns.domain",
             use_private_hostname=False,
             fleet_config=FLEET_CONFIG,
-            launch_overrides={
-                "queue3": {
-                    "p4d.24xlarge": {
-                        "CapacityReservationSpecification": {
-                            "CapacityReservationTarget": {"CapacityReservationId": "cr-123"}
-                        }
-                    },
-                    "c5.xlarge": {
-                        "CapacityReservationSpecification": {
-                            "CapacityReservationTarget": {"CapacityReservationId": "cr-456"}
-                        }
-                    },
-                },
-            },
+            run_instances_overrides={},
+            create_fleet_overrides={},
         )
         mocker.patch.object(instance_manager, "_table")
         return instance_manager

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -74,7 +74,7 @@ def boto3_stubber_path():
     ],
 )
 def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
-    mocker.patch("slurm_plugin.resume.read_json", side_effect=[FLEET_CONFIG, LAUNCH_OVERRIDES])
+    mocker.patch("slurm_plugin.resume.read_json", side_effect=[FLEET_CONFIG, LAUNCH_OVERRIDES, LAUNCH_OVERRIDES])
     resume_config = SlurmResumeConfig(test_datadir / config_file)
     for key in expected_attributes:
         assert_that(resume_config.__dict__.get(key)).is_equal_to(expected_attributes.get(key))
@@ -324,7 +324,8 @@ def test_resume_launch(
         cluster_name="hit",
         head_node_private_ip="some_ip",
         head_node_hostname="some_hostname",
-        launch_overrides={"dynamic": {"c5.xlarge": {"InstanceType": "t2.micro"}}},
+        run_instances_overrides={},
+        create_fleet_overrides={},
         fleet_config=FLEET_CONFIG,
         clustermgtd_heartbeat_file_path="some_path",
         clustermgtd_timeout=600,


### PR DESCRIPTION
### Description of changes
The two files, expected by both clustermgtd and slurm_resume daemons are:
* `/opt/slurm/etc/pcluster/run_instances_overrides.json`
* `/opt/slurm/etc/pcluster/create_fleet_overrides.json`

They will be passed to the fleet manager instance according to the API
to use for the given compute resource.

I modified the `read_json` file to avoid printing an INFO message with "exception" word
into it, when the file doesn't exist, to avoid to confuse users with this Errno/exception word.
Before of this patch we had:
```
2022-09-14 09:42:24,675 - [common.utils:read_json] - INFO - Unable to read file
'/opt/slurm/etc/pcluster/run_instances_overrides.json'
due to an exception: [Errno 2] No such file or directory:
'/opt/slurm/etc/pcluster/run_instances_overrides.json'. Using default: {}
````
Now we'll have this INFO message only when we're not able to parse the file (e.g. `JSONDecodeError`).`

Within this patch I also removed the useless cluster_config.yaml file from slurm_resume and clustermgtd config files.
This was a leftover of a previous commit on which we were using the yaml file to identify the API to use for each compute resource. We're using fleet_config_file now.

### Unit tests changes

I extended and fixed `read_json` unit tests that weren't using the files in the right folder
and they were always failing because of `FileNotFoundError`.

I added an empty override dict {} to all the read_json side effect,
because right now we are parsing 3 files rather than 2.
I also removed useless overrides content when not needed, replacing the values with {}


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.