### PR TITLE
Add check to prevent security exclusions in code

### DIFF
--- a/.github/workflows/security_exclusions_checker.yml
+++ b/.github/workflows/security_exclusions_checker.yml
@@ -1,0 +1,15 @@
+name: Security Exclusions Checker
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Prevent security exclusions
+  security-exclusions-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check PR
+      uses: francesco-giordano/gh-pr-content-checker@v1.0.0
+      with:
+        diffDoesNotContainRegex: "\\bnosec\\b|\\bnosemgrep\\b"
+        skipLabels: skip-security-exclusions-check

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist =
 
 # Default testenv. Used to run tests on all python versions.
 [testenv]
-passenv = CI GITHUB_*
+passenv =
+    CI
+    GITHUB_*
 usedevelop =
     cov: true
     nocov: false


### PR DESCRIPTION
### Description of changes
* This pr add a github action to check the presence of `nosec` and `nosemgrep `
* The GitHub action can be skipped with the label `skip-security-exclusions-check`
* Added fix in tox.ini file to comply with INI rules,

### Tests
* Check the action from this PR
* test [PR](https://github.com/aws/aws-parallelcluster/pull/4684)
* [Failed action](https://github.com/aws/aws-parallelcluster/actions/runs/3686760199/jobs/6239493058)
* [Skip action](https://github.com/aws/aws-parallelcluster/actions/runs/3686768735/jobs/6239491487)

### References
* https://github.com/francesco-giordano/gh-pr-content-checker
* https://github.com/tox-dev/tox/commit/f4840a034c936ca28239f2036f13e5dbbe57e14f
* https://tox.wiki/en/latest/faq.html#tox-4-changed-ini-rules
* https://github.com/tox-dev/tox/issues/2676

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
