### PR TITLE
Sort nodename, nodeaddrs, nodehostnames when doing scontrol update

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -122,7 +122,7 @@ def update_nodes(
 
 
 def _sort_nodes_attributes(nodes, nodeaddrs, nodehostnames):
-    nodes_str = ",".join(nodes) if type(nodes) is tuple else nodes
+    nodes_str = ",".join(nodes)
     sorted_node_names_str = check_command_output(
         f"{SCONTROL} show hostlistsorted {nodes_str} | xargs {SCONTROL} show hostnames", shell=True
     )

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -108,6 +108,9 @@ def update_nodes(
         if nodeaddrs or nodehostnames:
             # Sorting is only necessary if we set nodeaddrs or nodehostnames
             nodenames, addrs, hostnames = _sort_nodes_attributes(nodenames_, addrs_, hostnames_)
+        else:
+            nodenames = nodenames_
+            addrs = hostnames = None
         node_info = f"nodename={','.join(nodenames)}"
         if addrs:
             node_info += f" nodeaddr={','.join(addrs)}"

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -123,7 +123,7 @@ def update_nodes(
 
 def _sort_nodes_attributes(nodes, nodeaddrs, nodehostnames):
     nodes_str = ",".join(nodes)
-    sorted_node_names_str = check_command_output(
+    sorted_node_names_str = check_command_output(  # nosec
         f"{SCONTROL} show hostlistsorted {nodes_str} | xargs {SCONTROL} show hostnames", shell=True
     )
     sorted_node_names = sorted_node_names_str.strip().split("\n")
@@ -133,7 +133,10 @@ def _sort_nodes_attributes(nodes, nodeaddrs, nodehostnames):
     else:
         # Path from _update_slurm_node_addrs
         order = {k: i for i, k in enumerate(sorted_node_names)}
-        sorting_key = lambda x: order[x[0]]
+
+        def sorting_key(x):
+            return order[x[0]]
+
         if nodeaddrs and nodehostnames:
             _, nodeaddrs, nodehostnames = zip(*sorted(zip(nodes, nodeaddrs, nodehostnames), key=sorting_key))
         elif nodeaddrs:

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -105,7 +105,7 @@ def update_nodes(
     if reason:
         update_cmd += f' reason="{reason}"'
     for nodenames_, addrs_, hostnames_ in batched_node_info:
-        if nodeaddrs or nodehostnames:
+        if addrs_ or hostnames_:
             # Sorting is only necessary if we set nodeaddrs or nodehostnames
             nodenames, addrs, hostnames = _sort_nodes_attributes(nodenames_, addrs_, hostnames_)
         else:

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -234,6 +234,16 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output, caplog):
             2,
             ValueError,
         ),
+        (
+            # FIXME: This is a legit combination for slurm update, but our current batching
+            ## logic cannot handle it. We should review the batching logic so that this
+            ## scenario does not fail.
+            "queue1-st-c5xlarge-[1-2],queue1-st-c5xlarge-3",
+            "nodeaddr-1,nodeaddr-2,nodeaddr-3",
+            "nodehostname-[1-3]",
+            2,
+            ValueError,
+        ),
     ],
     ids=[
         "nodename_only",
@@ -244,6 +254,7 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output, caplog):
         "incorrect_addr2",
         "mixed_format",
         "same_length_string",
+        "strings_different_groupings",
     ],
 )
 def test_batch_node_info(nodenames, nodeaddrs, hostnames, batch_size, expected_result):

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -166,7 +166,7 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output, caplog):
             None,
             None,
             2,
-            [("queue1-st-c5xlarge-1,queue1-st-c5xlarge-2,queue1-st-c5xlarge-3", None, None)],
+            [(("queue1-st-c5xlarge-1,queue1-st-c5xlarge-2,queue1-st-c5xlarge-3",), None, None)],
         ),
         (
             # Only split on commas after bucket
@@ -177,8 +177,8 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output, caplog):
             2,
             [
                 (
-                    "queue1-st-c5xlarge-[1-2],queue1-st-c5xlarge-2,queue1-st-c5xlarge-3,queue1-st-c5xlarge-[4,6]",
-                    "nodeaddr-[1-2],nodeaddr-2,nodeaddr-3,nodeaddr-[4,6]",
+                    ("queue1-st-c5xlarge-[1-2]", "queue1-st-c5xlarge-2,queue1-st-c5xlarge-3,queue1-st-c5xlarge-[4,6]"),
+                    ("nodeaddr-[1-2]", "nodeaddr-2,nodeaddr-3,nodeaddr-[4,6]"),
                     None,
                 )
             ],
@@ -190,11 +190,11 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output, caplog):
             2,
             [
                 (
-                    "queue1-st-c5xlarge-[1-2],queue1-st-c5xlarge-2,queue1-st-c5xlarge-[3]",
-                    "nodeaddr-[1-2],nodeaddr-2,nodeaddr-[3]",
-                    "nodehostname-[1-2],nodehostname-2,nodehostname-[3]",
+                    ("queue1-st-c5xlarge-[1-2]", "queue1-st-c5xlarge-2,queue1-st-c5xlarge-[3]"),
+                    ("nodeaddr-[1-2]", "nodeaddr-2,nodeaddr-[3]"),
+                    ("nodehostname-[1-2]", "nodehostname-2,nodehostname-[3]"),
                 ),
-                ("queue1-st-c5xlarge-[4,6]", "nodeaddr-[4,6]", "nodehostname-[4,6]"),
+                (("queue1-st-c5xlarge-[4,6]",), ("nodeaddr-[4,6]",), ("nodehostname-[4,6]",)),
             ],
         ),
         ("queue1-st-c5xlarge-1,queue1-st-c5xlarge-[2],queue1-st-c5xlarge-3", ["nodeaddr-1"], None, 2, ValueError),
@@ -219,11 +219,11 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output, caplog):
             2,
             [
                 (
-                    "queue1-st-c5xlarge-1,queue1-st-c5xlarge-2",
-                    "nodeaddr-[1],nodeaddr-[2]",
-                    "nodehostname-1,nodehostname-2",
+                    ("queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"),
+                    ("nodeaddr-[1]", "nodeaddr-[2]"),
+                    ("nodehostname-1", "nodehostname-2"),
                 ),
-                ("queue1-st-c5xlarge-3", "nodeaddr-3", "nodehostname-3"),
+                (("queue1-st-c5xlarge-3",), ("nodeaddr-3",), ("nodehostname-3",)),
             ],
         ),
         (

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -236,8 +236,8 @@ def test_parse_nodes_info(node_info, expected_parsed_nodes_output, caplog):
         ),
         (
             # FIXME: This is a legit combination for slurm update, but our current batching
-            ## logic cannot handle it. We should review the batching logic so that this
-            ## scenario does not fail.
+            # logic cannot handle it. We should review the batching logic so that this
+            # scenario does not fail.
             "queue1-st-c5xlarge-[1-2],queue1-st-c5xlarge-3",
             "nodeaddr-1,nodeaddr-2,nodeaddr-3",
             "nodehostname-[1-3]",
@@ -463,7 +463,7 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                 call(
                     (
                         'sudo /opt/slurm/bin/scontrol update state=down reason="debugging"'
-                        + " nodename=queue1-st-c5xlarge-1 nodehostname=hostname-1"
+                        " nodename=queue1-st-c5xlarge-1 nodehostname=hostname-1"
                     ),
                     raise_on_error=True,
                     timeout=60,
@@ -472,7 +472,10 @@ def test_set_nodes_drain(nodes, reason, reset_addrs, update_call_kwargs, mocker)
                 call(
                     (
                         'sudo /opt/slurm/bin/scontrol update state=down reason="debugging"'
-                        + " nodename=queue1-st-c5xlarge-3,queue1-st-c5xlarge-4,queue1-st-c5xlarge-5,queue1-st-c5xlarge-6 nodeaddr=queue1-st-c5xlarge-3,queue1-st-c5xlarge-4,queue1-st-c5xlarge-5,queue1-st-c5xlarge-6 nodehostname=queue1-st-c5xlarge-3,queue1-st-c5xlarge-4,queue1-st-c5xlarge-5,queue1-st-c5xlarge-6"
+                        " nodename=queue1-st-c5xlarge-3,queue1-st-c5xlarge-4,queue1-st-c5xlarge-5,"
+                        "queue1-st-c5xlarge-6 nodeaddr=queue1-st-c5xlarge-3,queue1-st-c5xlarge-4,queue1-st-c5xlarge-5,"
+                        "queue1-st-c5xlarge-6 nodehostname=queue1-st-c5xlarge-3,queue1-st-c5xlarge-4,"
+                        "queue1-st-c5xlarge-5,queue1-st-c5xlarge-6"
                     ),
                     raise_on_error=True,
                     timeout=60,

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1452,7 +1452,7 @@ def test_manage_cluster(
 
 @pytest.mark.parametrize(
     (
-        "config_file, mocked_active_nodes, mocked_inactive_nodes, mocked_check_command_output, mocked_boto3_request, "
+        "config_file, mocked_active_nodes, mocked_inactive_nodes, mocked_boto3_request, "
         "launched_instances, expected_error_messages"
     ),
     [
@@ -1475,7 +1475,6 @@ def test_manage_cluster(
                 StaticNode("queue-st-c5xlarge-4", "ip-4", "hostname", "IDLE+CLOUD", "queue2"),
                 DynamicNode("queue-dy-c5xlarge-5", "ip-5", "hostname", "DOWN+CLOUD", "queue2"),
             ],
-            "queue-st-c5xlarge-4\nqueue-dy-c5xlarge-5",
             [
                 # _get_ec2_instances: get all cluster instances by tags
                 MockedBoto3Request(
@@ -1621,7 +1620,6 @@ def test_manage_cluster(
                 StaticNode("queue-st-c5xlarge-4", "ip-4", "hostname", "IDLE+CLOUD", "queue2"),
                 DynamicNode("queue-dy-c5xlarge-5", "ip-5", "hostname", "DOWN+CLOUD", "queue2"),
             ],
-            "queue-st-c5xlarge-4\nqueue-dy-c5xlarge-5",
             [
                 # _get_ec2_instances: get all cluster instances by tags
                 # Not producing failure here so logic after can be executed
@@ -1793,7 +1791,6 @@ def test_manage_cluster(
                 StaticNode("queue-st-c5xlarge-4", "ip-4", "hostname", "IDLE+CLOUD", "queue2"),
                 DynamicNode("queue-dy-c5xlarge-5", "ip-5", "hostname", "DOWN+CLOUD", "queue2"),
             ],
-            "queue-st-c5xlarge-4\nqueue-dy-c5xlarge-5",
             [
                 # _get_ec2_instances: get all cluster instances by tags
                 # Produce an error, cluster should be able to handle exception and skip other actions
@@ -1824,7 +1821,6 @@ def test_manage_cluster(
             Exception,
             Exception,
             [],
-            [],
             [{}],
             ["Unable to get partition/node info from slurm, no other action can be performed"],
         ),
@@ -1836,7 +1832,6 @@ def test_manage_cluster_boto3(
     config_file,
     mocked_active_nodes,
     mocked_inactive_nodes,
-    mocked_check_command_output,
     mocked_boto3_request,
     launched_instances,
     expected_error_messages,
@@ -1857,7 +1852,14 @@ def test_manage_cluster_boto3(
     cluster_manager = ClusterManager(sync_config)
     check_command_output_mocked = mocker.patch("slurm_plugin.clustermgtd.check_command_output")
     check_command_output_mocked.return_value = '{"status": "RUNNING"}'
-    mocker.patch("common.schedulers.slurm_commands.check_command_output", return_value=mocked_check_command_output)
+    mocker.patch(
+        "common.schedulers.slurm_commands.check_command_output",
+        side_effect=lambda x, shell=False: "\n".join(
+            x.replace("sudo /opt/slurm/bin/scontrol show hostlistsorted ", "")
+            .replace(" | xargs sudo /opt/slurm/bin/scontrol show hostnames", "")
+            .split(",")
+        ),
+    )
     mocker.patch.object(cluster_manager, "_write_timestamp_to_file", auto_spec=True)
     part_active = SlurmPartition("queue1", "placeholder_nodes", "UP")
     part_active.slurm_nodes = mocked_active_nodes


### PR DESCRIPTION
### Description of changes
* `update_nodes` function is called from multiple places. What we care about is the callings with nodeaddrs or nodehostnames. Moreover, we only apply the sort when there is nodeaddrs or nodehostnames
* There are two calling places with nodeaddrs or nodehostnames: `reset_nodes` and `_update_slurm_node_addrs`
* In `reset_nodes`, the nodename, nodeaddrs, and nodehostnames are identical. We use logic sort  the nodename, and assign the value to nodeaddrs and nodehostnames
* In `_update_slurm_node_addrs`, we know that all the nodes and addresses are already expanded (i.e. there is not Slurm compressed list expression). We use `zip` to sort the nodeaddrs and nodehostnames according to nodename
* The sort is put after the nodes are batched because `scontrol` accepts 5000 nodes at most. Putting the sort after the nodes are batches will make sure not hitting the limit

### Tests
* Unit tests are changed accordingly.
* Manual testing
We tested 30000 nodenames, addresses, hostnames mismatch can be recovered by clustermgtd.
* Whole integration tests (without AD integration and multiple FSx integration) look ok.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.