### PR TITLE
[BugFix] Fix issue causing IP misalignment on multi NICS instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ build/
 .tox/
 .coverage
 coverage.xml
+assets/
+report.html
 
 aws-parallelcluster-node-*.tgz
 aws-parallelcluster-node-*.md5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This file is used to list changes made in each version of the aws-parallelcluste
 - Consider dynamic nodes with INVALID_REG flag as bootstrap failure towards the Slurm protected mode.
 - Static nodes failing the Slurm registration are already treated as a bootstrap failure after the `node_replacement_timeout`.
 
+**BUG FIXES**
+- Fix an issue that was causing misalignment of compute nodes IP on multi NICS instances.
+
 3.5.1
 ------
 

--- a/src/common/ec2_utils.py
+++ b/src/common/ec2_utils.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+
+def get_private_ip_address(instance_info):
+    """
+    Return the PrivateIpAddress of the EC2 instance.
+
+    The PrivateIpAddress is considered to be the one for the
+    network interface with DeviceIndex = NetworkCardIndex = 0.
+    :param instance_info: the dictionary returned by a EC2:DescribeInstances call.
+    :return: the PrivateIpAddress of the instance.
+    """
+    private_ip = instance_info["PrivateIpAddress"]
+    for network_interface in instance_info["NetworkInterfaces"]:
+        attachment = network_interface["Attachment"]
+        if attachment["DeviceIndex"] == 0 and attachment["NetworkCardIndex"] == 0:
+            private_ip = network_interface["PrivateIpAddress"]
+            break
+    return private_ip

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -15,6 +15,7 @@ from abc import ABC, abstractmethod
 
 import boto3
 from botocore.exceptions import ClientError
+from common.ec2_utils import get_private_ip_address
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class EC2Instance:
         try:
             return EC2Instance(
                 instance_info["InstanceId"],
-                instance_info["PrivateIpAddress"],
+                get_private_ip_address(instance_info),
                 instance_info["PrivateDnsName"].split(".")[0],
                 instance_info["LaunchTime"],
             )

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -21,6 +21,7 @@ from typing import Iterable
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from common.ec2_utils import get_private_ip_address
 from common.schedulers.slurm_commands import update_nodes
 from common.utils import grouper
 from slurm_plugin.common import ComputeInstanceDescriptor, log_exception, print_with_count
@@ -342,7 +343,7 @@ class InstanceManager:
                 instances.append(
                     EC2Instance(
                         instance_info["InstanceId"],
-                        instance_info["PrivateIpAddress"],
+                        get_private_ip_address(instance_info),
                         instance_info["PrivateDnsName"].split(".")[0],
                         instance_info["LaunchTime"],
                     )

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -915,5 +915,7 @@ def test_get_nodes_info(nodes, cmd_timeout, run_command_call, run_command_side_e
     ],
 )
 def test_scontrol_output_awk_parser(scontrol_output, expected_parsed_output):
+    # This test makes use of grep option -P that is only supported by GNU grep.
+    # So the test is expected to fail on MacOS shipping BSD grep.
     parsed_output = check_command_output(f'echo "{scontrol_output}" | {SCONTROL_OUTPUT_AWK_PARSER}', shell=True)
     assert_that(parsed_output).is_equal_to(expected_parsed_output)

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1671,24 +1671,60 @@ def test_manage_cluster(
                                         "PrivateIpAddress": "ip-1",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-1",
+                                            },
+                                        ],
                                     },
                                     {
                                         "InstanceId": "i-2",
                                         "PrivateIpAddress": "ip-2",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-2",
+                                            },
+                                        ],
                                     },
                                     {
                                         "InstanceId": "i-3",
                                         "PrivateIpAddress": "ip-3",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-3",
+                                            },
+                                        ],
                                     },
                                     {
                                         "InstanceId": "i-4",
                                         "PrivateIpAddress": "ip-4",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-4",
+                                            },
+                                        ],
                                     },
                                     # Return an orphaned instance
                                     {
@@ -1696,6 +1732,15 @@ def test_manage_cluster(
                                         "PrivateIpAddress": "ip-999",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-999",
+                                            },
+                                        ],
                                     },
                                 ]
                             }
@@ -1785,6 +1830,15 @@ def test_manage_cluster(
                             "PrivateIpAddress": "ip-1234",
                             "PrivateDnsName": "hostname-1234",
                             "LaunchTime": datetime(2020, 1, 1, 0, 0, 0),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip-1234",
+                                },
+                            ],
                         }
                     ]
                 }
@@ -1852,24 +1906,60 @@ def test_manage_cluster(
                                         "PrivateIpAddress": "ip-1",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-1",
+                                            },
+                                        ],
                                     },
                                     {
                                         "InstanceId": "i-2",
                                         "PrivateIpAddress": "ip-2",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-2",
+                                            },
+                                        ],
                                     },
                                     {
                                         "InstanceId": "i-3",
                                         "PrivateIpAddress": "ip-3",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-3",
+                                            },
+                                        ],
                                     },
                                     {
                                         "InstanceId": "i-4",
                                         "PrivateIpAddress": "ip-4",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-4",
+                                            },
+                                        ],
                                     },
                                     # Return an orphaned instance
                                     {
@@ -1877,6 +1967,15 @@ def test_manage_cluster(
                                         "PrivateIpAddress": "ip-999",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-999",
+                                            },
+                                        ],
                                     },
                                 ]
                             }

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 import pytest
 from assertpy import assert_that
 from botocore.exceptions import ClientError
-from slurm_plugin.fleet_manager import Ec2CreateFleetManager, Ec2RunInstancesManager, FleetManagerFactory
+from slurm_plugin.fleet_manager import Ec2CreateFleetManager, EC2Instance, Ec2RunInstancesManager, FleetManagerFactory
 
 from tests.common import FLEET_CONFIG, MockedBoto3Request
 
@@ -420,12 +420,30 @@ class TestCreateFleetManager:
                                             "PrivateIpAddress": "ip-2",
                                             "PrivateDnsName": "hostname",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-2",
+                                                },
+                                            ],
                                         },
                                         {
                                             "InstanceId": "i-23456",
                                             "PrivateIpAddress": "ip-3",
                                             "PrivateDnsName": "hostname",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-3",
+                                                },
+                                            ],
                                         },
                                     ]
                                 }
@@ -441,12 +459,30 @@ class TestCreateFleetManager:
                         "PrivateIpAddress": "ip-2",
                         "PrivateDnsName": "hostname",
                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "DeviceIndex": 0,
+                                    "NetworkCardIndex": 0,
+                                },
+                                "PrivateIpAddress": "ip-2",
+                            },
+                        ],
                     },
                     {
                         "InstanceId": "i-23456",
                         "PrivateIpAddress": "ip-3",
                         "PrivateDnsName": "hostname",
                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "DeviceIndex": 0,
+                                    "NetworkCardIndex": 0,
+                                },
+                                "PrivateIpAddress": "ip-3",
+                            },
+                        ],
                     },
                 ],
             ),
@@ -476,6 +512,15 @@ class TestCreateFleetManager:
                                             "PrivateIpAddress": "ip-2",
                                             "PrivateDnsName": "hostname",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-2",
+                                                },
+                                            ],
                                         },
                                     ]
                                 }
@@ -491,6 +536,15 @@ class TestCreateFleetManager:
                         "PrivateIpAddress": "ip-2",
                         "PrivateDnsName": "hostname",
                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "DeviceIndex": 0,
+                                    "NetworkCardIndex": 0,
+                                },
+                                "PrivateIpAddress": "ip-2",
+                            },
+                        ],
                     }
                 ],
             ),
@@ -534,6 +588,15 @@ class TestCreateFleetManager:
                                             "PrivateIpAddress": "ip-2",
                                             "PrivateDnsName": "hostname",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-2",
+                                                },
+                                            ],
                                         },
                                     ]
                                 }
@@ -552,6 +615,15 @@ class TestCreateFleetManager:
                             "PrivateIpAddress": "ip-2",
                             "PrivateDnsName": "hostname",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip-2",
+                                },
+                            ],
                         },
                     ],
                     [],
@@ -571,12 +643,29 @@ class TestCreateFleetManager:
                                             # no private dns and address info
                                             "InstanceId": "i-12345",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                },
+                                            ],
                                         },
                                         {
                                             "InstanceId": "i-23456",
                                             "PrivateIpAddress": "ip-3",
                                             "PrivateDnsName": "hostname",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-3",
+                                                },
+                                            ],
                                         },
                                     ]
                                 }
@@ -596,6 +685,15 @@ class TestCreateFleetManager:
                                             "PrivateIpAddress": "ip-2",
                                             "PrivateDnsName": "hostname",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-2",
+                                                },
+                                            ],
                                         },
                                     ]
                                 }
@@ -614,12 +712,30 @@ class TestCreateFleetManager:
                             "PrivateIpAddress": "ip-3",
                             "PrivateDnsName": "hostname",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip-3",
+                                },
+                            ],
                         },
                         {
                             "InstanceId": "i-12345",
                             "PrivateIpAddress": "ip-2",
                             "PrivateDnsName": "hostname",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip-2",
+                                },
+                            ],
                         },
                     ],
                     [],
@@ -639,12 +755,29 @@ class TestCreateFleetManager:
                                             # no private dns and address info
                                             "InstanceId": "i-12345",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                },
+                                            ],
                                         },
                                         {
                                             "InstanceId": "i-23456",
                                             "PrivateIpAddress": "ip-3",
                                             "PrivateDnsName": "hostname",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-3",
+                                                },
+                                            ],
                                         },
                                     ]
                                 }
@@ -666,6 +799,14 @@ class TestCreateFleetManager:
                                             # no private dns and address info
                                             "InstanceId": "i-12345",
                                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                },
+                                            ],
                                         },
                                     ]
                                 }
@@ -684,6 +825,15 @@ class TestCreateFleetManager:
                             "PrivateIpAddress": "ip-3",
                             "PrivateDnsName": "hostname",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip-3",
+                                },
+                            ],
                         },
                     ],
                     ["i-12345"],
@@ -732,3 +882,71 @@ class TestCreateFleetManager:
         else:
             complete_instances, partial_instance_ids = fleet_manager._get_instances_info(instance_ids)
             assert_that(expected_result).is_equal_to((complete_instances, partial_instance_ids))
+
+    @pytest.mark.parametrize(
+        ("instance_ids", "mocked_boto3_request", "expected_result"),
+        [
+            (
+                ["i-12345"],
+                [
+                    MockedBoto3Request(
+                        method="describe_instances",
+                        response={
+                            "Reservations": [
+                                {
+                                    "Instances": [
+                                        {
+                                            "InstanceId": "i-12345",
+                                            "PrivateIpAddress": "ip-2",
+                                            "PrivateDnsName": "hostname",
+                                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                            "NetworkInterfaces": [
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 1,
+                                                    },
+                                                    "PrivateIpAddress": "ip-1",
+                                                },
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 1,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-2",
+                                                },
+                                                {
+                                                    "Attachment": {
+                                                        "DeviceIndex": 0,
+                                                        "NetworkCardIndex": 0,
+                                                    },
+                                                    "PrivateIpAddress": "ip-3",
+                                                },
+                                            ],
+                                        },
+                                    ]
+                                }
+                            ]
+                        },
+                        expected_params={"InstanceIds": ["i-12345"]},
+                        generate_error=False,
+                    ),
+                ],
+                "ip-3",
+            )
+        ],
+    )
+    def test_from_describe_instance_data(
+        self,
+        boto3_stubber,
+        mocker,
+        instance_ids,
+        mocked_boto3_request,
+        expected_result,
+    ):
+        # patch boto3 call
+        mocker.patch("time.sleep")
+        ec2_client = boto3_stubber("ec2", mocked_boto3_request)
+        instance_info = ec2_client.describe_instances(InstanceIds=instance_ids)["Reservations"][0]["Instances"][0]
+        instance_description = EC2Instance.from_describe_instance_data(instance_info)
+        assert_that(expected_result).is_equal_to(instance_description.private_ip)

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -101,6 +101,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.1",
                                 "PrivateDnsName": "ip-1-0-0-1",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.1",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -112,6 +121,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.2",
                                 "PrivateDnsName": "ip-1-0-0-2",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.2",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -123,6 +141,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.3",
                                 "PrivateDnsName": "ip-1-0-0-3",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.3",
+                                    },
+                                ],
                             },
                             {
                                 "InstanceId": "i-45678",
@@ -130,6 +157,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.4",
                                 "PrivateDnsName": "ip-1-0-0-4",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.4",
+                                    },
+                                ],
                             },
                         ]
                     },
@@ -178,6 +214,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.1",
                                 "PrivateDnsName": "ip-1-0-0-1",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.1",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -190,6 +235,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.3",
                                 "PrivateDnsName": "ip-1-0-0-3",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.3",
+                                    },
+                                ],
                             },
                             {
                                 "InstanceId": "i-45678",
@@ -197,6 +251,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.4",
                                 "PrivateDnsName": "ip-1-0-0-4",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.4",
+                                    },
+                                ],
                             },
                         ]
                     },
@@ -235,6 +298,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.1",
                                 "PrivateDnsName": "ip-1-0-0-1",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.1",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -269,6 +341,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.1",
                                 "PrivateDnsName": "ip-1-0-0-1",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.1",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -313,6 +394,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.1",
                                 "PrivateDnsName": "ip-1-0-0-1",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.1",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -325,6 +415,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.3",
                                 "PrivateDnsName": "ip-1-0-0-3",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.3",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -337,6 +436,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.4",
                                 "PrivateDnsName": "ip-1-0-0-4",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.4",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -381,6 +489,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.4",
                                 "PrivateDnsName": "ip-1-0-0-4",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.4",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -419,6 +536,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.1",
                                 "PrivateDnsName": "ip-1-0-0-1",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.1",
+                                    },
+                                ],
                             },
                             {
                                 "InstanceId": "i-22222",
@@ -426,6 +552,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.2",
                                 "PrivateDnsName": "ip-1-0-0-2",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.2",
+                                    },
+                                ],
                             },
                             {
                                 "InstanceId": "i-33333",
@@ -433,6 +568,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.3",
                                 "PrivateDnsName": "ip-1-0-0-3",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.3",
+                                    },
+                                ],
                             },
                         ]
                     },
@@ -478,6 +622,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.1",
                                 "PrivateDnsName": "ip-1-0-0-1",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.1",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -489,6 +642,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.2",
                                 "PrivateDnsName": "ip-1-0-0-2",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.2",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -500,6 +662,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.5",
                                 "PrivateDnsName": "ip-1-0-0-5",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.5",
+                                    },
+                                ],
                             }
                         ]
                     },
@@ -511,6 +682,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.3",
                                 "PrivateDnsName": "ip-1-0-0-3",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.3",
+                                    },
+                                ],
                             },
                             {
                                 "InstanceId": "i-45678",
@@ -518,6 +698,15 @@ class TestInstanceManager:
                                 "PrivateIpAddress": "ip.1.0.0.4",
                                 "PrivateDnsName": "ip-1-0-0-4",
                                 "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                "NetworkInterfaces": [
+                                    {
+                                        "Attachment": {
+                                            "DeviceIndex": 0,
+                                            "NetworkCardIndex": 0,
+                                        },
+                                        "PrivateIpAddress": "ip.1.0.0.4",
+                                    },
+                                ],
                             },
                         ]
                     },
@@ -1189,12 +1378,30 @@ class TestInstanceManager:
                                         "PrivateIpAddress": "ip-1",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-1",
+                                            },
+                                        ],
                                     },
                                     {
                                         "InstanceId": "i-2",
                                         "PrivateIpAddress": "ip-2",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-2",
+                                            },
+                                        ],
                                     },
                                 ]
                             }
@@ -1247,6 +1454,15 @@ class TestInstanceManager:
                                         "PrivateIpAddress": "ip-1",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-1",
+                                            },
+                                        ],
                                     },
                                 ]
                             }
@@ -1278,6 +1494,15 @@ class TestInstanceManager:
                                         "PrivateIpAddress": "ip-2",
                                         "PrivateDnsName": "hostname",
                                         "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                        "NetworkInterfaces": [
+                                            {
+                                                "Attachment": {
+                                                    "DeviceIndex": 0,
+                                                    "NetworkCardIndex": 0,
+                                                },
+                                                "PrivateIpAddress": "ip-2",
+                                            },
+                                        ],
                                     },
                                 ]
                             }

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -111,6 +111,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.1",
                             "PrivateDnsName": "ip-1-0-0-1",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                },
+                            ],
                         },
                         {
                             "InstanceId": "i-22222",
@@ -118,6 +127,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.2",
                             "PrivateDnsName": "ip-1-0-0-2",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.2",
+                                },
+                            ],
                         },
                         {
                             "InstanceId": "i-33333",
@@ -125,6 +143,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.3",
                             "PrivateDnsName": "ip-1-0-0-3",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.3",
+                                },
+                            ],
                         },
                     ]
                 },
@@ -169,6 +196,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.1",
                             "PrivateDnsName": "ip-1-0-0-1",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                },
+                            ],
                         },
                         {
                             "InstanceId": "i-22222",
@@ -176,6 +212,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.2",
                             "PrivateDnsName": "ip-1-0-0-2",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.2",
+                                },
+                            ],
                         },
                         {
                             "InstanceId": "i-33333",
@@ -183,6 +228,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.3",
                             "PrivateDnsName": "ip-1-0-0-3",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.3",
+                                },
+                            ],
                         },
                     ]
                 },
@@ -227,6 +281,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.1",
                             "PrivateDnsName": "ip-1-0-0-1",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                },
+                            ],
                         },
                     ]
                 },
@@ -266,6 +329,15 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                             "PrivateIpAddress": "ip.1.0.0.1",
                             "PrivateDnsName": "ip-1-0-0-1",
                             "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                },
+                            ],
                         },
                     ]
                 },


### PR DESCRIPTION
### Description of changes
Fix issue causing IP misalignment on multi NICS instances.
In particular, we consider as the instance primary IP address the one of the network interface with NetworkCardIndex 0 and DeviceIndex 0, returned by call to EC2 DescribeInstances.

Minor changes included in this PR:
1. Add a comment on a unit test that is expected to fail on MacOS
2. Add ti gitignore report and folder generated by local execution of tests.

### Tests
1. Regression tests: `test_trainium`, `test_slurm`, `test_awsbatch`, `test_mpi`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>