### PR TITLE
3.x Add check for empty property value

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -294,10 +294,14 @@ class ClustermgtdConfig:
 
     def _get_compute_console_output_config(self, config):
         """Get config options related to logging console output from compute nodes."""
-        self.compute_console_logging_enabled = config.getboolean(
-            "clustermgtd",
-            "compute_console_logging_enabled",
-            fallback=self.DEFAULTS.get("compute_console_logging_enabled"),
+        self.compute_console_logging_enabled = (
+            config.getboolean(
+                "clustermgtd",
+                "compute_console_logging_enabled",
+                fallback=self.DEFAULTS.get("compute_console_logging_enabled"),
+            )
+            if config.get("clustermgtd", "compute_console_logging_enabled", fallback=None)
+            else True
         )
         self.compute_console_logging_max_sample_size = config.getint(
             "clustermgtd",

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -161,8 +161,47 @@ class TestClustermgtdConfig:
                     "health_check_timeout": 10,
                 },
             ),
+            (
+                "no_console_output_enabled.conf",
+                {
+                    # basic configs
+                    "cluster_name": "hit",
+                    "region": "us-east-2",
+                    "_boto3_config": {"retries": {"max_attempts": 1, "mode": "standard"}},
+                    "loop_time": 60,
+                    "disable_all_cluster_management": False,
+                    "heartbeat_file_path": "/home/ec2-user/clustermgtd_heartbeat",
+                    "logging_config": os.path.join(
+                        os.path.dirname(slurm_plugin.__file__), "logging", "parallelcluster_clustermgtd_logging.conf"
+                    ),
+                    "dynamodb_table": "table-name",
+                    # launch configs
+                    "update_node_address": True,
+                    "launch_max_batch_size": 500,
+                    # terminate configs
+                    "terminate_max_batch_size": 1000,
+                    "node_replacement_timeout": 1800,
+                    "terminate_drain_nodes": True,
+                    "terminate_down_nodes": True,
+                    "orphaned_instance_timeout": 120,
+                    # health check configs
+                    "disable_ec2_health_check": False,
+                    "disable_scheduled_event_health_check": False,
+                    "disable_all_health_checks": False,
+                    "health_check_timeout": 180,
+                    "protected_failure_count": 10,
+                    "insufficient_capacity_timeout": 600,
+                    # Compute console logging configs
+                    "compute_console_logging_enabled": True,
+                    "compute_console_logging_max_sample_size": 1,
+                    "compute_console_wait_time": 300,
+                    # Task executor configs
+                    "worker_pool_size": 5,
+                    "worker_pool_max_backlog": 100,
+                },
+            ),
         ],
-        ids=["default", "all_options", "health_check"],
+        ids=["default", "all_options", "health_check", "no_console_output_enabled"],
     )
     def test_config_parsing(self, config_file, expected_attributes, test_datadir, mocker):
         mocker.patch(

--- a/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/no_console_output_enabled.conf
+++ b/tests/slurm_plugin/test_clustermgtd/TestClustermgtdConfig/test_config_parsing/no_console_output_enabled.conf
@@ -1,0 +1,8 @@
+[clustermgtd]
+cluster_name = hit
+region = us-east-2
+heartbeat_file_path = /home/ec2-user/clustermgtd_heartbeat
+dynamodb_table = table-name
+head_node_private_ip = head.node.ip
+head_node_hostname = head-node-hostname
+compute_console_logging_enabled =


### PR DESCRIPTION
### Description of changes
* If the cw_loggining_enabled property in parallelcluster_clustermgtd.conf was present but had no value, then clustermgtd would fail to start.
* Added check to make sure the  cw_loggining_enabled property has a value before trying to parse it as a boolean.

### Tests
* Added unit test for  the cw_loggining_enabled property being present but without a value.
* Ran unit tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.