### PR TITLE
[3.x] Reducing risks associated to Bandit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 
 **ENHANCEMENTS**
 - Add logging of compute node console output to CloudWatch from head node on compute node bootstrap failure.
+- Add validators to prevent malicious string injection while calling the subprocess module.
 
 3.4.1
 ------

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -110,7 +110,8 @@ def update_nodes(
             node_info += f" nodeaddr={addrs}"
         if hostnames:
             node_info += f" nodehostname={hostnames}"
-        run_command(  # nosec
+        # It's safe to use the function affected by B604 since the command is fully built in this code
+        run_command(  # nosec B604
             f"{update_cmd} {node_info}", raise_on_error=raise_on_error, timeout=command_timeout, shell=True
         )
 
@@ -119,7 +120,7 @@ def update_partitions(partitions, state):
     succeeded_partitions = []
     for partition in partitions:
         try:
-            run_command(  # nosec
+            run_command(  # nosec B604
                 f"{SCONTROL} update partitionname={partition} state={state}", raise_on_error=True, shell=True
             )
             succeeded_partitions.append(partition)
@@ -238,7 +239,7 @@ def get_nodes_info(nodes="", command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):
         'grep -oP "^(NodeName=\\S+)|(NodeAddr=\\S+)|(NodeHostName=\\S+)|(State=\\S+)|'
         '(Partitions=\\S+)|(Reason=.+) |(######)"'
     )
-    nodeinfo_str = check_command_output(show_node_info_command, timeout=command_timeout, shell=True)  # nosec
+    nodeinfo_str = check_command_output(show_node_info_command, timeout=command_timeout, shell=True)  # nosec B604
 
     return _parse_nodes_info(nodeinfo_str)
 
@@ -246,7 +247,8 @@ def get_nodes_info(nodes="", command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):
 def get_partition_info(command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT, get_all_nodes=True):
     """Retrieve slurm partition info from scontrol."""
     show_partition_info_command = f'{SCONTROL} show partitions | grep -oP "^PartitionName=\\K(\\S+)| State=\\K(\\S+)"'
-    partition_info_str = check_command_output(show_partition_info_command, timeout=command_timeout, shell=True)  # nosec
+    # It's safe to use the function affected by B604 since the command is fully built in this code
+    partition_info_str = check_command_output(show_partition_info_command, timeout=command_timeout, shell=True)  # nosec B604
     partitions_info = _parse_partition_name_and_state(partition_info_str)
     return [
         SlurmPartition(
@@ -273,7 +275,7 @@ def _parse_partition_name_and_state(partition_info):
 def _get_all_partition_nodes(partition_name, command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):
     """Get all nodes in partition."""
     show_all_nodes_command = f"{SINFO} -h -p {partition_name} -o %N"
-    return check_command_output(show_all_nodes_command, timeout=command_timeout, shell=True).strip()  # nosec
+    return check_command_output(show_all_nodes_command, timeout=command_timeout, shell=True).strip()  # nosec B604
 
 
 def _get_slurm_nodes(states=None, partition_name=None, command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):
@@ -283,7 +285,8 @@ def _get_slurm_nodes(states=None, partition_name=None, command_timeout=DEFAULT_G
     if states:
         sinfo_command += f" -t {states}"
     # Every node is print on a separate line
-    return check_command_output(sinfo_command, timeout=command_timeout, shell=True).splitlines()  # nosec
+    # It's safe to use the function affected by B604 since the command is fully built in this code
+    return check_command_output(sinfo_command, timeout=command_timeout, shell=True).splitlines()  # nosec B604
 
 
 def _get_partition_nodes(partition_name, command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -13,7 +13,7 @@ import logging
 import os
 import re
 
-from common.utils import check_command_output, grouper, run_command
+from common.utils import check_command_output, grouper, run_command, validate_subprocess_argument
 from retrying import retry
 from slurm_plugin.slurm_resources import (
     DynamicNode,
@@ -101,14 +101,19 @@ def update_nodes(
 
     update_cmd = f"{SCONTROL} update"
     if state:
+        validate_subprocess_argument(state)
         update_cmd += f" state={state}"
     if reason:
+        validate_subprocess_argument(reason)
         update_cmd += f' reason="{reason}"'
     for nodenames, addrs, hostnames in batched_node_info:
+        validate_subprocess_argument(nodenames)
         node_info = f"nodename={nodenames}"
         if addrs:
+            validate_subprocess_argument(addrs)
             node_info += f" nodeaddr={addrs}"
         if hostnames:
+            validate_subprocess_argument(hostnames)
             node_info += f" nodehostname={hostnames}"
         # It's safe to use the function affected by B604 since the command is fully built in this code
         run_command(  # nosec B604
@@ -118,8 +123,12 @@ def update_nodes(
 
 def update_partitions(partitions, state):
     succeeded_partitions = []
+    # Validation to sanitize the input argument and make it safe to use the function affected by B604
+    validate_subprocess_argument(state)
     for partition in partitions:
         try:
+            # Validation to sanitize the input argument and make it safe to use the function affected by B604
+            validate_subprocess_argument(partition)
             run_command(  # nosec B604
                 f"{SCONTROL} update partitionname={partition} state={state}", raise_on_error=True, shell=True
             )
@@ -232,6 +241,9 @@ def get_nodes_info(nodes="", command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):
 
     Sample slurm nodelist notation: queue1-dy-c5_xlarge-[1-3],queue2-st-t2_micro-5.
     """
+    # Validation to sanitize the input argument and make it safe to use the function affected by B604
+    validate_subprocess_argument(nodes)
+
     # awk is used to replace the \n\n record separator with '######\n'
     # Note: In case the node does not belong to any partition the Partitions field is missing from Slurm output
     show_node_info_command = (
@@ -248,7 +260,9 @@ def get_partition_info(command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT, get_all
     """Retrieve slurm partition info from scontrol."""
     show_partition_info_command = f'{SCONTROL} show partitions | grep -oP "^PartitionName=\\K(\\S+)| State=\\K(\\S+)"'
     # It's safe to use the function affected by B604 since the command is fully built in this code
-    partition_info_str = check_command_output(show_partition_info_command, timeout=command_timeout, shell=True)  # nosec B604
+    partition_info_str = check_command_output(
+        show_partition_info_command, timeout=command_timeout, shell=True  # nosec B604
+    )
     partitions_info = _parse_partition_name_and_state(partition_info_str)
     return [
         SlurmPartition(
@@ -274,6 +288,9 @@ def _parse_partition_name_and_state(partition_info):
 
 def _get_all_partition_nodes(partition_name, command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):
     """Get all nodes in partition."""
+    # Validation to sanitize the input argument and make it safe to use the function affected by B604
+    validate_subprocess_argument(partition_name)
+
     show_all_nodes_command = f"{SINFO} -h -p {partition_name} -o %N"
     return check_command_output(show_all_nodes_command, timeout=command_timeout, shell=True).strip()  # nosec B604
 
@@ -281,8 +298,10 @@ def _get_all_partition_nodes(partition_name, command_timeout=DEFAULT_GET_INFO_CO
 def _get_slurm_nodes(states=None, partition_name=None, command_timeout=DEFAULT_GET_INFO_COMMAND_TIMEOUT):
     sinfo_command = f"{SINFO} -h -N -o %N"
     if partition_name:
+        validate_subprocess_argument(partition_name)
         sinfo_command += f" -p {partition_name}"
     if states:
+        validate_subprocess_argument(states)
         sinfo_command += f" -t {states}"
     # Every node is print on a separate line
     # It's safe to use the function affected by B604 since the command is fully built in this code

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -74,11 +74,11 @@ def check_command_output(
     """
     if isinstance(command, str) and not shell:
         command = shlex.split(command)
-    # A nosec comment is appended to the following line in order to disable the B602 check.
+    # A nosec B602 comment is appended to the following line in order to disable the B602 check.
     # This check is disabled for the following reasons:
     # - Some callers (e.g., common slurm commands) require the use of `shell=True`.
-    # - All values passed as the command arg are constructed from known inputs.
-    result = _run_command(  # nosec
+    # - All values passed as the command arg are constructed from known inputs and are properly validated.
+    result = _run_command(
         lambda _command, _env, _preexec_fn: subprocess.run(
             _command,
             env=_env,
@@ -88,7 +88,7 @@ def check_command_output(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             encoding="utf-8",
-            shell=shell,
+            shell=shell,  # nosec B602
         ),
         command,
         env,
@@ -112,11 +112,11 @@ def run_command(command, env=None, raise_on_error=True, execute_as_user=None, lo
     """
     if isinstance(command, str) and not shell:
         command = shlex.split(command)
-    # A nosec comment is appended to the following line in order to disable the B602 check.
+    # A nosec B602 comment is appended to the following line in order to disable the B602 check.
     # This check is disabled for the following reasons:
     # - Some callers (e.g., common slurm commands) require the use of `shell=True`.
-    # - All values passed as the command arg are constructed from known inputs.
-    _run_command(  # nosec
+    # - All values passed as the command arg are constructed from known inputs and are properly validated.
+    _run_command(
         lambda _command, _env, _preexec_fn: subprocess.run(
             _command,
             env=_env,
@@ -124,7 +124,7 @@ def run_command(command, env=None, raise_on_error=True, execute_as_user=None, lo
             timeout=timeout,
             check=True,
             encoding="utf-8",
-            shell=shell,
+            shell=shell,  # nosec B602
         ),
         command,
         env,

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -295,7 +295,7 @@ def validate_subprocess_argument(argument):
     :raise: Exception if the argument contains a forbidden pattern
     :return: True if the argument does not contain forbidden patterns
     """
-    forbidden_patterns = ["&", "|",  ";",  "$",  ">", "<", "`", "\\", "!", "#", "\n"]
+    forbidden_patterns = ["&", "|", ";", "$", ">", "<", "`", "\\", "!", "#", "\n"]
 
     # Forcing the encoding to be the standard Python Unicode / UTF-8
     # https://docs.python.org/3/howto/unicode.html
@@ -303,7 +303,7 @@ def validate_subprocess_argument(argument):
     _argument = (str(argument).encode("utf-8", "ignore")).decode()
 
     if any(pattern in _argument for pattern in forbidden_patterns):
-        raise Exception("Value of provided argument contains at least a forbidden pattern")
+        raise ValueError("Value of provided argument contains at least a forbidden pattern")
     return True
 
 
@@ -316,5 +316,5 @@ def validate_absolute_path(path):
     :return: True if the path is a valid absolute path
     """
     if not os.path.isabs(path):
-        raise Exception(f"The path {path} is not a valid absolute path")
+        raise ValueError(f"The path {path} is not a valid absolute path")
     return True

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -99,7 +99,7 @@ def get_clustermgtd_heartbeat(clustermgtd_heartbeat_file_path):
         check_command_output(
             f"cat {clustermgtd_heartbeat_file_path}",
             timeout=DEFAULT_COMMAND_TIMEOUT,
-            shell=True,  # nosec
+            shell=True,  # nosec B604
         )
         .splitlines()[-1]
         .strip()

--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -16,7 +16,7 @@ from concurrent.futures import Future
 from datetime import datetime
 from typing import Callable, Optional, Protocol, TypedDict
 
-from common.utils import check_command_output, time_is_up
+from common.utils import check_command_output, time_is_up, validate_absolute_path
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +95,10 @@ def get_clustermgtd_heartbeat(clustermgtd_heartbeat_file_path):
     # Use subprocess based method to read shared file to prevent hanging when NFS is down
     # Do not copy to local. Different users need to access the file, but file should be writable by root only
     # Only use last line of output to avoid taking unexpected output in stdout
+
+    # Validation to sanitize the input argument and make it safe to use the function affected by B604
+    validate_absolute_path(clustermgtd_heartbeat_file_path)
+
     heartbeat = (
         check_command_output(
             f"cat {clustermgtd_heartbeat_file_path}",

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -24,7 +24,7 @@ from subprocess import CalledProcessError  # nosec B404
 from botocore.config import Config
 from common.schedulers.slurm_commands import get_nodes_info
 from common.time_utils import seconds
-from common.utils import check_command_output, run_command, sleep_remaining_loop_time
+from common.utils import check_command_output, run_command, sleep_remaining_loop_time, validate_absolute_path
 from retrying import retry
 from slurm_plugin.common import (
     DEFAULT_COMMAND_TIMEOUT,
@@ -69,6 +69,8 @@ class ComputemgtdConfig:
         log.info("Reading %s", config_file_path)
         config = ConfigParser()
         try:
+            # Validation to sanitize the input argument and make it safe to use the function affected by B604
+            validate_absolute_path(config_file_path)
             # Use subprocess based method to copy shared file to local to prevent hanging when NFS is down
             config_str = check_command_output(
                 f"cat {config_file_path}",

--- a/src/slurm_plugin/computemgtd.py
+++ b/src/slurm_plugin/computemgtd.py
@@ -73,7 +73,7 @@ class ComputemgtdConfig:
             config_str = check_command_output(
                 f"cat {config_file_path}",
                 timeout=DEFAULT_COMMAND_TIMEOUT,
-                shell=True,  # nosec
+                shell=True,  # nosec B604
             )
             config.read_file(StringIO(config_str))
         except Exception:

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -31,7 +31,7 @@ from common.schedulers.slurm_commands import (
     update_nodes,
     update_partitions,
 )
-from slurm_plugin.slurm_resources import DynamicNode, PartitionStatus, SlurmPartition, StaticNode
+from slurm_plugin.slurm_resources import DynamicNode, InvalidNodenameError, PartitionStatus, SlurmPartition, StaticNode
 
 
 @pytest.mark.parametrize(
@@ -57,7 +57,7 @@ from slurm_plugin.slurm_resources import DynamicNode, PartitionStatus, SlurmPart
 )
 def test_parse_nodename(nodename, expected_queue, expected_node_type, expected_instance_name, expected_failure):
     if expected_failure:
-        with pytest.raises(Exception):
+        with pytest.raises(InvalidNodenameError):
             parse_nodename(nodename)
     else:
         queue_name, node_type, instance_name = parse_nodename(nodename)

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -105,7 +105,7 @@ def test_sleep_remaining_loop_time(mocker, loop_start_time, loop_end_time, loop_
 )
 def test_validate_subprocess_argument(argument, raises_exception):
     if raises_exception:
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             utils.validate_subprocess_argument(argument)
     else:
         assert_that(utils.validate_subprocess_argument(argument)).is_true()
@@ -122,7 +122,7 @@ def test_validate_subprocess_argument(argument, raises_exception):
 )
 def test_validate_absolute_path(argument, raises_exception):
     if raises_exception:
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             utils.validate_absolute_path(argument)
     else:
         assert_that(utils.validate_absolute_path(argument)).is_true()

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -91,3 +91,38 @@ def test_sleep_remaining_loop_time(mocker, loop_start_time, loop_end_time, loop_
     elif expected_sleep_time == 0:
         sleep_mock.assert_not_called()
     datetime_now_mock.now.assert_called_with(tz=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "argument,raises_exception",
+    [
+        ("standard parameter name", False),
+        ("my/parameter", False),
+        ("execute this & then this", True),
+        ("redirect | my output", True),
+        ("execute\nmultiline", True),
+    ],
+)
+def test_validate_subprocess_argument(argument, raises_exception):
+    if raises_exception:
+        with pytest.raises(Exception):
+            utils.validate_subprocess_argument(argument)
+    else:
+        assert_that(utils.validate_subprocess_argument(argument)).is_true()
+
+
+@pytest.mark.parametrize(
+    "argument,raises_exception",
+    [
+        ("/usr/my_path", False),
+        ("./my_path", True),
+        ("my_path", True),
+        (".my_path", True),
+    ],
+)
+def test_validate_absolute_path(argument, raises_exception):
+    if raises_exception:
+        with pytest.raises(Exception):
+            utils.validate_absolute_path(argument)
+    else:
+        assert_that(utils.validate_absolute_path(argument)).is_true()

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -2004,7 +2004,7 @@ class TestComputeFleetStatusManager:
         "desired_status, update_item_response",
         [
             (ComputeFleetStatus.PROTECTED, None),
-            (ComputeFleetStatus.STOPPED, Exception),
+            (ComputeFleetStatus.STOPPED, AttributeError),
         ],
         ids=["success", "exception"],
     )
@@ -2012,9 +2012,9 @@ class TestComputeFleetStatusManager:
         check_command_output_mocked = mocker.patch("slurm_plugin.clustermgtd.check_command_output", autospec=True)
         compute_fleet_status_manager = ComputeFleetStatusManager()
 
-        if update_item_response is Exception:
+        if update_item_response is AttributeError:
             check_command_output_mocked.side_effect = update_item_response
-            with pytest.raises(Exception):
+            with pytest.raises(AttributeError):
                 compute_fleet_status_manager.update_status(desired_status)
         else:
             check_command_output_mocked.return_value = update_item_response

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -74,7 +74,7 @@ def test_get_clustermgtd_heartbeat(time, expected_parsed_time, mocker):
         "slurm_plugin.common.check_command_output",
         return_value=f"some_random_stdout\n{time.strftime(TIMESTAMP_FORMAT)}",
     )
-    assert_that(get_clustermgtd_heartbeat("some file path")).is_equal_to(expected_parsed_time)
+    assert_that(get_clustermgtd_heartbeat("/some/file/path")).is_equal_to(expected_parsed_time)
 
 
 @pytest.mark.parametrize(

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -91,7 +91,7 @@ def test_read_json(test_datadir, caplog, json_file, default_value, raises_except
     caplog.set_level(logging.INFO)
     json_file_path = str(test_datadir.joinpath(json_file))
     if raises_exception:
-        with pytest.raises(Exception):
+        with pytest.raises((ValueError, FileNotFoundError)):
             read_json(json_file_path, default_value)
     else:
         read_json(json_file_path, default_value)

--- a/tests/slurm_plugin/test_computemgtd.py
+++ b/tests/slurm_plugin/test_computemgtd.py
@@ -63,7 +63,7 @@ from slurm_plugin.slurm_resources import DynamicNode
 def test_computemgtd_config(config_file, expected_attributes, test_datadir, mocker):
     mocker.patch("slurm_plugin.computemgtd.ComputemgtdConfig._read_nodename_from_file", return_value="some_nodename")
     mocker.patch("slurm_plugin.computemgtd.check_command_output", return_value=(test_datadir / config_file).read_text())
-    compute_config = ComputemgtdConfig("mocked_config_path")
+    compute_config = ComputemgtdConfig("/mocked/config/path")
     for key in expected_attributes:
         assert_that(compute_config.__dict__.get(key)).is_equal_to(expected_attributes.get(key))
 

--- a/tests/slurm_plugin/test_fleet_status_manager.py
+++ b/tests/slurm_plugin/test_fleet_status_manager.py
@@ -114,19 +114,19 @@ def test_fleet_status_manager(mocker, test_datadir, computefleet_status_data_pat
     ("config_file", "expected_status"),
     [
         ("correct_status.json", ComputeFleetStatus.RUNNING),
-        ("no_status.json", Exception),
-        ("malformed_status.json", Exception),
-        ("wrong_status.json", Exception),
-        (None, Exception),
+        ("no_status.json", ValueError),
+        ("malformed_status.json", FileNotFoundError),
+        ("wrong_status.json", ValueError),
+        (None, TypeError),
     ],
 )
 def test_get_computefleet_status(test_datadir, config_file, expected_status):
-    if expected_status is Exception:
-        with pytest.raises(Exception):
-            _get_computefleet_status(test_datadir / config_file)
-    else:
+    if isinstance(expected_status, ComputeFleetStatus):
         status = _get_computefleet_status(test_datadir / config_file)
         assert_that(status).is_equal_to(expected_status)
+    else:
+        with pytest.raises(expected_status):
+            _get_computefleet_status(test_datadir / config_file)
 
 
 def test_start_partitions(mocker):


### PR DESCRIPTION
### Description of changes
* Restrict the scope of the overrides related to Bandit findings
* Add a set of string validators
* Use the string validators to validate input arguments used in subprocess calls
* Fix emergent issue related to B017 findings in the flake8-bugbear module

### Tests
* manual tested the stop/start/stop fleet commands
* manual tested the job submissions on multiple partitions, verified logs and outputs
* launched integration tests ("multiple_job_submission" and "test_slurm")
* added unit tests for the utils.py class

### References
* https://bandit.readthedocs.io/en/latest/config.html#exclusions

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.