### PR TITLE
Move security exclusion from .bandit.ini to the corresponding code line

### DIFF
--- a/.bandit.ini
+++ b/.bandit.ini
@@ -1,3 +1,1 @@
-# B404 checks for imports of the subprocess module.
-# It's disabled because we make use of that module.
-skips: ['B404']
+skips: []

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,4 @@ known_third_party=assertpy,boto3,botocore,common,pytest,retrying,setuptools,slur
 # )
 multi_line_output=3
 include_trailing_comma=true
+profile=black

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -20,7 +20,7 @@ import shlex
 
 # A nosec comment is appended to the following line in order to disable the B404 check.
 # In this file the input of the module subprocess is trusted.
-import subprocess  # nosec
+import subprocess  # nosec B404
 import sys
 import time
 from datetime import datetime, timezone

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -9,6 +9,7 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+
 import collections
 import itertools
 import json

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -16,7 +16,10 @@ import logging
 import os
 import pwd
 import shlex
-import subprocess
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess  # nosec
 import sys
 import time
 from datetime import datetime, timezone

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -21,7 +21,7 @@ from logging.config import fileConfig
 
 # A nosec comment is appended to the following line in order to disable the B404 check.
 # In this file the input of the module subprocess is trusted.
-from subprocess import CalledProcessError  # nosec
+from subprocess import CalledProcessError  # nosec B404
 from typing import Dict, List
 
 from botocore.config import Config

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -18,7 +18,10 @@ from configparser import ConfigParser
 from datetime import datetime, timezone
 from enum import Enum
 from logging.config import fileConfig
-from subprocess import CalledProcessError
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+from subprocess import CalledProcessError  # nosec
 from typing import Dict, List
 
 from botocore.config import Config

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -9,7 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import logging
 import os
 import time

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -17,7 +17,10 @@ from configparser import ConfigParser
 from datetime import datetime, timezone
 from io import StringIO
 from logging.config import fileConfig
-from subprocess import CalledProcessError
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+from subprocess import CalledProcessError  # nosec
 
 from botocore.config import Config
 from common.schedulers.slurm_commands import get_nodes_info

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -19,7 +19,7 @@ from logging.config import fileConfig
 
 # A nosec comment is appended to the following line in order to disable the B404 check.
 # In this file the input of the module subprocess is trusted.
-from subprocess import CalledProcessError  # nosec
+from subprocess import CalledProcessError  # nosec B404
 
 from botocore.config import Config
 from common.schedulers.slurm_commands import get_nodes_info

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -14,7 +14,7 @@ import logging
 
 # A nosec comment is appended to the following line in order to disable the B404 check.
 # In this file the input of the module subprocess is trusted.
-import subprocess  # nosec
+import subprocess  # nosec B404
 
 import boto3
 from botocore.config import Config

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -10,7 +10,10 @@
 # limitations under the License.
 import collections
 import logging
-import subprocess
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess  # nosec
 
 import boto3
 from botocore.config import Config

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+
 import collections
 import logging
 


### PR DESCRIPTION
### Description of changes
* Move security exclusion from .bandit.ini to the corresponding code line. This change aims to avoid global security exclusions.
* The security exclusions added by this PR will be assessed as part of another PR.
* Added the label skip-security-exclusions-check since now the checks are more precise.
* Also added `profile=black` in isort.cfg to avoid clashing between isort and black8


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
