### PR TITLE
[develop] Removed skip rule for finding B105 from the bandit conf

### DIFF
--- a/.bandit.ini
+++ b/.bandit.ini
@@ -1,5 +1,3 @@
-# B105 checks for potentially hard-coded passwords/API tokens.
-# It's disabled because it seems to have a high rate of false failures.
 # B404 checks for imports of the subprocess module.
 # It's disabled because we make use of that module.
-skips: ['B105', 'B404']
+skips: ['B404']


### PR DESCRIPTION
### Description of changes
Removed skip rule for the finding B105 from the bandit conf since this package has not hard-coded passwords/API tokens.

### Tests
* Manually launched tox suite.

### References
* Bandit configuration [exclusion documentation](https://bandit.readthedocs.io/en/latest/config.html#exclusions)

### Checklist
- [X ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.