### PR TITLE
[develop] Remove dependency between JobLevelScaling and NodeListScaling

### DIFF
--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -221,7 +221,8 @@ def _resume(arg_nodes, resume_config, slurm_resume):
     )
     failed_nodes = set().union(*instance_manager.failed_nodes.values())
     success_nodes = [node for node in node_list if node not in failed_nodes]
-    log.info("Successfully launched nodes %s", print_with_count(success_nodes))
+    if success_nodes:
+        log.info("Successfully launched nodes %s", print_with_count(success_nodes))
 
     if failed_nodes:
         log.error(

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -465,7 +465,7 @@ class TestInstanceManager:
             instance_manager._update_dns_hostnames(assigned_nodes)
 
     @pytest.mark.parametrize(
-        ("node_list", "expected_results", "expected_failed_nodes", "job_level_scaling"),
+        ("node_list", "expected_results", "expected_failed_nodes", "nodes_assigned_to_instances"),
         [
             (
                 [
@@ -502,13 +502,72 @@ class TestInstanceManager:
                         "in-valid/queue.name-st-c5xlarge-2",
                     }
                 },
-                False,
+                {},
+            ),
+            (
+                [
+                    "queue1-st-c5xlarge-1",
+                    "queue1-st-c5xlarge-2",
+                    "queue1-dy-c5xlarge-201",
+                    "queue2-st-g34xlarge-1",
+                    "in-valid/queue.name-st-c5xlarge-2",
+                    "noBrackets-st-c5xlarge-[1-2]",
+                    "queue2-dy-g38xlarge-1",
+                    "queue2-st-u6tb1metal-1",
+                    "queue2-invalidnodetype-c5xlarge-12",
+                    "queuename-with-dash-and_underscore-st-i3enmetal2tb-1",
+                ],
+                {},
+                {
+                    "InvalidNodenameError": {
+                        "queue2-invalidnodetype-c5xlarge-12",
+                        "noBrackets-st-c5xlarge-[1-2]",
+                        "queuename-with-dash-and_underscore-st-i3enmetal2tb-1",
+                        "in-valid/queue.name-st-c5xlarge-2",
+                    }
+                },
+                {
+                    "queue1": {
+                        "c5xlarge": [
+                            "queue1-st-c5xlarge-1",
+                            "queue1-st-c5xlarge-2",
+                            "queue1-dy-c5xlarge-201",
+                        ]
+                    },
+                    "queue2": {
+                        "g34xlarge": ["queue2-st-g34xlarge-1"],
+                        "g38xlarge": ["queue2-dy-g38xlarge-1"],
+                        "u6tb1metal": ["queue2-st-u6tb1metal-1"],
+                    },
+                },
+            ),
+            (
+                [
+                    "queue1-st-c5xlarge-1",
+                    "queue1-st-c5xlarge-2",
+                ],
+                {
+                    "queue1": {
+                        "c5xlarge": [
+                            "queue1-st-c5xlarge-1",
+                        ]
+                    },
+                },
+                {},
+                {
+                    "queue1": {
+                        "c5xlarge": [
+                            "queue1-st-c5xlarge-2",
+                        ]
+                    },
+                },
             ),
         ],
     )
-    def test_parse_requested_instances(
-        self, node_list, expected_results, expected_failed_nodes, instance_manager, job_level_scaling
+    def test_parse_nodes_resume_list(
+        self, node_list, expected_results, expected_failed_nodes, instance_manager, nodes_assigned_to_instances
     ):
+        instance_manager.nodes_assigned_to_instances = nodes_assigned_to_instances
         assert_that(instance_manager._parse_nodes_resume_list(node_list)).is_equal_to(expected_results)
         assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
 

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -378,93 +378,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
             False,
             False,
         ),
-        # job level scaling + empty resume file + all_or_nothing_batch without ice error
-        (
-            [
-                SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
-                SimpleNamespace(name="queue1-dy-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
-                SimpleNamespace(name="queue1-st-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
-                SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
-            ],
-            3,
-            True,
-            [
-                {
-                    "Instances": [
-                        {
-                            "InstanceId": "i-11111",
-                            "InstanceType": "c5.xlarge",
-                            "PrivateIpAddress": "ip.1.0.0.1",
-                            "PrivateDnsName": "ip-1-0-0-1",
-                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            "NetworkInterfaces": [
-                                {
-                                    "Attachment": {
-                                        "DeviceIndex": 0,
-                                        "NetworkCardIndex": 0,
-                                    },
-                                    "PrivateIpAddress": "ip.1.0.0.1",
-                                },
-                            ],
-                        },
-                        {
-                            "InstanceId": "i-22222",
-                            "InstanceType": "c5.xlarge",
-                            "PrivateIpAddress": "ip.1.0.0.2",
-                            "PrivateDnsName": "ip-1-0-0-2",
-                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            "NetworkInterfaces": [
-                                {
-                                    "Attachment": {
-                                        "DeviceIndex": 0,
-                                        "NetworkCardIndex": 0,
-                                    },
-                                    "PrivateIpAddress": "ip.1.0.0.2",
-                                },
-                            ],
-                        },
-                        {
-                            "InstanceId": "i-33333",
-                            "InstanceType": "c5.xlarge",
-                            "PrivateIpAddress": "ip.1.0.0.3",
-                            "PrivateDnsName": "ip-1-0-0-3",
-                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
-                            "NetworkInterfaces": [
-                                {
-                                    "Attachment": {
-                                        "DeviceIndex": 0,
-                                        "NetworkCardIndex": 0,
-                                    },
-                                    "PrivateIpAddress": "ip.1.0.0.3",
-                                },
-                            ],
-                        },
-                    ]
-                },
-                client_error("RequestLimitExceeded"),
-            ],
-            {"RequestLimitExceeded": {"queue1-st-c5xlarge-2"}},
-            [
-                call(
-                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1"],
-                    nodeaddrs=["ip.1.0.0.1", "ip.1.0.0.2", "ip.1.0.0.3"],
-                    nodehostnames=None,
-                )
-            ],
-            dict(
-                zip(
-                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1"],
-                    [
-                        EC2Instance("i-11111", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                        EC2Instance("i-22222", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                        EC2Instance("i-33333", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                    ],
-                )
-            ),
-            True,
-            True,
-        ),
-        # job level scaling + empty resume file + all_or_nothing_batch with ice error
+        # job level scaling + empty resume file + all_or_nothing_batch with ICE error
         (
             [
                 SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
@@ -531,26 +445,119 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
             ],
             {"InsufficientInstanceCapacity": {"queue1-st-c5xlarge-2"}},
             [
+                # call(
+                #     ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1"],
+                #     nodeaddrs=["ip.1.0.0.1", "ip.1.0.0.2", "ip.1.0.0.3"],
+                #     nodehostnames=None,
+                # )
+            ],
+            {},
+            True,
+            True,
+        ),
+        # job level scaling + empty resume file + all_or_nothing without error
+        (
+            [
+                SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+            ],
+            3,
+            True,
+            [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-11111",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.1",
+                            "PrivateDnsName": "ip-1-0-0-1",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                },
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-22222",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.2",
+                            "PrivateDnsName": "ip-1-0-0-2",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.2",
+                                },
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-33333",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.3",
+                            "PrivateDnsName": "ip-1-0-0-3",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.3",
+                                },
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-44444",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.4",
+                            "PrivateDnsName": "ip-1-0-0-4",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.4",
+                                },
+                            ],
+                        },
+                    ]
+                },
+            ],
+            {},
+            [
                 call(
-                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1"],
-                    nodeaddrs=["ip.1.0.0.1", "ip.1.0.0.2", "ip.1.0.0.3"],
+                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"],
+                    nodeaddrs=["ip.1.0.0.1", "ip.1.0.0.2", "ip.1.0.0.3", "ip.1.0.0.4"],
                     nodehostnames=None,
                 )
             ],
             dict(
                 zip(
-                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1"],
+                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"],
                     [
                         EC2Instance("i-11111", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)),
                         EC2Instance("i-22222", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)),
                         EC2Instance("i-33333", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                        EC2Instance("i-44444", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)),
                     ],
                 )
             ),
             True,
             True,
         ),
-        # job level scaling + empty resume file + best_effort without ice error
+        # job level scaling + empty resume file + best_effort with CLIENT error
         (
             [
                 SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
@@ -584,8 +591,8 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 client_error("ServiceUnavailable"),
             ],
             {
-                "LimitedInstanceCapacity": {"queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1"},
                 "ServiceUnavailable": {"queue1-st-c5xlarge-2"},
+                "LimitedInstanceCapacity": {"queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1"},
             },
             [call(["queue1-dy-c5xlarge-1"], nodeaddrs=["ip.1.0.0.1"], nodehostnames=None)],
             dict(
@@ -599,7 +606,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
             True,
             True,
         ),
-        # job level scaling + empty resume file + best_effort wit ice error
+        # job level scaling + empty resume file + best_effort wit ICE error
         (
             [
                 SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
@@ -645,6 +652,108 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
             True,
             True,
         ),
+        # job level scaling + empty resume file + best-effort without error
+        (
+            [
+                SimpleNamespace(name="queue1-dy-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-dy-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-1", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+                SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
+            ],
+            3,
+            False,
+            [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-11111",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.1",
+                            "PrivateDnsName": "ip-1-0-0-1",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.1",
+                                },
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-22222",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.2",
+                            "PrivateDnsName": "ip-1-0-0-2",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.2",
+                                },
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-33333",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.3",
+                            "PrivateDnsName": "ip-1-0-0-3",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.3",
+                                },
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-44444",
+                            "InstanceType": "c5.xlarge",
+                            "PrivateIpAddress": "ip.1.0.0.4",
+                            "PrivateDnsName": "ip-1-0-0-4",
+                            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            "NetworkInterfaces": [
+                                {
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "NetworkCardIndex": 0,
+                                    },
+                                    "PrivateIpAddress": "ip.1.0.0.4",
+                                },
+                            ],
+                        },
+                    ]
+                },
+            ],
+            {},
+            [
+                call(
+                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"],
+                    nodeaddrs=["ip.1.0.0.1", "ip.1.0.0.2", "ip.1.0.0.3", "ip.1.0.0.4"],
+                    nodehostnames=None,
+                )
+            ],
+            dict(
+                zip(
+                    ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2", "queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"],
+                    [
+                        EC2Instance("i-11111", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                        EC2Instance("i-22222", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                        EC2Instance("i-33333", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                        EC2Instance("i-44444", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                    ],
+                )
+            ),
+            True,
+            True,
+        ),
     ],
     ids=[
         "node list scaling + all_or_nothing without ICE error",
@@ -652,10 +761,11 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
         "node list scaling + best_effort without ICE error",
         "node list scaling + best_effort with ICE error",
         "invalid_heartbeat",
-        "job level scaling + empty resume file + all_or_nothing without ICE error",
         "job level scaling + empty resume file + all_or_nothing with ICE error",
-        "job level scaling + empty resume file + best_effort without ICE error",
+        "job level scaling + empty resume file + all_or_nothing without error",
+        "job level scaling + empty resume file + best_effort with CLIENT error",
         "job level scaling + empty resume file + best_effort with ICE error",
+        "job level scaling + empty resume file + best_effort without error",
     ],
 )
 def test_resume_launch(
@@ -701,12 +811,18 @@ def test_resume_launch(
     # patch slurm calls
     mock_update_nodes = mocker.patch("slurm_plugin.instance_manager.update_nodes", autospec=True)
     mock_get_node_info = mocker.patch("slurm_plugin.resume.get_nodes_info", return_value=mock_node_lists, autospec=True)
-    # patch DNS related functions
+    # patch Table and DNS related functions
     mock_store_hostname = mocker.patch.object(
         slurm_plugin.instance_manager.InstanceManager, "_store_assigned_hostnames", autospec=True
     )
     mock_update_dns = mocker.patch.object(
         slurm_plugin.instance_manager.InstanceManager, "_update_dns_hostnames", autospec=True
+    )
+    # patch EC2 calls
+    mock_terminate_instances = mocker.patch.object(
+        slurm_plugin.instance_manager.JobLevelScalingInstanceManager,
+        "_terminate_unassigned_launched_instances",
+        autospec=True,
     )
 
     # Only mock fleet manager if testing case of valid clustermgtd heartbeat
@@ -725,6 +841,7 @@ def test_resume_launch(
         mock_get_node_info.assert_not_called()
         mock_store_hostname.assert_not_called()
         mock_update_dns.assert_not_called()
+        mock_terminate_instances.assert_not_called()
     else:
         mock_handle_failed_nodes_calls = []
         if expected_failed_nodes:
@@ -733,11 +850,20 @@ def test_resume_launch(
                     call(nodeset, reason=f"(Code:{error_code})Failure when resuming nodes")
                 )
             mock_handle_failed_nodes.assert_has_calls(mock_handle_failed_nodes_calls)
+            if job_level_scaling:
+                mock_terminate_instances.assert_called_with(ANY, mock_resume_config.terminate_max_batch_size)
+            else:
+                mock_terminate_instances.assert_not_called()
         if expected_update_node_calls:
             mock_update_nodes.assert_has_calls(expected_update_node_calls)
         if expected_assigned_nodes:
             mock_store_hostname.assert_called_with(ANY, expected_assigned_nodes)
-            mock_update_dns.assert_called_with(ANY, expected_assigned_nodes)
+            if job_level_scaling:
+                mock_update_dns.assert_called_with(
+                    ANY, expected_assigned_nodes, update_dns_batch_size=mock_resume_config.assign_node_max_batch_size
+                )
+            else:
+                mock_update_dns.assert_called_with(ANY, expected_assigned_nodes)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of changes
* Remove dependency between JobLevelScalingInstanceManager and NodeListScalingInstanceManager, by implementing the _add_instances_for_nodes methods also for the JobLevelScalingInstanceManager class. This allows to:
  * have a node-list scaling fallback when slurm resume file content is not available
  * remove the NodeListScalingInstanceManager implementation eventually in the future

* Build a map of launched instances associated to nodes, so that on the processing of the node_resume list, the nodes for which there is already an associated running instance are discarded

### Tests
* unit tests added
* manual tests on running cluster

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
