### PR TITLE
[3.6] Avoid duplication of nodes in `ClusterManager._find_active_nodes()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file is used to list changes made in each version of the aws-parallelcluste
 3.6.1
 ------
 
+**CHANGES**
+- Avoid duplication of nodes seen by ClusterManager if compute nodes are added to multiple Slurm partitions.
+
 **BUG FIXES**
 - Fix fast insufficient capacity fail-over logic when using Multiple Instance Types and no instances are returned
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1123,12 +1123,11 @@ class ClusterManager:
 
     @staticmethod
     def _find_active_nodes(partitions_name_map):
-        active_nodes = set()
+        active_nodes = []
         for partition in partitions_name_map.values():
             if partition.state != "INACTIVE":
-                active_nodes |= set(partition.slurm_nodes)
-        # TODO: Returning the set breaks some unit tests (I believe the unit test should be revised though).
-        return sorted(list(active_nodes), key=str)
+                active_nodes += partition.slurm_nodes
+        return list(dict.fromkeys(active_nodes))
 
     def _is_node_in_replacement_valid(self, node, check_node_is_valid):
         """

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1123,11 +1123,12 @@ class ClusterManager:
 
     @staticmethod
     def _find_active_nodes(partitions_name_map):
-        active_nodes = []
+        active_nodes = set()
         for partition in partitions_name_map.values():
             if partition.state != "INACTIVE":
-                active_nodes += partition.slurm_nodes
-        return active_nodes
+                active_nodes |= set(partition.slurm_nodes)
+        # TODO: Returning the set breaks some unit tests (I believe the unit test should be revised though).
+        return sorted(list(active_nodes), key=str)
 
     def _is_node_in_replacement_valid(self, node, check_node_is_valid):
         """

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -15,6 +15,7 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from typing import List
 
 from common.utils import time_is_up
 
@@ -49,12 +50,12 @@ class PartitionStatus(Enum):
 
 
 class SlurmPartition:
-    def __init__(self, name, nodenames, state):
+    def __init__(self, name, nodenames, state, slurm_nodes: List = None):
         """Initialize slurm partition with attributes."""
         self.name = name
         self.nodenames = nodenames
         self.state = state
-        self.slurm_nodes = []
+        self.slurm_nodes = slurm_nodes if slurm_nodes else []
 
     def is_inactive(self):
         return self.state == "INACTIVE"

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -15,7 +15,6 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import List
 
 from common.utils import time_is_up
 
@@ -50,12 +49,12 @@ class PartitionStatus(Enum):
 
 
 class SlurmPartition:
-    def __init__(self, name, nodenames, state, slurm_nodes: List = None):
+    def __init__(self, name, nodenames, state):
         """Initialize slurm partition with attributes."""
         self.name = name
         self.nodenames = nodenames
         self.state = state
-        self.slurm_nodes = slurm_nodes if slurm_nodes else []
+        self.slurm_nodes = []
 
     def is_inactive(self):
         return self.state == "INACTIVE"

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -3736,7 +3736,7 @@ def test_find_unhealthy_slurm_nodes(
     [
         pytest.param(
             {
-                "queue1": SlurmPartition(
+                "queue1": SimpleNamespace(
                     name="queue1",
                     nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
                     state="UP",
@@ -3745,7 +3745,7 @@ def test_find_unhealthy_slurm_nodes(
                         StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
                     ],
                 ),
-                "queue2": SlurmPartition(
+                "queue2": SimpleNamespace(
                     name="queue2",
                     nodenames="queue2-st-cr1-1,queue2-st-cr1-2",
                     state="UP",
@@ -3765,7 +3765,7 @@ def test_find_unhealthy_slurm_nodes(
         ),
         pytest.param(
             {
-                "queue1": SlurmPartition(
+                "queue1": SimpleNamespace(
                     name="queue1",
                     nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
                     state="UP",
@@ -3774,7 +3774,7 @@ def test_find_unhealthy_slurm_nodes(
                         StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
                     ],
                 ),
-                "custom_partition": SlurmPartition(
+                "custom_partition": SimpleNamespace(
                     name="custom_partition",
                     nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
                     state="UP",
@@ -3790,6 +3790,62 @@ def test_find_unhealthy_slurm_nodes(
             ],
             id="Two overlapping partitions obtained by creating a custom partition that includes nodes from a "
             "PC-managed queue",
+        ),
+        pytest.param(
+            {},
+            [],
+            id="Empty cluster with no partitions",
+        ),
+        pytest.param(
+            {
+                "queue1": SimpleNamespace(
+                    name="queue1",
+                    nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
+                    state="UP",
+                    slurm_nodes=[
+                        StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+                "queue2": SimpleNamespace(
+                    name="queue2",
+                    nodenames="queue2-st-cr1-1,queue2-st-cr1-2",
+                    state="INACTIVE",
+                    slurm_nodes=[
+                        StaticNode(name="queue2-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue2-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+            },
+            [
+                StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+            ],
+            id="Two non-overlapping partitions, one active and one inactive",
+        ),
+        pytest.param(
+            {
+                "queue1": SimpleNamespace(
+                    name="queue1",
+                    nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
+                    state="INACTIVE",
+                    slurm_nodes=[
+                        StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+                "queue2": SimpleNamespace(
+                    name="queue2",
+                    nodenames="queue2-st-cr1-1,queue2-st-cr1-2",
+                    state="INACTIVE",
+                    slurm_nodes=[
+                        StaticNode(name="queue2-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue2-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+            },
+            [],
+            id="Two inactive non-overlapping partitions",
         ),
     ],
 )

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1314,14 +1314,13 @@ def test_maintain_nodes(
     # Run test
     cluster_manager._maintain_nodes(partitions, {})
     # Check function calls
-    active_nodes_sorted = sorted(active_nodes, key=str)
-    mock_update_replacement.assert_called_with(active_nodes_sorted)
+    mock_update_replacement.assert_called_with(active_nodes)
     mock_handle_dynamic.assert_called_with(expected_unhealthy_dynamic_nodes)
     mock_handle_static.assert_called_with(expected_unhealthy_static_nodes)
-    mock_handle_powering_down_nodes.assert_called_with(active_nodes_sorted)
-    mock_handle_failed_health_check_nodes_in_replacement.assert_called_with(active_nodes_sorted)
+    mock_handle_powering_down_nodes.assert_called_with(active_nodes)
+    mock_handle_failed_health_check_nodes_in_replacement.assert_called_with(active_nodes)
     if _is_protected_mode_enabled:
-        mock_handle_protected_mode_process.assert_called_with(active_nodes_sorted, partitions)
+        mock_handle_protected_mode_process.assert_called_with(active_nodes, partitions)
     else:
         mock_handle_protected_mode_process.assert_not_called()
 
@@ -3795,21 +3794,6 @@ def test_find_unhealthy_slurm_nodes(
     ],
 )
 def test_find_active_nodes(partitions_name_map, expected_nodelist):
-    """
-    Unit test for the `ClusterManager._find_active_nodes()` method.
-
-    Some context about the way this test is implemented:
-    - `ClusterManager._find_active_nodes()` may be implemented to return different types of iterables.
-      This test was implemented together with a fix that changed the return type from a list to a set,
-      and it was desirable to have the test compatible with both return types.
-    - The implementation that returned a list caused a duplication of node entities in the returned iterable
-      in case the same node belonged to multiple Slurm partitions (via a customization of the Slurm configuration).
-    - Due to the way we implement the `__hash__()` dunder method for the SlurmNode class, two different
-      SlurmNode objects with the same node name are squashed into the same entity in a set. Therefore
-      we cannot use `set(expected_nodelist)` when trying to test the duplication of the node entities
-      in the iterable returned by `ClusterManager._find_active_nodes()`.
-    - Sets are unordered, so when transforming them into lists we have to sort them to make them comparable with
-      the `expected_nodelist`.
-    """
-    result_nodelist = sorted(list(ClusterManager._find_active_nodes(partitions_name_map)), key=str)
-    assert_that(result_nodelist).is_equal_to(sorted(expected_nodelist, key=str))
+    """Unit test for the `ClusterManager._find_active_nodes()` method."""
+    result_nodelist = ClusterManager._find_active_nodes(partitions_name_map)
+    assert_that(result_nodelist).is_equal_to(expected_nodelist)

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -1314,13 +1314,14 @@ def test_maintain_nodes(
     # Run test
     cluster_manager._maintain_nodes(partitions, {})
     # Check function calls
-    mock_update_replacement.assert_called_with(active_nodes)
+    active_nodes_sorted = sorted(active_nodes, key=str)
+    mock_update_replacement.assert_called_with(active_nodes_sorted)
     mock_handle_dynamic.assert_called_with(expected_unhealthy_dynamic_nodes)
     mock_handle_static.assert_called_with(expected_unhealthy_static_nodes)
-    mock_handle_powering_down_nodes.assert_called_with(active_nodes)
-    mock_handle_failed_health_check_nodes_in_replacement.assert_called_with(active_nodes)
+    mock_handle_powering_down_nodes.assert_called_with(active_nodes_sorted)
+    mock_handle_failed_health_check_nodes_in_replacement.assert_called_with(active_nodes_sorted)
     if _is_protected_mode_enabled:
-        mock_handle_protected_mode_process.assert_called_with(active_nodes, partitions)
+        mock_handle_protected_mode_process.assert_called_with(active_nodes_sorted, partitions)
     else:
         mock_handle_protected_mode_process.assert_not_called()
 
@@ -3729,3 +3730,86 @@ def test_find_unhealthy_slurm_nodes(
     assert_that(unhealthy_dynamic_nodes).is_equal_to(expected_unhealthy_dynamic_nodes)
     assert_that(unhealthy_static_nodes).is_equal_to(expected_unhealthy_static_nodes)
     assert_that(ice_compute_resources_and_nodes_map).is_equal_to(expected_ice_compute_resources_and_nodes_map)
+
+
+@pytest.mark.parametrize(
+    "partitions_name_map, expected_nodelist",
+    [
+        pytest.param(
+            {
+                "queue1": SlurmPartition(
+                    name="queue1",
+                    nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
+                    state="UP",
+                    slurm_nodes=[
+                        StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+                "queue2": SlurmPartition(
+                    name="queue2",
+                    nodenames="queue2-st-cr1-1,queue2-st-cr1-2",
+                    state="UP",
+                    slurm_nodes=[
+                        StaticNode(name="queue2-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue2-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+            },
+            [
+                StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                StaticNode(name="queue2-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                StaticNode(name="queue2-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+            ],
+            id="Two non-overlapping partitions",
+        ),
+        pytest.param(
+            {
+                "queue1": SlurmPartition(
+                    name="queue1",
+                    nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
+                    state="UP",
+                    slurm_nodes=[
+                        StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+                "custom_partition": SlurmPartition(
+                    name="custom_partition",
+                    nodenames="queue1-st-cr1-1,queue1-st-cr1-2",
+                    state="UP",
+                    slurm_nodes=[
+                        StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                        StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+                    ],
+                ),
+            },
+            [
+                StaticNode(name="queue1-st-cr1-1", nodeaddr="", nodehostname="", state=""),
+                StaticNode(name="queue1-st-cr1-2", nodeaddr="", nodehostname="", state=""),
+            ],
+            id="Two overlapping partitions obtained by creating a custom partition that includes nodes from a "
+            "PC-managed queue",
+        ),
+    ],
+)
+def test_find_active_nodes(partitions_name_map, expected_nodelist):
+    """
+    Unit test for the `ClusterManager._find_active_nodes()` method.
+
+    Some context about the way this test is implemented:
+    - `ClusterManager._find_active_nodes()` may be implemented to return different types of iterables.
+      This test was implemented together with a fix that changed the return type from a list to a set,
+      and it was desirable to have the test compatible with both return types.
+    - The implementation that returned a list caused a duplication of node entities in the returned iterable
+      in case the same node belonged to multiple Slurm partitions (via a customization of the Slurm configuration).
+    - Due to the way we implement the `__hash__()` dunder method for the SlurmNode class, two different
+      SlurmNode objects with the same node name are squashed into the same entity in a set. Therefore
+      we cannot use `set(expected_nodelist)` when trying to test the duplication of the node entities
+      in the iterable returned by `ClusterManager._find_active_nodes()`.
+    - Sets are unordered, so when transforming them into lists we have to sort them to make them comparable with
+      the `expected_nodelist`.
+    """
+    result_nodelist = sorted(list(ClusterManager._find_active_nodes(partitions_name_map)), key=str)
+    assert_that(result_nodelist).is_equal_to(sorted(expected_nodelist, key=str))


### PR DESCRIPTION
### Description of changes
* Avoid duplication of nodes in `ClusterManager._find_active_nodes()` when nodes belong to multiple Slurm partitions.
* This is relevant only in cases when the Slurm partition configuration is edited and PC-managed nodes are added to multiple custom partitions.
* Small extention to the `SlurmNode` class constructor to allow specifying the `slurm_nodes` attribute at object creation.

### Tests
* Added unit test to verify that overlapping partitions do not lead to duplication of nodes in the group returned by
`ClusterManager._find_active_nodes()`.
* Adapted existing tests to new logic.

### References
* Related to https://github.com/aws/aws-parallelcluster/issues/5404
* See also https://github.com/aws/aws-parallelcluster-node/pull/538

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.