### PR TITLE
Implement workaround for dynamic nodes stuck in bad Slurm state

### DIFF
--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -859,6 +859,18 @@ def test_slurm_node_is_bootstrap_failure(
             None,
             True,
         ),
+        # Workaround for nodes stuck in IDLE+CLOUD+COMPLETING+POWER_DOWN+NOT_RESPONDING
+        (
+            DynamicNode(
+                "queue-dy-c5xlarge-1",
+                "queue-dy-c5xlarge-1",
+                "queue-dy-c5xlarge-1",
+                "IDLE+CLOUD+COMPLETING+POWER_DOWN+NOT_RESPONDING",
+                "queue",
+            ),
+            None,
+            False,
+        ),
     ],
     ids=[
         "basic",
@@ -871,6 +883,7 @@ def test_slurm_node_is_bootstrap_failure(
         "power_unhealthy1",
         "power_unhealthy2",
         "power_healthy",
+        "dynamic_node_stuck_in_bug_state",
     ],
 )
 def test_slurm_node_is_healthy(node, instance, expected_result):


### PR DESCRIPTION
### Description of changes
* Consider all dynamic nodes in IDLE+CLOUD+COMPLETING+POWER_DOWN+NOT_RESPONDING as unhealthy.
* Fixes `test_slurm_protected_mode` integration test.

### Tests
* TBD (possibly directly on develop)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.