### PR TITLE
[Versioning] Bump version to 3.4.0b1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ console_scripts = [
     "clustermgtd = slurm_plugin.clustermgtd:main",
     "computemgtd = slurm_plugin.computemgtd:main",
 ]
-version = "3.3.0"
+version = "3.4.0b1"
 requires = ["boto3>=1.7.55", "retrying>=1.3.3"]
 
 setup(


### PR DESCRIPTION
### Description of changes
Version bumped to `3.4.0b1`.
Changes have been generated by the dedicated version bumping script.

### Tests
Not needed since the version bump is executed via the dedicated version bumping script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>