### PR TITLE
[develop] Fix CreateFleet output parsing

### DIFF
--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -319,7 +319,7 @@ class Ec2CreateFleetManager(FleetManager):
                 logger.log(
                     log_level,
                     "Error in CreateFleet request (%s): %s - %s",
-                    err.get("ResponseMetadata").get("RequestId"),
+                    response.get("ResponseMetadata", {}).get("RequestId"),
                     err.get("ErrorCode"),
                     err.get("ErrorMessage"),
                 )
@@ -331,7 +331,7 @@ class Ec2CreateFleetManager(FleetManager):
 
             return {"Instances": instances}
         except ClientError as e:
-            logger.error("Failed CreateFleet request: %s", e.response.get("ResponseMetadata").get("RequestId"))
+            logger.error("Failed CreateFleet request: %s", e.response.get("ResponseMetadata", {}).get("RequestId"))
             raise e
 
     def _get_instances_info(self, instance_ids: list):

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -368,7 +368,13 @@ class TestCreateFleetManager:
                 [
                     MockedBoto3Request(
                         method="create_fleet",
-                        response={"Instances": [{"InstanceIds": ["i-12345", "i-23456"]}]},
+                        response={
+                            "Instances": [{"InstanceIds": ["i-12345", "i-23456"]}],
+                            "Errors": [
+                                {"ErrorCode": "InsufficientInstanceCapacity", "ErrorMessage": "Insufficient capacity."}
+                            ],
+                            "ResponseMetadata": {"RequestId": "1234-abcde"},
+                        },
                         expected_params=_mocked_create_fleet_params(
                             "queue1", "fleet-spot", 1, "capacity-optimized", "spot"
                         ),
@@ -420,7 +426,13 @@ class TestCreateFleetManager:
                 [
                     MockedBoto3Request(
                         method="create_fleet",
-                        response={"Instances": [{"InstanceIds": ["i-12345"]}]},
+                        response={
+                            "Instances": [{"InstanceIds": ["i-12345"]}],
+                            "Errors": [
+                                {"ErrorCode": "InsufficientInstanceCapacity", "ErrorMessage": "Insufficient capacity."}
+                            ],
+                            "ResponseMetadata": {"RequestId": "1234-abcde"},
+                        },
                         expected_params=_mocked_create_fleet_params(
                             "queue2", "fleet-ondemand", 1, "lowest-price", "on-demand"
                         ),


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Fix CreateFleet output parsing because ResponseMetadata is at root level of the CreateFleet output and not inside the Errors list

### Tests
unit tested

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.