### PR TITLE
[develop] POC for new scaling strategy

### DIFF
--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -47,6 +47,7 @@ class SlurmResumeConfig:
         "fleet_config_file": "/etc/parallelcluster/slurm_plugin/fleet-config.json",
         "all_or_nothing_batch": True,
         "job_level_scaling": True,
+        "terminate_idle_nodes": True,
     }
 
     def __init__(self, config_file_path):
@@ -94,6 +95,9 @@ class SlurmResumeConfig:
         )
         self.job_level_scaling = config.getboolean(
             "slurm_resume", "job_level_scaling", fallback=self.DEFAULTS.get("job_level_scaling")
+        )
+        self.terminate_idle_nodes = config.getboolean(
+            "slurm_resume", "terminate_idle_nodes", fallback=self.DEFAULTS.get("terminate_idle_nodes")
         )
         fleet_config_file = config.get(
             "slurm_resume", "fleet_config_file", fallback=self.DEFAULTS.get("fleet_config_file")
@@ -214,6 +218,7 @@ def _resume(arg_nodes, resume_config, slurm_resume):
         terminate_batch_size=resume_config.terminate_max_batch_size,
         update_node_address=resume_config.update_node_address,
         all_or_nothing_batch=resume_config.all_or_nothing_batch,
+        terminate_idle_nodes=resume_config.terminate_idle_nodes,
     )
     failed_nodes = set().union(*instance_manager.failed_nodes.values())
     success_nodes = [node for node in node_list if node not in failed_nodes]


### PR DESCRIPTION
### Description of changes
* POC for new scaling strategy
  * if all-or-nothing is set into cluster configuration: 
    * perform all-or-nothing all-in
    * perform all-or-nothing for all job
    * assign instances to slurm nodes in all-or-nothing
  
  * if best-effort is set into cluster configuration: 
    * perform best-effort all-in
    * assign instances to slurm nodes in all-or-nothing
  
  In both case, no idle running instances will be left at the end of the resume program execution

* Add internal flag to leave running IDLE nodes at the end of the resume program execution, default is False
  
### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
