### PR TITLE
3.5 Fix file mode for console output log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This file is used to list changes made in each version of the aws-parallelcluste
 3.5.1
 ------
 
-**CHANGES**
-- There were no changes for this version.
+**BUG FIXES**
+- Fix for compute_console_output log file being truncated at every clustermgtd iteration.
 
 3.5.0
 ------

--- a/src/slurm_plugin/logging/parallelcluster_clustermgtd_logging.conf
+++ b/src/slurm_plugin/logging/parallelcluster_clustermgtd_logging.conf
@@ -33,4 +33,4 @@ format=%(asctime)s - %(message)s
 class=FileHandler
 level=INFO
 formatter=computeConsoleFormatter
-args=('/var/log/parallelcluster/compute_console_output.log', 'w', None, False)
+args=('/var/log/parallelcluster/compute_console_output.log', 'a', None, False)


### PR DESCRIPTION
### Description of changes
* This change fixes the file open mode for the compute console output log. The log was being opened in write mode instead of append mode. This would cause the log file to be truncated on every iteration of the clustermgtd loop.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.