### PR TITLE
[develop] Keep fast capacity failover consistent with current behavior

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -776,7 +776,7 @@ class JobLevelScalingInstanceManager(InstanceManager):
         self.unused_launched_instances |= self._launch_instances(
             nodes_to_launch=self._parse_requested_nodes(node_list),
             launch_batch_size=launch_batch_size,
-            all_or_nothing_batch=True,
+            all_or_nothing_batch=False,
         )
 
         self._scaling_for_jobs(


### PR DESCRIPTION
### Description of changes
* Keep fast capacity failover consistent with current behavior, which is activating fast failover at the first batch launch failure, and not wait to consider failure on the whole aggregated capacity

* Switch preliminary scale-all nodes attempt to be best-effort 
  
  Optimize job level scaling with preliminary scale-all nodes attempt.
  Switch this preliminary scaling from all-or-nothing to best-effort, so to maximize instance launches

### Tests
* unit tests added
* manually tested on running cluster

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.