### PR TITLE
Fix color formatting on flake8 style offenses

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,13 +11,13 @@ ignore =
     # D103: Missing docstring in public function
     D103,
     # D104: Missing docstring in public package
-    D104
+    D104,
     # D107: Missing docstring in __init__
     D107,
     # W503: line break before binary operator => Conflicts with black style.
     W503,
     # N818: exception name should be named with an Error suffix
-    N818,
+    N818
 exclude =
     .tox,
     .git,
@@ -34,4 +34,4 @@ max-complexity = 10
 max-line-length = 120
 import-order-style = google
 application-import-names = flake8
-format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+format = %(cyan)s%(path)s%(reset)s:%(bold)s%(yellow)s%(row)d%(reset)s:%(bold)s%(green)s%(col)d%(reset)s: %(bold)s%(red)s%(code)s%(reset)s %(text)s


### PR DESCRIPTION
### Description of changes
* Fix color formatting on flake8 style offenses.

### Tests
* manually run `tox -e code-linters`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.