### PR TITLE
Support specification of multiple scaling strategies

### DIFF
--- a/src/slurm_plugin/common.py
+++ b/src/slurm_plugin/common.py
@@ -14,6 +14,7 @@ import functools
 import logging
 from concurrent.futures import Future
 from datetime import datetime
+from enum import Enum
 from typing import Callable, Optional, Protocol, TypedDict
 
 from common.utils import check_command_output, time_is_up, validate_absolute_path
@@ -32,6 +33,23 @@ ComputeInstanceDescriptor = TypedDict(
         "InstanceId": str,
     },
 )
+
+
+class ScalingStrategy(Enum):
+    ALL_OR_NOTHING = "all-or-nothing"
+    BEST_EFFORT = "best-effort"
+
+    @classmethod
+    def _missing_(cls, strategy):
+        # Ref: https://docs.python.org/3/library/enum.html#enum.Enum._missing_
+        _strategy = str(strategy).lower()
+        for member in cls:
+            if member.value == _strategy:
+                return member
+        return cls.ALL_OR_NOTHING  # Default to All-Or-Nothing
+
+    def __str__(self):
+        return str(self.value)
 
 
 class TaskController(Protocol):

--- a/tests/slurm_plugin/test_common.py
+++ b/tests/slurm_plugin/test_common.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from assertpy import assert_that
 from common.utils import read_json, time_is_up
-from slurm_plugin.common import TIMESTAMP_FORMAT, get_clustermgtd_heartbeat
+from slurm_plugin.common import TIMESTAMP_FORMAT, ScalingStrategy, get_clustermgtd_heartbeat
 
 
 @pytest.mark.parametrize(
@@ -106,3 +106,17 @@ def test_read_json(test_datadir, caplog, json_file, default_value, raises_except
         assert_that(caplog.text).matches(message_in_log)
     else:
         assert_that(caplog.text).does_not_match("exception")
+
+
+@pytest.mark.parametrize(
+    "strategy_as_value, expected_strategy_enum",
+    [
+        ("best-effort", ScalingStrategy.BEST_EFFORT),
+        ("all-or-nothing", ScalingStrategy.ALL_OR_NOTHING),
+        ("", ScalingStrategy.ALL_OR_NOTHING),
+        ("invalid-strategy", ScalingStrategy.ALL_OR_NOTHING),
+    ],
+)
+def test_scaling_strategies_enum_from_value(strategy_as_value, expected_strategy_enum):
+    strategy_enum = ScalingStrategy(strategy_as_value)
+    assert_that(strategy_enum).is_equal_to(expected_strategy_enum)

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -22,6 +22,7 @@ import botocore
 import pytest
 import slurm_plugin
 from assertpy import assert_that
+from slurm_plugin.common import ScalingStrategy
 from slurm_plugin.fleet_manager import EC2Instance
 from slurm_plugin.instance_manager import (
     HostnameDnsStoreError,
@@ -1265,7 +1266,7 @@ class TestInstanceManager:
             "assign_node_batch_size",
             "terminate_batch_size",
             "update_node_address",
-            "all_or_nothing_batch",
+            "scaling_strategy",
         ),
         [
             (
@@ -1284,7 +1285,7 @@ class TestInstanceManager:
                 30,
                 40,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
             ),
             (
                 {
@@ -1302,7 +1303,7 @@ class TestInstanceManager:
                 20,
                 30,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
             ),
             (
                 {},
@@ -1311,7 +1312,7 @@ class TestInstanceManager:
                 40,
                 20,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
             ),
             (
                 {},
@@ -1320,7 +1321,7 @@ class TestInstanceManager:
                 40,
                 20,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
             ),
         ],
     )
@@ -1332,7 +1333,7 @@ class TestInstanceManager:
         assign_node_batch_size,
         terminate_batch_size,
         update_node_address,
-        all_or_nothing_batch,
+        scaling_strategy,
         instance_manager,
         mocker,
     ):
@@ -1346,7 +1347,7 @@ class TestInstanceManager:
             assign_node_batch_size=assign_node_batch_size,
             terminate_batch_size=terminate_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
 
         assert_that(instance_manager.failed_nodes).is_empty()
@@ -1359,7 +1360,7 @@ class TestInstanceManager:
                 launch_batch_size=launch_batch_size,
                 assign_node_batch_size=assign_node_batch_size,
                 update_node_address=update_node_address,
-                all_or_nothing_batch=all_or_nothing_batch,
+                scaling_strategy=scaling_strategy,
             )
         else:
             instance_manager._add_instances_for_nodes.assert_called_once_with(
@@ -1367,7 +1368,7 @@ class TestInstanceManager:
                 launch_batch_size=launch_batch_size,
                 assign_node_batch_size=assign_node_batch_size,
                 update_node_address=update_node_address,
-                all_or_nothing_batch=all_or_nothing_batch,
+                scaling_strategy=scaling_strategy,
             )
 
 
@@ -1395,7 +1396,7 @@ class TestJobLevelScalingInstanceManager:
 
     @pytest.mark.parametrize(
         (
-            "node_list, launch_batch_size, update_node_address, all_or_nothing, slurm_resume, "
+            "node_list, launch_batch_size, update_node_address, scaling_strategy, slurm_resume, "
             "assign_node_batch_size, terminate_batch_size"
         ),
         [
@@ -1403,7 +1404,7 @@ class TestJobLevelScalingInstanceManager:
                 ["queue1-st-c5xlarge-2", "queue2-dy-c5xlarge-10"],
                 10,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {},
                 30,
                 40,
@@ -1412,7 +1413,7 @@ class TestJobLevelScalingInstanceManager:
                 ["queue1-st-c5xlarge-2", "queue2-dy-c5xlarge-10"],
                 40,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 {
                     "jobs": [
                         {
@@ -1444,7 +1445,7 @@ class TestJobLevelScalingInstanceManager:
         node_list,
         launch_batch_size,
         update_node_address,
-        all_or_nothing,
+        scaling_strategy,
         slurm_resume,
         assign_node_batch_size,
         terminate_batch_size,
@@ -1458,7 +1459,7 @@ class TestJobLevelScalingInstanceManager:
             node_list=node_list,
             launch_batch_size=launch_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing,
+            scaling_strategy=scaling_strategy,
             slurm_resume=slurm_resume,
             assign_node_batch_size=assign_node_batch_size,
             terminate_batch_size=terminate_batch_size,
@@ -1474,7 +1475,7 @@ class TestJobLevelScalingInstanceManager:
                 launch_batch_size=launch_batch_size,
                 assign_node_batch_size=assign_node_batch_size,
                 update_node_address=update_node_address,
-                all_or_nothing_batch=all_or_nothing,
+                scaling_strategy=scaling_strategy,
             )
             assert_that(caplog.text).contains(
                 "Not possible to perform job level scaling " "because Slurm resume file content is empty."
@@ -1487,7 +1488,7 @@ class TestJobLevelScalingInstanceManager:
                 launch_batch_size=launch_batch_size,
                 assign_node_batch_size=assign_node_batch_size,
                 update_node_address=update_node_address,
-                all_or_nothing_batch=all_or_nothing,
+                scaling_strategy=scaling_strategy,
             )
 
     @pytest.mark.parametrize(
@@ -1497,7 +1498,7 @@ class TestJobLevelScalingInstanceManager:
             "launch_batch_size",
             "assign_node_batch_size",
             "update_node_address",
-            "all_or_nothing_batch",
+            "scaling_strategy",
             "expected_jobs_multi_node_oversubscribe",
             "expected_multi_node_oversubscribe",
             "expected_jobs_single_node_oversubscribe",
@@ -1558,7 +1559,7 @@ class TestJobLevelScalingInstanceManager:
                 10,
                 30,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     SlurmResumeJob(
                         job_id=140814,
@@ -1624,7 +1625,7 @@ class TestJobLevelScalingInstanceManager:
                 5,
                 25,
                 False,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     SlurmResumeJob(
                         job_id=140814,
@@ -1659,7 +1660,7 @@ class TestJobLevelScalingInstanceManager:
                 8,
                 28,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [],
                 [],
                 [],
@@ -1707,7 +1708,7 @@ class TestJobLevelScalingInstanceManager:
                 8,
                 28,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [],
                 [],
                 [
@@ -1745,7 +1746,7 @@ class TestJobLevelScalingInstanceManager:
         launch_batch_size,
         assign_node_batch_size,
         update_node_address,
-        all_or_nothing_batch,
+        scaling_strategy,
         expected_jobs_multi_node_oversubscribe,
         expected_multi_node_oversubscribe,
         expected_jobs_single_node_oversubscribe,
@@ -1766,7 +1767,7 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
 
         instance_manager._scaling_for_jobs_single_node.assert_any_call(
@@ -1774,7 +1775,7 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
         instance_manager._scaling_for_jobs_multi_node.assert_any_call(
             job_list=expected_jobs_multi_node_no_oversubscribe + expected_jobs_multi_node_oversubscribe,
@@ -1782,7 +1783,7 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
         assert_that(instance_manager.unused_launched_instances).is_empty()
         assert_that(instance_manager._scaling_for_jobs_single_node.call_count).is_equal_to(1)
@@ -2655,7 +2656,7 @@ class TestJobLevelScalingInstanceManager:
         assert_that(instance_manager.failed_nodes).is_empty()
 
     @pytest.mark.parametrize(
-        "job, launch_batch_size, assign_node_batch_size, update_node_address, all_or_nothing_batch, "
+        "job, launch_batch_size, assign_node_batch_size, update_node_address, scaling_strategy, "
         "expected_nodes_to_launch, mock_instances_launched, initial_unused_launched_instances, "
         "expected_unused_launched_instances, expect_assign_instances_to_nodes_called, "
         "expect_assign_instances_to_nodes_failure, expected_failed_nodes",
@@ -2665,7 +2666,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 {"queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {},
                 {},
@@ -2679,7 +2680,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {},
                 {},
@@ -2693,7 +2694,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {
                     "queue4": {
@@ -2715,7 +2716,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {
                     "queue4": {
@@ -2742,7 +2743,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue1": {"c5xlarge": ["queue1-st-c5xlarge-1"]}, "queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {
                     "queue4": {
@@ -2777,7 +2778,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue1": {"c5xlarge": ["queue1-st-c5xlarge-1"]}, "queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {},
                 {},
@@ -2796,7 +2797,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue1": {"c5xlarge": ["queue1-st-c5xlarge-1"]}},
                 {},
                 {},
@@ -2815,7 +2816,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue1": {"c5xlarge": ["queue1-st-c5xlarge-1"]}},
                 {
                     "queue1": {
@@ -2842,7 +2843,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue1": {"c5xlarge": ["queue1-st-c5xlarge-1"]}, "queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {
                     "queue4": {
@@ -2892,7 +2893,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {"queue1": {"c5xlarge": ["queue1-st-c5xlarge-1"]}, "queue4": {"c5xlarge": ["queue4-st-c5xlarge-1"]}},
                 {
                     "queue4": {
@@ -2938,7 +2939,7 @@ class TestJobLevelScalingInstanceManager:
         launch_batch_size,
         assign_node_batch_size,
         update_node_address,
-        all_or_nothing_batch,
+        scaling_strategy,
         expected_nodes_to_launch,
         mock_instances_launched,
         initial_unused_launched_instances,
@@ -2960,14 +2961,14 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
 
         instance_manager._launch_instances.assert_called_once_with(
             job=job,
             nodes_to_launch=expected_nodes_to_launch,
             launch_batch_size=launch_batch_size,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
 
         assert_that(instance_manager.unused_launched_instances).is_equal_to(expected_unused_launched_instances)
@@ -3285,7 +3286,7 @@ class TestJobLevelScalingInstanceManager:
             job=job,
             nodes_to_launch=nodes_to_launch,
             launch_batch_size=launch_batch_size,
-            all_or_nothing_batch=True,
+            scaling_strategy=ScalingStrategy.ALL_OR_NOTHING,
         )
 
         assert_that(instances_launched).is_equal_to(expected_instances_launched)
@@ -3293,7 +3294,7 @@ class TestJobLevelScalingInstanceManager:
 
     @pytest.mark.parametrize(
         "job_list, launch_batch_size, assign_node_batch_size, update_node_address, "
-        "expected_single_nodes_no_oversubscribe, all_or_nothing_batch",
+        "expected_single_nodes_no_oversubscribe, scaling_strategy",
         [
             (
                 [],
@@ -3301,7 +3302,7 @@ class TestJobLevelScalingInstanceManager:
                 2,
                 True,
                 [],
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
             ),
             (
                 [
@@ -3311,7 +3312,7 @@ class TestJobLevelScalingInstanceManager:
                 2,
                 True,
                 [],
-                False,
+                ScalingStrategy.BEST_EFFORT,
             ),
             (
                 [
@@ -3322,7 +3323,7 @@ class TestJobLevelScalingInstanceManager:
                 2,
                 True,
                 ["queue4-st-c5xlarge-1", "queue4-st-c5xlarge-2"],
-                False,
+                ScalingStrategy.BEST_EFFORT,
             ),
             (
                 [
@@ -3333,7 +3334,7 @@ class TestJobLevelScalingInstanceManager:
                 2,
                 True,
                 ["queue4-st-c5xlarge-1", "queue4-st-c5xlarge-2"],
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
             ),
         ],
     )
@@ -3346,7 +3347,7 @@ class TestJobLevelScalingInstanceManager:
         assign_node_batch_size,
         update_node_address,
         expected_single_nodes_no_oversubscribe,
-        all_or_nothing_batch,
+        scaling_strategy,
     ):
         # patch internal functions
         instance_manager._scaling_for_jobs = mocker.MagicMock()
@@ -3357,7 +3358,7 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
         if not job_list:
             instance_manager._scaling_for_jobs.assert_not_called()
@@ -3368,7 +3369,7 @@ class TestJobLevelScalingInstanceManager:
                 launch_batch_size=launch_batch_size,
                 assign_node_batch_size=assign_node_batch_size,
                 update_node_address=update_node_address,
-                all_or_nothing_batch=all_or_nothing_batch,
+                scaling_strategy=scaling_strategy,
             )
             instance_manager._add_instances_for_nodes.assert_not_called()
         if len(job_list) > 1:
@@ -3378,11 +3379,11 @@ class TestJobLevelScalingInstanceManager:
                 launch_batch_size=launch_batch_size,
                 assign_node_batch_size=assign_node_batch_size,
                 update_node_address=update_node_address,
-                all_or_nothing_batch=False,
+                scaling_strategy=ScalingStrategy.BEST_EFFORT,
             )
 
     @pytest.mark.parametrize(
-        "job_list, launch_batch_size, assign_node_batch_size, update_node_address, all_or_nothing_batch",
+        "job_list, launch_batch_size, assign_node_batch_size, update_node_address, scaling_strategy",
         [
             ([], 1, 2, True, False),
             (
@@ -3397,7 +3398,7 @@ class TestJobLevelScalingInstanceManager:
                 3,
                 2,
                 True,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
             ),
             (
                 [
@@ -3417,7 +3418,7 @@ class TestJobLevelScalingInstanceManager:
                 2,
                 1,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
             ),
         ],
     )
@@ -3429,7 +3430,7 @@ class TestJobLevelScalingInstanceManager:
         launch_batch_size,
         assign_node_batch_size,
         update_node_address,
-        all_or_nothing_batch,
+        scaling_strategy,
     ):
         # patch internal functions
         instance_manager._terminate_unassigned_launched_instances = mocker.MagicMock()
@@ -3443,7 +3444,7 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
 
         if not job_list:
@@ -3456,7 +3457,7 @@ class TestJobLevelScalingInstanceManager:
                     launch_batch_size=launch_batch_size,
                     assign_node_batch_size=assign_node_batch_size,
                     update_node_address=update_node_address,
-                    all_or_nothing_batch=all_or_nothing_batch,
+                    scaling_strategy=scaling_strategy,
                 )
                 setup_logging_filter.return_value.__enter__.return_value.set_custom_value.assert_any_call(job.job_id)
             assert_that(
@@ -4099,7 +4100,7 @@ class TestJobLevelScalingInstanceManager:
         "launch_batch_size, "
         "assign_node_batch_size, "
         "update_node_address, "
-        "all_or_nothing_batch, "
+        "scaling_strategy, "
         "unused_launched_instances, "
         "mock_launch_instances, "
         "expected_unused_launched_instances",
@@ -4110,7 +4111,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 False,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 {},
                 {},
                 {},
@@ -4121,7 +4122,7 @@ class TestJobLevelScalingInstanceManager:
                 1,
                 2,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 {
                     "q1": {
                         "c1": [
@@ -4132,33 +4133,6 @@ class TestJobLevelScalingInstanceManager:
                     }
                 },
                 {},
-                {
-                    "q1": {
-                        "c1": [
-                            EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
-                            )
-                        ]
-                    }
-                },
-            ),
-            (
-                [],
-                [],
-                1,
-                2,
-                False,
-                True,
-                {},
-                {
-                    "q1": {
-                        "c1": [
-                            EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
-                            )
-                        ]
-                    }
-                },
                 {
                     "q1": {
                         "c1": [
@@ -4174,8 +4148,35 @@ class TestJobLevelScalingInstanceManager:
                 [],
                 1,
                 2,
+                False,
+                ScalingStrategy.ALL_OR_NOTHING,
+                {},
+                {
+                    "q1": {
+                        "c1": [
+                            EC2Instance(
+                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            )
+                        ]
+                    }
+                },
+                {
+                    "q1": {
+                        "c1": [
+                            EC2Instance(
+                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            )
+                        ]
+                    }
+                },
+            ),
+            (
+                [],
+                [],
+                1,
+                2,
                 True,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {
                     "q1": {
                         "c1": [
@@ -4220,7 +4221,7 @@ class TestJobLevelScalingInstanceManager:
                 3,
                 2,
                 True,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 {
                     "q1": {
                         "c1": [
@@ -4267,7 +4268,7 @@ class TestJobLevelScalingInstanceManager:
         launch_batch_size,
         assign_node_batch_size,
         update_node_address,
-        all_or_nothing_batch,
+        scaling_strategy,
         unused_launched_instances,
         mock_launch_instances,
         expected_unused_launched_instances,
@@ -4283,7 +4284,7 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
 
         instance_manager._scaling_for_jobs.assert_called_once_with(
@@ -4291,7 +4292,7 @@ class TestJobLevelScalingInstanceManager:
             launch_batch_size=launch_batch_size,
             assign_node_batch_size=assign_node_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
 
         assert_that(instance_manager.unused_launched_instances).is_equal_to(expected_unused_launched_instances)
@@ -4368,18 +4369,18 @@ class TestNodeListScalingInstanceManager:
         return instance_manager
 
     @pytest.mark.parametrize(
-        "node_list, launch_batch_size, update_node_address, all_or_nothing",
+        "node_list, launch_batch_size, update_node_address, scaling_strategy",
         [
             (
                 ["queue1-st-c5xlarge-2", "queue2-dy-c5xlarge-10"],
                 10,
                 False,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
             )
         ],
     )
     def test_add_instances(
-        self, instance_manager, mocker, node_list, launch_batch_size, update_node_address, all_or_nothing
+        self, instance_manager, mocker, node_list, launch_batch_size, update_node_address, scaling_strategy
     ):
         # patch internal functions
         instance_manager._add_instances_for_nodes = mocker.MagicMock()
@@ -4388,7 +4389,7 @@ class TestNodeListScalingInstanceManager:
             node_list=node_list,
             launch_batch_size=launch_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing,
+            scaling_strategy=scaling_strategy,
         )
 
         assert_that(instance_manager.failed_nodes).is_empty()
@@ -4396,7 +4397,7 @@ class TestNodeListScalingInstanceManager:
             node_list=node_list,
             launch_batch_size=launch_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing,
+            scaling_strategy=scaling_strategy,
         )
 
     @pytest.mark.parametrize(
@@ -4404,7 +4405,7 @@ class TestNodeListScalingInstanceManager:
             "nodes_to_launch",
             "launch_batch_size",
             "update_node_address",
-            "all_or_nothing_batch",
+            "scaling_strategy",
             "launched_instances",
             "expected_failed_nodes",
             "expected_update_nodes_calls",
@@ -4422,7 +4423,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 10,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     {
                         "Instances": [
@@ -4536,7 +4537,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 10,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     {
                         "Instances": [
@@ -4621,7 +4622,7 @@ class TestNodeListScalingInstanceManager:
                 {"queue1": {"c5xlarge": ["queue1-st-c5xlarge-2"]}},
                 10,
                 False,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     {
                         "Instances": [
@@ -4665,7 +4666,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 3,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     {
                         "Instances": [
@@ -4719,7 +4720,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 1,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     {
                         "Instances": [
@@ -4814,7 +4815,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 10,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 # Simulate the case that only a part of the requested capacity is launched
                 [
                     {
@@ -4863,7 +4864,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 3,
                 True,
-                True,
+                ScalingStrategy.ALL_OR_NOTHING,
                 [
                     {
                         "Instances": [
@@ -4950,7 +4951,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 10,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     {
                         "Instances": [
@@ -5088,7 +5089,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 18,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [Exception()],
                 {
                     "Exception": {
@@ -5112,7 +5113,7 @@ class TestNodeListScalingInstanceManager:
                 },
                 18,
                 True,
-                False,
+                ScalingStrategy.BEST_EFFORT,
                 [
                     {
                         "Instances": [
@@ -5203,7 +5204,7 @@ class TestNodeListScalingInstanceManager:
             "batch_size1",
             "batch_size2",
             "partial_launch",
-            "all_or_nothing",
+            "scaling_strategy",
             "override_runinstances",
             "launch_exception",
             "dns_or_table_exception",
@@ -5214,7 +5215,7 @@ class TestNodeListScalingInstanceManager:
         nodes_to_launch,
         launch_batch_size,
         update_node_address,
-        all_or_nothing_batch,
+        scaling_strategy,
         launched_instances,
         expected_failed_nodes,
         expected_update_nodes_calls,
@@ -5244,7 +5245,7 @@ class TestNodeListScalingInstanceManager:
             node_list=["placeholder_node_list"],
             launch_batch_size=launch_batch_size,
             update_node_address=update_node_address,
-            all_or_nothing_batch=all_or_nothing_batch,
+            scaling_strategy=scaling_strategy,
         )
         if expected_update_nodes_calls:
             instance_manager._update_slurm_node_addrs_and_failed_nodes.assert_has_calls(expected_update_nodes_calls)

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -23,6 +23,7 @@ from assertpy import assert_that
 from slurm_plugin.fleet_manager import EC2Instance
 from slurm_plugin.resume import SlurmResumeConfig, _get_slurm_resume, _handle_failed_nodes, _resume
 
+from src.slurm_plugin.common import ScalingStrategy
 from tests.common import FLEET_CONFIG, LAUNCH_OVERRIDES, client_error
 
 
@@ -50,7 +51,7 @@ def boto3_stubber_path():
                 "logging_config": os.path.join(
                     os.path.dirname(slurm_plugin.__file__), "logging", "parallelcluster_resume_logging.conf"
                 ),
-                "all_or_nothing_batch": True,
+                "scaling_strategy": "all-or-nothing",
                 "clustermgtd_timeout": 300,
                 "clustermgtd_heartbeat_file_path": "/home/ec2-user/clustermgtd_heartbeat",
                 "job_level_scaling": True,
@@ -70,7 +71,7 @@ def boto3_stubber_path():
                     "proxies": {"https": "my.resume.proxy"},
                 },
                 "logging_config": "/path/to/resume_logging/config",
-                "all_or_nothing_batch": True,
+                "scaling_strategy": "all-or-nothing",
                 "clustermgtd_timeout": 5,
                 "clustermgtd_heartbeat_file_path": "alternate/clustermgtd_heartbeat",
                 "job_level_scaling": False,
@@ -91,7 +92,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
     (
         "mock_node_lists",
         "batch_size",
-        "all_or_nothing_batch",
+        "scaling_strategy",
         "launched_instances",
         "expected_failed_nodes",
         "expected_update_node_calls",
@@ -109,7 +110,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            True,
+            ScalingStrategy.ALL_OR_NOTHING,
             [
                 {
                     "Instances": [
@@ -195,7 +196,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            True,
+            ScalingStrategy.ALL_OR_NOTHING,
             [
                 {
                     "Instances": [
@@ -281,7 +282,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            False,
+            ScalingStrategy.BEST_EFFORT,
             [
                 {
                     "Instances": [
@@ -330,7 +331,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            False,
+            ScalingStrategy.BEST_EFFORT,
             [
                 {
                     "Instances": [
@@ -387,7 +388,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            True,
+            ScalingStrategy.ALL_OR_NOTHING,
             [
                 {
                     "Instances": [
@@ -458,7 +459,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            True,
+            ScalingStrategy.ALL_OR_NOTHING,
             [
                 {
                     "Instances": [
@@ -560,7 +561,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            False,
+            ScalingStrategy.BEST_EFFORT,
             [
                 {
                     "Instances": [
@@ -609,7 +610,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            False,
+            ScalingStrategy.BEST_EFFORT,
             [
                 {
                     "Instances": [
@@ -655,7 +656,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 SimpleNamespace(name="queue1-st-c5xlarge-2", state_string="ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP"),
             ],
             3,
-            False,
+            ScalingStrategy.BEST_EFFORT,
             [
                 {
                     "Instances": [
@@ -765,7 +766,7 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
 def test_resume_launch(
     mock_node_lists,
     batch_size,
-    all_or_nothing_batch,
+    scaling_strategy,
     launched_instances,
     expected_failed_nodes,
     expected_update_node_calls,
@@ -779,7 +780,7 @@ def test_resume_launch(
     mock_resume_config = SimpleNamespace(
         launch_max_batch_size=batch_size,
         update_node_address=True,
-        all_or_nothing_batch=all_or_nothing_batch,
+        scaling_strategy=scaling_strategy,
         dynamodb_table="some_table",
         region="us-east-2",
         cluster_name="hit",


### PR DESCRIPTION
### Description of changes
* There is need to support more than 2 scaling strategies (i.e. `all-or-nothing` and `best-effort`).
* These changes refactor the code base to accommodate more than 2 scaling strategies.
* This has been done by using an Enum that defines/enumerates the possible strategies
* The mapping between the Enum values and existing `all_or_nothing_batch` configuration parameter has been done as follows:
    * `all_or_nothing_batch=False` maps to `ScalingStrategy.BEST_EFFORT`
    * `all_or_nothing_batch=True` maps to `ScalingStrategy.ALL_OR_NOTHING`
    * `all_or_nothing_batch` missing/undefined maps to `ScalingStrategy.ALL_OR_NOTHING`
* The existing unit tests have been updated to use this `Enum`.

### Tests
* Updated existing unit tests and added a unit test to check the behaviour of the ScalingStrategy Enum based on various values used to initialise it
* Submitted jobs matching the ones done here [#564](https://github.com/aws/aws-parallelcluster-node/pull/564#issue-1900927691) and confirmed that we get the same output

### References
* N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
