### PR TITLE
Port changes related to release 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This file is used to list changes made in each version of the aws-parallelcluste
 
 **BUG FIXES**
 
+3.6.1
+------
+
+**CHANGES**
+- There were no changes for this version.
+
 3.6.0
 ------
 


### PR DESCRIPTION
### Description of changes
Port changes related to release 3.6.1. In particular:
1. Add CHANGELOG entries for version 3.6.1. https://github.com/aws/aws-parallelcluster-node/pull/531

### Tests
Not needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.