### PR TITLE
Improve debug logging to show Slurm node state

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         queries: +security-and-quality
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -161,8 +161,12 @@ def _resume(arg_nodes, resume_config):
         _handle_failed_nodes(arg_nodes)
         return
     log.info("Launching EC2 instances for the following Slurm nodes: %s", arg_nodes)
-    node_list = [node.name for node in get_nodes_info(arg_nodes)]
-    log.debug("Retrieved nodelist: %s", node_list)
+    node_list = []
+    node_list_with_status = []
+    for node in get_nodes_info(arg_nodes):
+        node_list.append(node.name)
+        node_list_with_status.append((node.name, node.state_string))
+    log.info("Current state of Slurm nodes to resume: %s", node_list_with_status)
 
     instance_manager = InstanceManager(
         resume_config.region,

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -217,7 +217,7 @@ class SlurmNode(metaclass=ABCMeta):
         """Check if node resume timeout expires."""
         return self.states == self.SLURM_SCONTROL_RESUME_FAILED_STATE
 
-    def is_poweing_up_idle(self):
+    def is_powering_up_idle(self):
         """Check if node is in IDLE# state."""
         return self.SLURM_SCONTROL_IDLE_STATE in self.states and self.is_powering_up()
 
@@ -451,7 +451,7 @@ class DynamicNode(SlurmNode):
     def is_bootstrap_failure(self):
         """Check if a slurm node has boostrap failure."""
         # no backing instance + [working state]# in node state
-        if (self.is_configuring_job() or self.is_poweing_up_idle()) and not self.is_backing_instance_valid(
+        if (self.is_configuring_job() or self.is_powering_up_idle()) and not self.is_backing_instance_valid(
             log_warn_if_unhealthy=False
         ):
             logger.warning(

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -95,10 +95,10 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
         # all_or_nothing_batch without ice error
         (
             [
-                SimpleNamespace(name="queue1-dy-c5xlarge-1"),
-                SimpleNamespace(name="queue1-dy-c5xlarge-2"),
-                SimpleNamespace(name="queue1-st-c5xlarge-1"),
-                SimpleNamespace(name="queue1-st-c5xlarge-2"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
             True,
@@ -153,10 +153,10 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
         # all_or_nothing_batch with ice error
         (
             [
-                SimpleNamespace(name="queue1-dy-c5xlarge-1"),
-                SimpleNamespace(name="queue1-dy-c5xlarge-2"),
-                SimpleNamespace(name="queue1-st-c5xlarge-1"),
-                SimpleNamespace(name="queue1-st-c5xlarge-2"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
             True,
@@ -211,10 +211,10 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
         # best_effort without ice error
         (
             [
-                SimpleNamespace(name="queue1-dy-c5xlarge-1"),
-                SimpleNamespace(name="queue1-dy-c5xlarge-2"),
-                SimpleNamespace(name="queue1-st-c5xlarge-1"),
-                SimpleNamespace(name="queue1-st-c5xlarge-2"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
             False,
@@ -250,10 +250,10 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
         # best_effort wit ice error
         (
             [
-                SimpleNamespace(name="queue1-dy-c5xlarge-1"),
-                SimpleNamespace(name="queue1-dy-c5xlarge-2"),
-                SimpleNamespace(name="queue1-st-c5xlarge-1"),
-                SimpleNamespace(name="queue1-st-c5xlarge-2"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
             False,


### PR DESCRIPTION
The output is now something like:
`Current state of Slurm nodes to resume: [('queue1-dy-queue1-t2medium-2', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP')]`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.