### PR TITLE
[develop] Continue job level scaling optimization for other compute resources

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -1032,11 +1032,12 @@ class JobLevelScalingInstanceManager(InstanceManager):
                             #   queue_2: {cr_3: list[EC2Instance]}
                             # }
 
-                            if all_or_nothing_batch and len(launched_ec2_instances) < len(batch_nodes):
-                                # Exit fast if not all the requested capacity can be launched
-                                # Return the EC2 instances launched so far,
+                            if job and all_or_nothing_batch and len(launched_ec2_instances) < len(batch_nodes):
+                                # When launching instances for a specific Job,
+                                # exit fast if not all the requested capacity can be launched,
+                                # returning the EC2 instances launched so far,
                                 # so that they can be eventually allocated to other Slurm nodes
-                                # Handle CreateFleet case, which doesn't fail when no capacity is returned
+                                # This path handle the CreateFleet case, which doesn't fail when no capacity is returned
                                 return instances_launched
                         except (ClientError, Exception) as e:
                             logger.error(
@@ -1044,12 +1045,13 @@ class JobLevelScalingInstanceManager(InstanceManager):
                                 print_with_count(batch_nodes),
                                 e,
                             )
-                            if all_or_nothing_batch:
-                                # Exit fast if not all the requested capacity can be launched
-                                # Return the EC2 instances launched so far,
+                            if job and all_or_nothing_batch:
+                                # When launching instances for a specific Job,
+                                # exit fast if not all the requested capacity can be launched,
+                                # returning the EC2 instances launched so far,
                                 # so that they can be eventually allocated to other Slurm nodes
-                                # Handle RunInstances case, which throw an exc when no capacity is returned
-                                # Handle CreateFleet case when exc is thrown
+                                # This path handle the RunInstances case, which throw an exc when
+                                # no capacity is returned, and handle the CreateFleet case when exc is thrown
                                 return instances_launched
 
         return instances_launched


### PR DESCRIPTION
### Description of changes
For the case when we are performing node-list scaling before job-level scaling, avoid to stop launching instances when there is no capacity for a given compute resource, by continuing the loop for other compute resources

Ref https://github.com/aws/aws-parallelcluster-node/pull/541

### Tests
added unit tests

### References
https://github.com/aws/aws-parallelcluster-node/pull/541

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.