### PR TITLE
Set minimum version of semgrep in tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -168,7 +168,7 @@ commands =
 [testenv:semgrep]
 basepython = python3
 deps =
-    semgrep
+    semgrep>=1.8.0
 commands =
     semgrep \
         --config p/r2c-security-audit \


### PR DESCRIPTION
### Description of changes
* This is a temporary workaround to avoid the problem described here: https://github.com/returntocorp/semgrep/issues/7033
* Fixes the code-linters GitHub action.

### Tests
* Manual run of the `code-linters` action

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.