### PR TITLE
[develop][wip-1] Job Level Scaling for Node Sharing case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 **ENHANCEMENTS**
 
 **CHANGES**
+- WIP Perform default job-level scaling for all jobs, by reading job information from `SLURM_RESUME_FILE`.
 
 **BUG FIXES**
 

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -47,6 +47,7 @@ class SlurmResumeConfig:
         "fleet_config_file": "/etc/parallelcluster/slurm_plugin/fleet-config.json",
         "all_or_nothing_batch": False,
         "job_level_scaling": True,
+        "temp_jls_for_node_sharing": False,
     }
 
     def __init__(self, config_file_path):
@@ -94,6 +95,9 @@ class SlurmResumeConfig:
         )
         self.job_level_scaling = config.getboolean(
             "slurm_resume", "job_level_scaling", fallback=self.DEFAULTS.get("job_level_scaling")
+        )
+        self.temp_jls_for_node_sharing = config.getboolean(
+            "slurm_resume", "temp_jls_for_node_sharing", fallback=self.DEFAULTS.get("temp_jls_for_node_sharing")
         )
         fleet_config_file = config.get(
             "slurm_resume", "fleet_config_file", fallback=self.DEFAULTS.get("fleet_config_file")
@@ -197,6 +201,7 @@ def _resume(arg_nodes, resume_config, slurm_resume):
         run_instances_overrides=resume_config.run_instances_overrides,
         create_fleet_overrides=resume_config.create_fleet_overrides,
         job_level_scaling=resume_config.job_level_scaling,
+        temp_jls_for_node_sharing=resume_config.temp_jls_for_node_sharing,
     )
     instance_manager.add_instances(
         slurm_resume=slurm_resume,

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -154,14 +154,18 @@ class SlurmResumeData:
     jobs_single_node_no_oversubscribe: List[SlurmResumeJob]
     # List of exclusive job allocated to more than 1 node each
     jobs_multi_node_no_oversubscribe: List[SlurmResumeJob]
-    # List of non-exclusive job
-    jobs_oversubscribe: List[SlurmResumeJob]
+    # List of non-exclusive job allocated to 1 node each
+    jobs_single_node_oversubscribe: List[SlurmResumeJob]
+    # List of non-exclusive job allocated to more than 1 node each
+    jobs_multi_node_oversubscribe: List[SlurmResumeJob]
     # List of node allocated to single node exclusive job
     single_node_no_oversubscribe: List[str]
     # List of node allocated to multiple node exclusive job
     multi_node_no_oversubscribe: List[str]
-    # List of node allocated to non-exclusive job
-    nodes_oversubscribe: List[str]
+    # List of node allocated to single node non-exclusive job
+    single_node_oversubscribe: List[str]
+    # List of node allocated to multiple node non-exclusive job
+    multi_node_oversubscribe: List[str]
 
 
 class SlurmNode(metaclass=ABCMeta):

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -834,7 +834,7 @@ class TestCreateFleetManager:
                         generate_error=False,
                     ),
                 ]
-                + 3
+                + 4
                 * [
                     MockedBoto3Request(
                         method="describe_instances",
@@ -887,7 +887,7 @@ class TestCreateFleetManager:
             # client error
             (
                 ["i-12345"],
-                4
+                5
                 * [
                     MockedBoto3Request(
                         method="describe_instances",

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -694,6 +694,7 @@ def test_resume_launch(
         job_level_scaling=job_level_scaling,
         assign_node_max_batch_size=500,
         terminate_max_batch_size=1000,
+        temp_jls_for_node_sharing=False,
     )
     mocker.patch("slurm_plugin.resume.is_clustermgtd_heartbeat_valid", autospec=True, return_value=is_heartbeat_valid)
     mock_handle_failed_nodes = mocker.patch("slurm_plugin.resume._handle_failed_nodes", autospec=True)


### PR DESCRIPTION
### Description of changes
Series of changes needed for the work in progress feature "Job Level Scaling for Node Sharing".

 * Add temporary config to be able to enable node sharing jls, useful when developing the feature

* Split oversubscribed job list, to have ready to consume knowledge about
  *  oversubscribed job list with single node allocation
  *  oversubscribed job list with multiple node allocation
  *  oversubscribed single node list
  *  oversubscribed multi node list

* Change retry logic on DescribeInstances to be exponential backoff plus a random number in the interval 0 + 0.5.
  The random number is to add a jitter so to avoid wave requests.
  Retries have been increased from 4 to 5

* Accumulate unused capacity over different instance launch calls, when it isn't possible to assign the full requested allocation to a job

### Tests
* unit tests added
* manual tests performed on running cluster

### References
* n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
