### PR TITLE
[MultiAZ] Use the SubnetId in the `fleet-config` for RunInstances-based launches

### DIFF
--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -202,6 +202,8 @@ class Ec2RunInstancesManager(FleetManager):
                 "LaunchTemplateName": f"{self._cluster_name}-{self._queue}-{self._compute_resource}",
                 "Version": "$Latest",
             },
+            # Single InstanceType Compute Resource should have only one Subnet Id
+            "SubnetId": self._compute_resource_config["Networking"]["SubnetIds"][0],
         }
 
         launch_params.update(self._launch_overrides)

--- a/tests/common.py
+++ b/tests/common.py
@@ -35,11 +35,21 @@ SINGLE_SUBNET = {"SubnetIds": ["1234567"]}
 MULTIPLE_SUBNETS = {"SubnetIds": ["1234567", "7654321"]}
 
 FLEET_CONFIG = {
-    "queue": {"c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}]}},
+    "queue": {
+        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}], "Networking": SINGLE_SUBNET}
+    },
     "queue1": {
-        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}]},
-        "c52xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.2xlarge"}]},
-        "p4d24xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "p4d.24xlarge"}]},
+        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}], "Networking": SINGLE_SUBNET},
+        "c52xlarge": {
+            "Api": "run-instances",
+            "Instances": [{"InstanceType": "c5.2xlarge"}],
+            "Networking": SINGLE_SUBNET,
+        },
+        "p4d24xlarge": {
+            "Api": "run-instances",
+            "Instances": [{"InstanceType": "p4d.24xlarge"}],
+            "Networking": SINGLE_SUBNET,
+        },
         "fleet-spot": {
             "Api": "create-fleet",
             "Instances": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
@@ -50,7 +60,7 @@ FLEET_CONFIG = {
         },
     },
     "queue2": {
-        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}]},
+        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}], "Networking": SINGLE_SUBNET},
         "fleet-ondemand": {
             "Api": "create-fleet",
             "Instances": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
@@ -60,12 +70,20 @@ FLEET_CONFIG = {
         },
     },
     "queue3": {
-        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}]},
-        "c52xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.2xlarge"}]},
-        "p4d24xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "p4d.24xlarge"}]},
+        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}], "Networking": SINGLE_SUBNET},
+        "c52xlarge": {
+            "Api": "run-instances",
+            "Instances": [{"InstanceType": "c5.2xlarge"}],
+            "Networking": SINGLE_SUBNET,
+        },
+        "p4d24xlarge": {
+            "Api": "run-instances",
+            "Instances": [{"InstanceType": "p4d.24xlarge"}],
+            "Networking": SINGLE_SUBNET,
+        },
     },
     "queue4": {
-        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}]},
+        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}], "Networking": SINGLE_SUBNET},
         "fleet1": {
             "Api": "create-fleet",
             "Instances": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
@@ -75,7 +93,7 @@ FLEET_CONFIG = {
         },
     },
     "queue5": {
-        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}]},
+        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}], "Networking": SINGLE_SUBNET},
         "fleet1": {
             "Api": "create-fleet",
             "Instances": [{"InstanceType": "t2.medium"}],
@@ -85,7 +103,7 @@ FLEET_CONFIG = {
         },
     },
     "queue6": {
-        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}]},
+        "c5xlarge": {"Api": "run-instances", "Instances": [{"InstanceType": "c5.xlarge"}], "Networking": SINGLE_SUBNET},
         "fleet1": {
             "Api": "create-fleet",
             "Instances": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -88,6 +88,7 @@ class TestEc2RunInstancesManager:
                         "LaunchTemplateName": "hit-queue1-p4d24xlarge",
                         "Version": "$Latest",
                     },
+                    "SubnetId": "1234567",
                 },
             ),
             (
@@ -102,6 +103,7 @@ class TestEc2RunInstancesManager:
                         "LaunchTemplateName": "hit-queue1-c5xlarge",
                         "Version": "$Latest",
                     },
+                    "SubnetId": "1234567",
                 },
             ),
             (
@@ -124,6 +126,7 @@ class TestEc2RunInstancesManager:
                         "LaunchTemplateName": "hit-queue1-p4d24xlarge",
                         "Version": "$Latest",
                     },
+                    "SubnetId": "1234567",
                     "CapacityReservationSpecification": {
                         "CapacityReservationTarget": {"CapacityReservationId": "cr-12345"}
                     },


### PR DESCRIPTION
### Description of changes
* The SubnetIds used by each compute resource are included in the `fleet-config` file. This covers both CreateFleet and RunInstances API
* Instead of setting the SubnetId in the Launch Template (CLI) during cluster creation, the SubnetId can be read from
the `fleet-config` file and passed as parameters for the RunInstances call.
* [Impacted open issues](https://github.com/aws/aws-parallelcluster/pull/4521/#discussion_r1019071770)

### Tests
* Automated tests checking if the SubnetId is included in the launch params for RunInstances calls

### References
* [Include SubnetID only when using RunInstances API #4521](https://github.com/aws/aws-parallelcluster/pull/4521/)
* [EC2.Client.run_instances](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.run_instances)

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.