### PR TITLE
Fix FleetManager behavior when create-fleet returns no instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ This file is used to list changes made in each version of the aws-parallelcluste
 3.6.1
 ------
 
-**CHANGES**
-- There were no changes for this version.
+**BUG FIXES**
+- Fix fast insufficient capacity fail-over logic when using Multiple Instance Types and no instances are returned
 
 3.6.0
 ------

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -216,11 +216,20 @@ class InstanceManager:
                     print_with_count(zip(launched_nodes, launched_instances)),
                 )
             if fail_launch_nodes:
-                logger.warning(
-                    "Failed to launch instances due to limited EC2 capacity for following nodes: %s",
-                    print_with_count(fail_launch_nodes),
-                )
-                self._update_failed_nodes(set(fail_launch_nodes), "LimitedInstanceCapacity")
+                if launched_nodes:
+                    logger.warning(
+                        "Failed to launch instances due to limited EC2 capacity for following nodes: %s",
+                        print_with_count(fail_launch_nodes),
+                    )
+                    self._update_failed_nodes(set(fail_launch_nodes), "LimitedInstanceCapacity")
+                else:
+                    # EC2 Fleet doens't trigger any exception in case of ICEs and may return more than one error
+                    # for each request. So when no instances were launched we force the reason to ICE
+                    logger.error(
+                        "Failed to launch instances due to limited EC2 capacity for following nodes: %s",
+                        print_with_count(fail_launch_nodes),
+                    )
+                    self._update_failed_nodes(set(fail_launch_nodes), "InsufficientInstanceCapacity")
 
             return dict(zip(launched_nodes, launched_instances))
 

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -816,7 +816,7 @@ class TestInstanceManager:
                 ["queue1-st-c5xlarge-1"],
                 {},
                 None,
-                {"LimitedInstanceCapacity": {"queue1-st-c5xlarge-1"}},
+                {"InsufficientInstanceCapacity": {"queue1-st-c5xlarge-1"}},
                 False,
                 "dns.domain",
             ),


### PR DESCRIPTION
### Description of changes
Fix FleetManager behavior when create-fleet returns no instances

In case of ICE create-fleet doesn't raise an exception and the default behavior isn't triggered This change forces the failure reason to ICE when create-fleet doesn't return any instance

* Added new behavior when create-fleet returns no instances
* Changed unit test according to new behavior
* Updated Changelog

### Tests
* Unit tests executed locally.
* Integration test will be extended on the CLI.

### References
* TODO: Add CLI integ-test PR when ready.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.
