### PR TITLE
Fix slurm_resume.event message when dynamic node fails to launch

### DIFF
--- a/src/slurm_plugin/cluster_event_publisher.py
+++ b/src/slurm_plugin/cluster_event_publisher.py
@@ -36,8 +36,12 @@ _LAUNCH_FAILURE_GROUPING = {
 }
 
 
-NODE_LAUNCH_FAILURE_COUNT = {
+STATIC_NODE_LAUNCH_FAILURE_COUNT = {
     "message": "Number of static nodes that failed to launch a backing instance after node maintenance",
+    "event_type": "node-launch-failure-count",
+}
+DYNAMIC_NODE_LAUNCH_FAILURE_COUNT = {
+    "message": "Number of dynamic nodes that failed to launch a backing instance",
     "event_type": "node-launch-failure-count",
 }
 NODE_LAUNCH_FAILURE = {
@@ -192,7 +196,7 @@ class ClusterEventPublisher:
         for count, error_detail in self._generate_launch_failure_details(failed_nodes):
             self.publish_event(
                 logging.WARNING if count else logging.DEBUG,
-                **NODE_LAUNCH_FAILURE_COUNT,
+                **STATIC_NODE_LAUNCH_FAILURE_COUNT,
                 timestamp=timestamp,
                 detail=error_detail,
             )
@@ -497,7 +501,7 @@ class ClusterEventPublisher:
         for count, error_detail in self._generate_launch_failure_details(failed_nodes):
             self.publish_event(
                 logging.WARNING if count else logging.DEBUG,
-                **NODE_LAUNCH_FAILURE_COUNT,
+                **DYNAMIC_NODE_LAUNCH_FAILURE_COUNT,
                 timestamp=timestamp,
                 detail=error_detail,
             )


### PR DESCRIPTION
### Description of changes
* Fix the message in slurm_resume.events when dynamic node fails to launch, change the message from "Number of static nodes that failed to launch a backing instance after node maintenance" to ""Number of dynamic nodes that failed to launch a backing instance"

### Tests
* Manual test
* After the fix
 ```
(cookbook_virtualenv) [root@ip-192-168-32-56 slurm_plugin]# cat /var/log/parallelcluster/slurm_resume.events
{"datetime": "2023-08-11T21:17:28.556+00:00", "version": 0, "scheduler": "slurm", "cluster-name": "test-gpujob2", "node-role": "HeadNode", "component": "slurm-resume", "level": "WARNING", "instance-id": "i-04dba46edcc07a967", "event-type": "node-launch-failure-count", "message": "Number of dynamic nodes that failed to launch a backing instance", "detail": {"failure-type": "ice-failures", "count": 1, "error-details": {"InsufficientHostCapacity": {"count": 1, "nodes": [{"name": "queue-1-dy-test-resume-3"}]}}}}
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
