### PR TITLE
Remove deprecated seed-isort-config pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
       - id: trailing-whitespace
@@ -30,11 +30,6 @@ repos:
     hooks:
       - id: isort
         args: ['-rc', '-w 120']
-
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
 
   - repo: https://github.com/ambv/black
     rev: 23.1.0


### PR DESCRIPTION
### Description of changes
* Remove deprecated seed-isort-config pre-commit hook
  * The seed-isort-config pre-commit hook was deprecated in 2020. See https://github.com/asottile-archive/seed-isort-config#deprecated
* Fix repo definition for pre-commit-hooks project.

### Tests
* Manually ran new pre-commit configuration for node (the previous one was hanging because of the wrong repo for `pre-commit-hooks`.

### References
* Related to https://github.com/aws/aws-parallelcluster-node/pull/499

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.