### PR TITLE
[develop]Remove duplicated log info

### DIFF
--- a/src/slurm_plugin/fleet_status_manager.py
+++ b/src/slurm_plugin/fleet_status_manager.py
@@ -77,7 +77,7 @@ class SlurmFleetManagerConfig:
             "slurm_fleet_status_manager", "logging_config", fallback=self.DEFAULTS.get("logging_config")
         )
 
-        log.info(self.__repr__())
+        log.debug(self.__repr__())
 
 
 def _manage_fleet_status_transition(config, computefleet_status_data_path):

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -124,7 +124,7 @@ class SlurmResumeConfig:
         self.logging_config = config.get("slurm_resume", "logging_config", fallback=self.DEFAULTS.get("logging_config"))
         self.head_node_instance_id = config.get("slurm_resume", "instance_id", fallback="unknown")
 
-        log.info(self.__repr__())
+        log.debug(self.__repr__())
 
 
 def _handle_failed_nodes(node_list, reason="Failure when resuming nodes"):


### PR DESCRIPTION
### Description of changes
Remove duplicated log info regarding resume and fleet_status_manager configuration. The _get_config repr object info has been moved to log debug level

Changed from
```
023-04-14 11:01:54,780 - [slurm_plugin.resume:_get_config] - INFO - SlurmResumeConfig(region='us-east-1', cluster_name='gpu-test-4', dynamodb_table='parallelcluster-slurm-gpu-test-4', hosted_zone='Z0614475DFAUBVE3UZGM', dns_domain='gpu-test-4.pcluster.', use_private_hostname=False, head_node_private_ip='192.168.27.25', head_node_hostname='ip-192-168-27-25.ec2.internal', max_batch_size=500, update_node_address=True, all_or_nothing_batch=False, fleet_config={'q1': {'c1': {'Api': 'create-fleet', 'CapacityType': 'on-demand', 'AllocationStrategy': 'lowest-price', 'Instances': [{'InstanceType': 'g4dn.12xlarge'}], 'Networking': {'SubnetIds': ['subnet-0fd51fa2857cb2041']}}}, 'q2': {'c2': {'Api': 'run-instances', 'Instances': [{'InstanceType': 'p4d.24xlarge'}]}}, 'q3': {'c3': {'Api': 'create-fleet', 'CapacityType': 'on-demand', 'AllocationStrategy': 'lowest-price', 'Instances': [{'InstanceType': 'p3.16xlarge'}], 'Networking': {'SubnetIds': ['subnet-0fd51fa2857cb2041']}}}}, run_instances_overrides={}, create_fleet_overrides={}, clustermgtd_timeout=300, clustermgtd_heartbeat_file_path='/opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat', _boto3_retry=1, _boto3_config={'retries': {'max_attempts': 1, 'mode': 'standard'}}, boto3_config=<botocore.config.Config object at 0x7fcd38d5d7f0>, logging_config='/opt/parallelcluster/pyenv/versions/3.9.16/envs/node_virtualenv/lib/python3.9/site-packages/slurm_plugin/logging/parallelcluster_resume_logging.conf', head_node_instance_id='i-0ab10018ca4e5cab5')

2023-04-14 11:01:54,781 - [slurm_plugin.resume:main] - INFO - ResumeProgram config: SlurmResumeConfig(region='us-east-1', cluster_name='gpu-test-4', dynamodb_table='parallelcluster-slurm-gpu-test-4', hosted_zone='Z0614475DFAUBVE3UZGM', dns_domain='gpu-test-4.pcluster.', use_private_hostname=False, head_node_private_ip='192.168.27.25', head_node_hostname='ip-192-168-27-25.ec2.internal', max_batch_size=500, update_node_address=True, all_or_nothing_batch=False, fleet_config={'q1': {'c1': {'Api': 'create-fleet', 'CapacityType': 'on-demand', 'AllocationStrategy': 'lowest-price', 'Instances': [{'InstanceType': 'g4dn.12xlarge'}], 'Networking': {'SubnetIds': ['subnet-0fd51fa2857cb2041']}}}, 'q2': {'c2': {'Api': 'run-instances', 'Instances': [{'InstanceType': 'p4d.24xlarge'}]}}, 'q3': {'c3': {'Api': 'create-fleet', 'CapacityType': 'on-demand', 'AllocationStrategy': 'lowest-price', 'Instances': [{'InstanceType': 'p3.16xlarge'}], 'Networking': {'SubnetIds': ['subnet-0fd51fa2857cb2041']}}}}, run_instances_overrides={}, create_fleet_overrides={}, clustermgtd_timeout=300, clustermgtd_heartbeat_file_path='/opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat', _boto3_retry=1, _boto3_config={'retries': {'max_attempts': 1, 'mode': 'standard'}}, boto3_config=<botocore.config.Config object at 0x7fcd38d5d7f0>, logging_config='/opt/parallelcluster/pyenv/versions/3.9.16/envs/node_virtualenv/lib/python3.9/site-packages/slurm_plugin/logging/parallelcluster_resume_logging.conf', head_node_instance_id='i-0ab10018ca4e5cab5')
```
to
```
2023-04-14 11:01:54,781 - [slurm_plugin.resume:main] - INFO - ResumeProgram config: SlurmResumeConfig(region='us-east-1', cluster_name='gpu-test-4', dynamodb_table='parallelcluster-slurm-gpu-test-4', hosted_zone='Z0614475DFAUBVE3UZGM', dns_domain='gpu-test-4.pcluster.', use_private_hostname=False, head_node_private_ip='192.168.27.25', head_node_hostname='ip-192-168-27-25.ec2.internal', max_batch_size=500, update_node_address=True, all_or_nothing_batch=False, fleet_config={'q1': {'c1': {'Api': 'create-fleet', 'CapacityType': 'on-demand', 'AllocationStrategy': 'lowest-price', 'Instances': [{'InstanceType': 'g4dn.12xlarge'}], 'Networking': {'SubnetIds': ['subnet-0fd51fa2857cb2041']}}}, 'q2': {'c2': {'Api': 'run-instances', 'Instances': [{'InstanceType': 'p4d.24xlarge'}]}}, 'q3': {'c3': {'Api': 'create-fleet', 'CapacityType': 'on-demand', 'AllocationStrategy': 'lowest-price', 'Instances': [{'InstanceType': 'p3.16xlarge'}], 'Networking': {'SubnetIds': ['subnet-0fd51fa2857cb2041']}}}}, run_instances_overrides={}, create_fleet_overrides={}, clustermgtd_timeout=300, clustermgtd_heartbeat_file_path='/opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat', _boto3_retry=1, _boto3_config={'retries': {'max_attempts': 1, 'mode': 'standard'}}, boto3_config=<botocore.config.Config object at 0x7fcd38d5d7f0>, logging_config='/opt/parallelcluster/pyenv/versions/3.9.16/envs/node_virtualenv/lib/python3.9/site-packages/slurm_plugin/logging/parallelcluster_resume_logging.conf', head_node_instance_id='i-0ab10018ca4e5cab5')
```

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.