### PR TITLE
[develop] Job Level Scaling for exclusive nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **ENHANCEMENTS**
 
 **CHANGES**
+- Perform job level scaling for exclusive jobs, by reading at job information from `SLURM_RESUME_FILE`. 
 
 **BUG FIXES**
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -827,10 +827,10 @@ class ClusterManager:
                 instances_to_terminate, terminate_batch_size=self._config.terminate_max_batch_size
             )
         log.info("Launching new instances for unhealthy static nodes")
-        self._instance_manager.add_instances_for_nodes(
-            node_list,
-            self._config.launch_max_batch_size,
-            self._config.update_node_address,
+        self._instance_manager.add_instances(
+            node_list=node_list,
+            launch_batch_size=self._config.launch_max_batch_size,
+            update_node_address=self._config.update_node_address,
         )
         # Add launched nodes to list of nodes being replaced, excluding any nodes that failed to launch
         failed_nodes = set().union(*self._instance_manager.failed_nodes.values())

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -44,6 +44,7 @@ class SlurmResumeConfig:
         "create_fleet_overrides": "/opt/slurm/etc/pcluster/create_fleet_overrides.json",
         "fleet_config_file": "/etc/parallelcluster/slurm_plugin/fleet-config.json",
         "all_or_nothing_batch": False,
+        "job_level_scaling": True,
     }
 
     def __init__(self, config_file_path):
@@ -82,6 +83,9 @@ class SlurmResumeConfig:
         )
         self.all_or_nothing_batch = config.getboolean(
             "slurm_resume", "all_or_nothing_batch", fallback=self.DEFAULTS.get("all_or_nothing_batch")
+        )
+        self.job_level_scaling = config.getboolean(
+            "slurm_resume", "job_level_scaling", fallback=self.DEFAULTS.get("job_level_scaling")
         )
         fleet_config_file = config.get(
             "slurm_resume", "fleet_config_file", fallback=self.DEFAULTS.get("fleet_config_file")
@@ -184,13 +188,14 @@ def _resume(arg_nodes, resume_config, slurm_resume):
         fleet_config=resume_config.fleet_config,
         run_instances_overrides=resume_config.run_instances_overrides,
         create_fleet_overrides=resume_config.create_fleet_overrides,
-        slurm_resume=slurm_resume,
     )
-    instance_manager.add_instances_for_nodes(
+    instance_manager.add_instances(
+        slurm_resume=slurm_resume,
         node_list=node_list,
         launch_batch_size=resume_config.max_batch_size,
         update_node_address=resume_config.update_node_address,
         all_or_nothing_batch=resume_config.all_or_nothing_batch,
+        job_level_scaling=resume_config.job_level_scaling,
     )
     failed_nodes = set().union(*instance_manager.failed_nodes.values())
     success_nodes = [node for node in node_list if node not in failed_nodes]

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1117,8 +1117,8 @@ def test_handle_unhealthy_static_nodes(
     cluster_manager._instance_manager._store_assigned_hostnames = mocker.MagicMock()
     cluster_manager._instance_manager._update_dns_hostnames = mocker.MagicMock()
     # Mock add_instances_for_nodes but still try to execute original code
-    original_add_instances = cluster_manager._instance_manager.add_instances_for_nodes
-    cluster_manager._instance_manager.add_instances_for_nodes = mocker.MagicMock(side_effect=original_add_instances)
+    original_add_instances = cluster_manager._instance_manager.add_instances
+    cluster_manager._instance_manager.add_instances = mocker.MagicMock(side_effect=original_add_instances)
     reset_mock = mocker.patch("slurm_plugin.clustermgtd.reset_nodes", autospec=True)
     if set_nodes_down_exception is Exception:
         reset_mock.side_effect = set_nodes_down_exception
@@ -1146,7 +1146,9 @@ def test_handle_unhealthy_static_nodes(
         )
     else:
         cluster_manager._instance_manager.delete_instances.assert_not_called()
-    cluster_manager._instance_manager.add_instances_for_nodes.assert_called_with(add_node_list, 5, True)
+    cluster_manager._instance_manager.add_instances.assert_called_with(
+        node_list=add_node_list, launch_batch_size=5, update_node_address=True
+    )
     assert_that(caplog.records).is_length(len(expected_warnings))
     for actual, expected in zip(caplog.records, expected_warnings):
         assert_that(actual.message).matches(expected)

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -53,6 +53,7 @@ def boto3_stubber_path():
                 "all_or_nothing_batch": False,
                 "clustermgtd_timeout": 300,
                 "clustermgtd_heartbeat_file_path": "/home/ec2-user/clustermgtd_heartbeat",
+                "job_level_scaling": True,
             },
         ),
         (
@@ -70,6 +71,7 @@ def boto3_stubber_path():
                 "all_or_nothing_batch": True,
                 "clustermgtd_timeout": 5,
                 "clustermgtd_heartbeat_file_path": "alternate/clustermgtd_heartbeat",
+                "job_level_scaling": False,
             },
         ),
     ],
@@ -407,6 +409,7 @@ def test_resume_launch(
         dns_domain=None,
         use_private_hostname=False,
         head_node_instance_id="i-headnode",
+        job_level_scaling=True,
     )
     mocker.patch("slurm_plugin.resume.is_clustermgtd_heartbeat_valid", autospec=True, return_value=is_heartbeat_valid)
     mock_handle_failed_nodes = mocker.patch("slurm_plugin.resume._handle_failed_nodes", autospec=True)

--- a/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
+++ b/tests/slurm_plugin/test_resume/test_resume_config/all_options.conf
@@ -16,3 +16,4 @@ use_private_hostname = False
 all_or_nothing_batch = True
 clustermgtd_heartbeat_file_path = alternate/clustermgtd_heartbeat
 clustermgtd_timeout = 5
+job_level_scaling = False


### PR DESCRIPTION
### Description of changes
Perform job level scaling for exclusive jobs, by reading at job information from `SLURM_RESUME_FILE`. 

Job objects are built from SLURM_RESUME_FILE content, and split into two list, based on the value of the Oversubscribe property.

Nodes for job with Oversubscribe=NO are launched on a per job basis, while nodes for job with Oversubscribe!=NO are launched all together in single call.

A new `job_level_scaling` resume configuration parameter is added, so to allow to switch back from job level scaling to node list scaling

### Tests
* unit tests added
* manual tests performed
* integration tests will be added in another PR (on CLI code)

### References
* https://github.com/aws/aws-parallelcluster-node/pull/526

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.