### PR TITLE
Fix code coverage upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e ${{ matrix.toxenv }}
+      - name: Upload code coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        if: ${{ endsWith(matrix.toxenv, '-cov') }}
+        with:
+          files: coverage.xml
+          flags: unittests
+          verbose: true
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -15,12 +15,10 @@ allowlist_externals =
     bash
 deps =
     -r tests/requirements.txt
-    cov: codecov
 commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/
     cov: python setup.py clean --all build_ext --force --inplace
-    cov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --cov=src tests/
-    cov: codecov -e TOXENV
+    cov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --cov-report=xml --cov=src tests/
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
### Description of changes
1. Remove the upload of the code coverage report to Codecov from Tox steps.
2. Add to CI workflow: upload of the code coverage report to Codecov.


### Tests
1. Verified locally that the tox env with coverage works.
2. Code coverage checks executed by GH checks in this PR.
3. Code coverage report uploaded to Codecov and displayed in the PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.