### PR TITLE
Mark dynamic nodes with INVALID_REG as bootstrap failure towards the protected mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ This file is used to list changes made in each version of the aws-parallelcluste
 3.6.0
 ------
 
+**CHANGES**
+- Consider dynamic nodes with INVALID_REG flag as bootstrap failure towards the Slurm protected mode.
+  - Static nodes failing the Slurm registration are already treated as a bootstrap failure after the `node_replacement_timeout`.
+
 3.5.0
 ------
 
 **ENHANCEMENTS**
 - Add logging of compute node console output to CloudWatch from head node on compute node bootstrap failure.
 - Add validators to prevent malicious string injection while calling the subprocess module.
-  
+
 **BUG FIXES**
 - Fix an issue in clustermgtd that caused compute nodes rebooted via Slurm to be replaced if the EC2 instance status checks fail.
 

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -98,6 +98,7 @@ class SlurmNode(metaclass=ABCMeta):
     SLURM_SCONTROL_POWER_STATES = [{"IDLE", "CLOUD", "POWERED_DOWN"}, {"IDLE", "CLOUD", "POWERED_DOWN", "POWER_DOWN"}]
     SLURM_SCONTROL_REBOOT_REQUESTED_STATE = "REBOOT_REQUESTED"
     SLURM_SCONTROL_REBOOT_ISSUED_STATE = "REBOOT_ISSUED"
+    SLURM_SCONTROL_INVALID_REGISTRATION_STATE = "INVALID_REG"
 
     EC2_ICE_ERROR_CODES = {
         "InsufficientInstanceCapacity",
@@ -244,6 +245,10 @@ class SlurmNode(metaclass=ABCMeta):
             )
             cond = True
         return cond
+
+    def is_invalid_slurm_registration(self):
+        """Check if a slurm node has failed registration with the Slurm management daemon."""
+        return self.SLURM_SCONTROL_INVALID_REGISTRATION_STATE in self.states
 
     @abstractmethod
     def is_state_healthy(self, terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=True):
@@ -466,6 +471,17 @@ class DynamicNode(SlurmNode):
         elif self.is_failing_health_check and self.is_powering_up():
             logger.warning(
                 "Node bootstrap error: Node %s failed during bootstrap when performing health check, node state: %s",
+                self,
+                self.state_string,
+            )
+            return True
+        # Consider the invalid registration as a bootstrap failure event, but only the first time it is registered.
+        # After this, clustermgtd will mark the node as unhealthy and power it down.
+        # This does not clear the INVALID_REG flag immediately: this will happen only when the node is fully powered
+        # down. Therefore we exclude the nodes that are still pending powering down from this check.
+        elif self.is_invalid_slurm_registration() and not (self.is_power_down() or self.is_powering_down()):
+            logger.warning(
+                "Node bootstrap error: Node %s failed to register to the Slurm management daemon, node state: %s",
                 self,
                 self.state_string,
             )

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -325,7 +325,7 @@ class StaticNode(SlurmNode):
     def is_healthy(self, terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=True):
         """Check if a slurm node is considered healthy."""
         return (
-            self._is_static_node_configuration_valid(log_warn_if_unhealthy=log_warn_if_unhealthy)
+            self._is_static_node_ip_configuration_valid(log_warn_if_unhealthy=log_warn_if_unhealthy)
             and self.is_backing_instance_valid(log_warn_if_unhealthy=log_warn_if_unhealthy)
             and self.is_state_healthy(
                 terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=log_warn_if_unhealthy
@@ -365,7 +365,7 @@ class StaticNode(SlurmNode):
                 return False
         return True
 
-    def _is_static_node_configuration_valid(self, log_warn_if_unhealthy=True):
+    def _is_static_node_ip_configuration_valid(self, log_warn_if_unhealthy=True):
         """Check if static node is configured with a private IP."""
         if not self.is_nodeaddr_set():
             if log_warn_if_unhealthy:

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -1021,8 +1021,8 @@ def test_slurm_node_needs_reset_when_inactive(node, expected_result):
     ],
     ids=["static_addr_not_set", "static_valid"],
 )
-def test_is_static_node_configuration_valid(node, expected_result):
-    assert_that(node._is_static_node_configuration_valid()).is_equal_to(expected_result)
+def test_is_static_node_ip_configuration_valid(node, expected_result):
+    assert_that(node._is_static_node_ip_configuration_valid()).is_equal_to(expected_result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of changes
* Mark dynamic nodes with INVALID_REG as bootstrap failure towards the protected mode
    * This prevents an endless loop of reprovisioning of dynamic nodes if `slurmd` fails to register to the `slurmctld` (e.g. due to a bad Slurm configuration of the compute node).
    * This is useful if customer use custom Slurm settings ad compute resource level.
* Static nodes are already covered by the current replacement timeout logic.
* Small refactoring of a function with a potentially misleading name.

### Tests
* Added unit tests for the new logic in clustermgtd.
* Ran manual tests verifying that a bad node configuration (forcing `RealMemory` to be much larger than the one really available on the instance):
    * verified that a static node failing Slurm registration triggers the protected mode due to the node replacement timeout logic;
    * verified that a dynamic node failing Slurm registration triggers the protected mode due to new logic implemented in this PR.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change. -> created internal task about this.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.