### PR TITLE
[MultiAZ] Log a warning when using multiple AZs and InstanceTypes while all-or-nothing is enabled.

### DIFF
--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -286,6 +286,12 @@ class Ec2CreateFleetManager(FleetManager):
                 # If the minimum target capacity is not reached, the fleet launches no instances
                 common_launch_options.update({"MinTargetCapacity": count if self._all_or_nothing else 1})
 
+            if not self._uses_single_az() and not self._uses_single_instance_type() and self._all_or_nothing:
+                logger.warning(
+                    "All-or-Nothing is only available with single instance type compute resources or "
+                    "single subnet queues"
+                )
+
             if self._compute_resource_config["CapacityType"] == "spot":
                 launch_options = {"SpotOptions": common_launch_options}
             else:

--- a/tests/slurm_plugin/test_fleet_manager/TestCreateFleetManager/test_evaluate_launch_params/fleet-multi-az-multi-it-all_or_nothing/expected_launch_params.json
+++ b/tests/slurm_plugin/test_fleet_manager/TestCreateFleetManager/test_evaluate_launch_params/fleet-multi-az-multi-it-all_or_nothing/expected_launch_params.json
@@ -1,0 +1,41 @@
+{
+  "LaunchTemplateConfigs": [
+    {
+      "LaunchTemplateSpecification": {
+        "LaunchTemplateName": "hit-queue6-fleet1",
+        "Version": "$Latest"
+      },
+      "Overrides": [
+        {
+          "InstanceType": "t2.medium",
+          "SubnetId": "1234567"
+        },
+        {
+          "InstanceType": "t2.medium",
+          "SubnetId": "7654321"
+        },
+        {
+          "InstanceType": "t2.large",
+          "SubnetId": "1234567"
+        },
+        {
+          "InstanceType": "t2.large",
+          "SubnetId": "7654321"
+        }
+      ]
+    }
+  ],
+  "OnDemandOptions": {
+    "AllocationStrategy": "lowest-price",
+    "SingleInstanceType": false,
+    "SingleAvailabilityZone": false,
+    "CapacityReservationOptions": {
+      "UsageStrategy": "use-capacity-reservations-first"
+    }
+  },
+  "TargetCapacitySpecification": {
+    "TotalTargetCapacity": 5,
+    "DefaultTargetCapacityType": "on-demand"
+  },
+  "Type": "instant"
+}


### PR DESCRIPTION
### Description of changes
* MinTargetCapacity is currently used for [All-Or-Nothing behaviour](https://github.com/aws/aws-parallelcluster/wiki/Configuring-all_or_nothing_batch-launches) when using Multiple Instance Types
* MinTargetCapacity however does not work when using Multiple Subnets and Multiple instance Types at the same time
* 

### Tests
* Unit test to check logging occurs when using Multiple Subnets and Multiple instance Types
* Manually created a cluster and followed [All-Or-Nothing](https://github.com/aws/aws-parallelcluster/wiki/Configuring-all_or_nothing_batch-launches) usage instructions

### References
* [Configuring-all_or_nothing_batch-launches](https://github.com/aws/aws-parallelcluster/wiki/Configuring-all_or_nothing_batch-launches)

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.