### PR TITLE
[release-3.6] Fix FleetManager behavior when create-fleet returns no instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This file is used to list changes made in each version of the aws-parallelcluste
 3.6.1
 ------
 
-**CHANGES**
-- There were no changes for this version.
+**BUG FIXES**
+- Fix fast insufficient capacity fail-over logic when using Multiple Instance Types and no instances are returned
 
 3.6.0
 ------

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -167,11 +167,20 @@ class InstanceManager:
                     print_with_count(zip(launched_nodes, launched_instances)),
                 )
             if fail_launch_nodes:
-                logger.warning(
-                    "Failed to launch instances due to limited EC2 capacity for following nodes: %s",
-                    print_with_count(fail_launch_nodes),
-                )
-                self._update_failed_nodes(set(fail_launch_nodes), "LimitedInstanceCapacity")
+                if launched_nodes:
+                    logger.warning(
+                        "Failed to launch instances due to limited EC2 capacity for following nodes: %s",
+                        print_with_count(fail_launch_nodes),
+                    )
+                    self._update_failed_nodes(set(fail_launch_nodes), "LimitedInstanceCapacity")
+                else:
+                    # EC2 Fleet doens't trigger any exception in case of ICEs and may return more than one error
+                    # for each request. So when no instances were launched we force the reason to ICE
+                    logger.error(
+                        "Failed to launch instances due to limited EC2 capacity for following nodes: %s",
+                        print_with_count(fail_launch_nodes),
+                    )
+                    self._update_failed_nodes(set(fail_launch_nodes), "InsufficientInstanceCapacity")
 
             return dict(zip(launched_nodes, launched_instances))
 

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -814,7 +814,7 @@ class TestInstanceManager:
                 ["queue1-st-c5xlarge-1"],
                 {},
                 None,
-                {"LimitedInstanceCapacity": {"queue1-st-c5xlarge-1"}},
+                {"InsufficientInstanceCapacity": {"queue1-st-c5xlarge-1"}},
                 False,
                 "dns.domain",
             ),


### PR DESCRIPTION
In case of ICE create-fleet doesn't raise an exception and the default behavior isn't triggered This change forces the failure reason to ICE when create-fleet doens't return any instance


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* [PR for develop branch](https://github.com/aws/aws-parallelcluster-node/pull/528)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
