### PR TITLE
[develop] Optimize job level scaling with preliminary scale-all nodes attempt

### DIFF
--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -150,10 +150,17 @@ class SlurmResumeJob(SlurmJob):
 
 @dataclass
 class SlurmResumeData:
+    # List of exclusive job allocated to 1 node each
     jobs_single_node_no_oversubscribe: List[SlurmResumeJob]
+    # List of exclusive job allocated to more than 1 node each
     jobs_multi_node_no_oversubscribe: List[SlurmResumeJob]
+    # List of non-exclusive job
     jobs_oversubscribe: List[SlurmResumeJob]
-    nodes_no_oversubscribe: List[str]
+    # List of node allocated to single node exclusive job
+    single_node_no_oversubscribe: List[str]
+    # List of node allocated to multiple node exclusive job
+    multi_node_no_oversubscribe: List[str]
+    # List of node allocated to non-exclusive job
     nodes_oversubscribe: List[str]
 
 


### PR DESCRIPTION
### Description of changes
Optimize job level scaling by performing a preliminary attempt to scale-all nodes for jobs, before going into job loop, so to save the time needed to loop for all jobs in a resume call.


### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.