### PR TITLE
3.x Remove checks against Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.7 Tests
-          - Python 3.8 Tests
           - Python 3.9 Tests
           - Python 3.9 Tests Coverage
           - Code Checks
         include:
-          - name: Python 3.7 Tests
-            python: 3.7
-            toxenv: py37-nocov
-          - name: Python 3.8 Tests
-            python: 3.8
-            toxenv: py38-nocov
           - name: Python 3.9 Tests
             python: 3.9
             toxdir: cli
@@ -47,7 +39,7 @@ jobs:
             toxdir: cli
             toxenv: py39-cov
           - name: Code Checks
-            python: 3.7
+            python: 3.9
             toxdir: cli
             toxenv: code-linters
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         os: [ubuntu-latest]
         name:
           - Python 3.9 Tests
+          - Python 3.10 Tests
           - Python 3.9 Tests Coverage
           - Code Checks
         include:
@@ -34,6 +35,10 @@ jobs:
             python: 3.9
             toxdir: cli
             toxenv: py39-nocov
+          - name: Python 3.10 Tests
+            python: '3.10'
+            toxdir: cli
+            toxenv: py310-nocov
           - name: Python 3.9 Tests Coverage
             python: 3.9
             toxdir: cli

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache License 2.0",
     packages=find_packages("src", exclude=["tests"]),
     package_dir={"": "src"},
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=requires,
     entry_points=dict(console_scripts=console_scripts),
     zip_safe=False,

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -516,7 +516,7 @@ def test_update_partitions(
     partitions, state, run_command_calls, run_command_side_effects, expected_succeeded_partitions, mocker
 ):
     run_command_spy = mocker.patch(
-        "common.schedulers.slurm_commands.run_command", side_effect=run_command_side_effects, auto_spec=True
+        "common.schedulers.slurm_commands.run_command", side_effect=run_command_side_effects, autospec=True
     )
     assert_that(update_partitions(partitions, state)).is_equal_to(expected_succeeded_partitions)
     if run_command_calls:
@@ -611,12 +611,12 @@ def test_update_all_partitions(
     expected_results,
     mocker,
 ):
-    set_nodes_power_down_spy = mocker.patch("common.schedulers.slurm_commands.set_nodes_power_down", auto_spec=True)
+    set_nodes_power_down_spy = mocker.patch("common.schedulers.slurm_commands.set_nodes_power_down", autospec=True)
     update_partitions_spy = mocker.patch(
-        "common.schedulers.slurm_commands.update_partitions", return_value=mock_succeeded_partitions, auto_spec=True
+        "common.schedulers.slurm_commands.update_partitions", return_value=mock_succeeded_partitions, autospec=True
     )
     get_part_spy = mocker.patch(
-        "common.schedulers.slurm_commands.get_partition_info", return_value=mock_partitions, auto_spec=True
+        "common.schedulers.slurm_commands.get_partition_info", return_value=mock_partitions, autospec=True
     )
     assert_that(update_all_partitions(state, reset_node_addrs_hostname=reset_node_info)).is_equal_to(expected_results)
     get_part_spy.assert_called_with(get_all_nodes=True)
@@ -628,8 +628,8 @@ def test_update_all_partitions(
 
 
 def test_resume_powering_down_nodes(mocker):
-    get_slurm_nodes_mocked = mocker.patch("common.schedulers.slurm_commands._get_slurm_nodes", auto_spec=True)
-    update_nodes_mocked = mocker.patch("common.schedulers.slurm_commands.update_nodes", auto_spec=True)
+    get_slurm_nodes_mocked = mocker.patch("common.schedulers.slurm_commands._get_slurm_nodes", autospec=True)
+    update_nodes_mocked = mocker.patch("common.schedulers.slurm_commands.update_nodes", autospec=True)
 
     resume_powering_down_nodes()
     get_slurm_nodes_mocked.assert_called_with(states="powering_down")
@@ -644,7 +644,7 @@ def test_resume_powering_down_nodes(mocker):
     ],
 )
 def test_get_slurm_nodes(mocker, states, partition_name, expected_command):
-    check_command_output_mocked = mocker.patch("common.schedulers.slurm_commands.check_command_output", auto_spec=True)
+    check_command_output_mocked = mocker.patch("common.schedulers.slurm_commands.check_command_output", autospec=True)
 
     _get_slurm_nodes(states=states, partition_name=partition_name, command_timeout=10)
     check_command_output_mocked.assert_called_with(expected_command, timeout=10, shell=True)

--- a/tests/slurm_plugin/test_fleet_status_manager.py
+++ b/tests/slurm_plugin/test_fleet_status_manager.py
@@ -12,6 +12,7 @@
 
 import os
 from types import SimpleNamespace
+from unittest.mock import ANY
 
 import botocore
 import pytest
@@ -146,7 +147,7 @@ def test_stop_partitions(mocker):
     update_all_partitions_mocked = mocker.patch("slurm_plugin.fleet_status_manager.update_all_partitions")
 
     terminate_all_compute_nodes_mocked = mocker.patch.object(
-        slurm_plugin.instance_manager.InstanceManager, "terminate_all_compute_nodes", auto_spec=True
+        slurm_plugin.instance_manager.InstanceManager, "terminate_all_compute_nodes", autospec=True
     )
 
     # method to test
@@ -154,4 +155,4 @@ def test_stop_partitions(mocker):
 
     # assertions
     update_all_partitions_mocked.assert_called_once_with(PartitionStatus.INACTIVE, reset_node_addrs_hostname=True)
-    terminate_all_compute_nodes_mocked.assert_called_once_with(config.terminate_max_batch_size)
+    terminate_all_compute_nodes_mocked.assert_called_once_with(ANY, config.terminate_max_batch_size)

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -13,7 +13,7 @@
 import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import call
+from unittest.mock import ANY, call
 
 import botocore
 import pytest
@@ -334,19 +334,17 @@ def test_resume_launch(
         dns_domain=None,
         use_private_hostname=False,
     )
-    mocker.patch("slurm_plugin.resume.is_clustermgtd_heartbeat_valid", auto_spec=True, return_value=is_heartbeat_valid)
-    mock_handle_failed_nodes = mocker.patch("slurm_plugin.resume._handle_failed_nodes", auto_spec=True)
+    mocker.patch("slurm_plugin.resume.is_clustermgtd_heartbeat_valid", autospec=True, return_value=is_heartbeat_valid)
+    mock_handle_failed_nodes = mocker.patch("slurm_plugin.resume._handle_failed_nodes", autospec=True)
     # patch slurm calls
-    mock_update_nodes = mocker.patch("slurm_plugin.instance_manager.update_nodes", auto_spec=True)
-    mock_get_node_info = mocker.patch(
-        "slurm_plugin.resume.get_nodes_info", return_value=mock_node_lists, auto_spec=True
-    )
+    mock_update_nodes = mocker.patch("slurm_plugin.instance_manager.update_nodes", autospec=True)
+    mock_get_node_info = mocker.patch("slurm_plugin.resume.get_nodes_info", return_value=mock_node_lists, autospec=True)
     # patch DNS related functions
     mock_store_hostname = mocker.patch.object(
-        slurm_plugin.instance_manager.InstanceManager, "_store_assigned_hostnames", auto_spec=True
+        slurm_plugin.instance_manager.InstanceManager, "_store_assigned_hostnames", autospec=True
     )
     mock_update_dns = mocker.patch.object(
-        slurm_plugin.instance_manager.InstanceManager, "_update_dns_hostnames", auto_spec=True
+        slurm_plugin.instance_manager.InstanceManager, "_update_dns_hostnames", autospec=True
     )
 
     # Only mock fleet manager if testing case of valid clustermgtd heartbeat
@@ -376,5 +374,5 @@ def test_resume_launch(
         if expected_update_node_calls:
             mock_update_nodes.assert_has_calls(expected_update_node_calls)
         if expected_assigned_nodes:
-            mock_store_hostname.assert_called_with(expected_assigned_nodes)
-            mock_update_dns.assert_called_with(expected_assigned_nodes)
+            mock_store_hostname.assert_called_with(ANY, expected_assigned_nodes)
+            mock_update_dns.assert_called_with(ANY, expected_assigned_nodes)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38}-cov
+    py{39}-cov
     code-linters
 
 # Default testenv. Used to run tests on all python versions.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39}-cov
+    py{39,310}-cov
     code-linters
 
 # Default testenv. Used to run tests on all python versions.


### PR DESCRIPTION
### Description of changes
* This change removes testing python components against 3.7 and 3.8
*  It should no longer be necessary to test against these versions and the node components are installed and run in a Python 3.9 virtual environment.
* Testing on 3.7 and 3.8 keeps us from using features that are only supported in 3.9 and above.
* Added testing for v3.10.
* Fixed unit tests that failed when run against 3.10.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.