### PR TITLE
3.x Fix tox.ini to adhere to tox INI rules

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist =
 
 # Default testenv. Used to run tests on all python versions.
 [testenv]
-passenv = CI GITHUB_*
+passenv =
+    CI
+    GITHUB_*
 usedevelop =
     cov: true
     nocov: false


### PR DESCRIPTION
### Description of changes
* Tox [updated format](https://tox.wiki/en/latest/faq.html#tox-4-changed-ini-rules) for passevent rule in INI file
* Mirror fix from this [commit](https://github.com/aws/aws-parallelcluster/commit/93521562197129490c1b75007ed9eb263afc7000) in aws-parallelcluster.

### References
* [Wiki Entry](https://tox.wiki/en/latest/faq.html#tox-4-changed-ini-rules) for changed tox.ini rules.
* [Commit](https://github.com/aws/aws-parallelcluster/commit/93521562197129490c1b75007ed9eb263afc7000) for aws-parallelcluster.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.