### PR TITLE
Extend scontrol output parser to be able to retrieve reservation info

### DIFF
--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -63,7 +63,7 @@ SINFO = f"{SLURM_BINARIES_DIR}/sinfo"
 SCONTROL_OUTPUT_AWK_PARSER = (
     'awk \'BEGIN{{RS="\\n\\n" ; ORS="######\\n";}} {{print}}\' | '
     + "grep -oP '^(NodeName=\\S+)|(NodeAddr=\\S+)|(NodeHostName=\\S+)|(?<!Next)(State=\\S+)|"
-    + "(Partitions=\\S+)|(SlurmdStartTime=\\S+)|(LastBusyTime=\\S+)|(Reason=.*)|(######)'"
+    + "(Partitions=\\S+)|(SlurmdStartTime=\\S+)|(LastBusyTime=\\S+)|(ReservationName=\\S+)|(Reason=.*)|(######)'"
 )
 
 # Set default timeouts for running different slurm commands.
@@ -389,8 +389,8 @@ def _parse_nodes_info(slurm_node_info: str) -> List[SlurmNode]:
     """Parse slurm node info into SlurmNode objects."""
     # [ec2-user@ip-10-0-0-58 ~]$ /opt/slurm/bin/scontrol show nodes compute-dy-c5xlarge-[1-3],compute-dy-c5xlarge-50001\
     # | awk 'BEGIN{{RS="\n\n" ; ORS="######\n";}} {{print}}' | grep -oP "^(NodeName=\S+)|(NodeAddr=\S+)
-    # |(NodeHostName=\S+)|(?<!Next)(State=\S+)|(Partitions=\S+)|(SlurmdStartTime=\S+)|(LastBusyTime=\\S+)|(Reason=.*)\
-    # |(######)"
+    # |(NodeHostName=\S+)|(?<!Next)(State=\S+)|(Partitions=\S+)|(SlurmdStartTime=\S+)|(LastBusyTime=\\S+)
+    # |(ReservationName=\S+)|(Reason=.*)|(######)"
     # NodeName=compute-dy-c5xlarge-1
     # NodeAddr=1.2.3.4
     # NodeHostName=compute-dy-c5xlarge-1
@@ -398,6 +398,7 @@ def _parse_nodes_info(slurm_node_info: str) -> List[SlurmNode]:
     # Partitions=compute,compute2
     # SlurmdStartTime=2023-01-26T09:57:15
     # Reason=some reason
+    # ReservationName=root_1
     # ######
     # NodeName=compute-dy-c5xlarge-2
     # NodeAddr=1.2.3.4
@@ -430,6 +431,7 @@ def _parse_nodes_info(slurm_node_info: str) -> List[SlurmNode]:
         "Reason": "reason",
         "SlurmdStartTime": "slurmdstarttime",
         "LastBusyTime": "lastbusytime",
+        "ReservationName": "reservation",
     }
 
     date_fields = ["SlurmdStartTime", "LastBusyTime"]

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -202,6 +202,7 @@ class SlurmNode(metaclass=ABCMeta):
         instance=None,
         slurmdstarttime: datetime = None,
         lastbusytime: datetime = None,
+        reservation=None,
     ):
         """Initialize slurm node with attributes."""
         self.name = name
@@ -214,6 +215,7 @@ class SlurmNode(metaclass=ABCMeta):
         self.instance = instance
         self.slurmdstarttime = slurmdstarttime
         self.lastbusytime = lastbusytime
+        self.reservation = reservation
         self.is_static_nodes_in_replacement = False
         self.is_being_replaced = False
         self._is_replacement_timeout = False
@@ -441,6 +443,7 @@ class StaticNode(SlurmNode):
         instance=None,
         slurmdstarttime=None,
         lastbusytime=None,
+        reservation=None,
     ):
         """Initialize slurm node with attributes."""
         super().__init__(
@@ -453,6 +456,7 @@ class StaticNode(SlurmNode):
             instance,
             slurmdstarttime,
             lastbusytime=lastbusytime,
+            reservation=reservation,
         )
 
     def is_healthy(self, terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=True):
@@ -558,6 +562,7 @@ class DynamicNode(SlurmNode):
         instance=None,
         slurmdstarttime=None,
         lastbusytime=None,
+        reservation=None,
     ):
         """Initialize slurm node with attributes."""
         super().__init__(
@@ -570,6 +575,7 @@ class DynamicNode(SlurmNode):
             instance,
             slurmdstarttime,
             lastbusytime=lastbusytime,
+            reservation=reservation,
         )
 
     def is_state_healthy(self, terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=True):

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -107,6 +107,15 @@ def test_is_static_node(nodename, expected_is_static):
             "State=IDLE+CLOUD+POWER\n"
             "Partitions=multiple\n"
             "SlurmdStartTime=2023-01-23T17:57:07\n"
+            "######\n"
+            "NodeName=queue1-st-crt2micro-1\n"
+            "NodeAddr=10.0.236.182\n"
+            "NodeHostName=queue1-st-crt2micro-1\n"
+            "State=IDLE+CLOUD+MAINTENANCE+RESERVED\n"
+            "Partitions=queue1\n"
+            "SlurmdStartTime=2023-01-23T17:57:07\n"
+            "LastBusyTime=2023-10-13T10:13:20\n"
+            "ReservationName=root_1\n"
             "######\n",
             [
                 StaticNode(
@@ -124,6 +133,16 @@ def test_is_static_node(nodename, expected_is_static):
                     "IDLE+CLOUD+POWER",
                     "multiple",
                     slurmdstarttime=datetime(2023, 1, 23, 17, 57, 7).astimezone(tz=timezone.utc),
+                ),
+                StaticNode(
+                    "queue1-st-crt2micro-1",
+                    "10.0.236.182",
+                    "queue1-st-crt2micro-1",
+                    "IDLE+CLOUD+MAINTENANCE+RESERVED",
+                    "queue1",
+                    slurmdstarttime=datetime(2023, 1, 23, 17, 57, 7).astimezone(tz=timezone.utc),
+                    lastbusytime=datetime(2023, 10, 13, 10, 13, 20).astimezone(tz=timezone.utc),
+                    reservation="root_1",
                 ),
             ],
             False,
@@ -1044,7 +1063,25 @@ def test_get_nodes_info_argument_validation(
                 "   CurrentWatts=0 AveWatts=0\n"
                 "   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s\n"
                 "   Reason=Reboot ASAP : reboot issued [slurm@2023-01-26T10:11:40]\n"
-                "   Comment=some comment \n"
+                "   Comment=some comment \n\n"
+                "NodeName=queue1-st-crt2micro-1 Arch=x86_64 CoresPerSocket=1\n"
+                "   CPUAlloc=0 CPUEfctv=1 CPUTot=1 CPULoad=0.00\n"
+                "   AvailableFeatures=static,t2.micro,crt2micro\n"
+                "   ActiveFeatures=static,t2.micro,crt2micro\n"
+                "   Gres=(null)\n"
+                "   NodeAddr=10.0.236.182 NodeHostName=queue1-st-crt2micro-1 Version=23.02.4\n"
+                "   OS=Linux 5.10.186-179.751.amzn2.x86_64 #1 SMP Tue Aug 1 20:51:38 UTC 2023\n"
+                "   RealMemory=972 AllocMem=0 FreeMem=184 Sockets=1 Boards=1\n"
+                "   State=IDLE+CLOUD+MAINTENANCE+RESERVED ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A\n"
+                "   Partitions=queue1\n"
+                "   BootTime=2023-10-13T10:09:58 SlurmdStartTime=2023-10-13T10:13:17\n"
+                "   LastBusyTime=2023-10-13T10:13:20 ResumeAfterTime=None\n"
+                "   CfgTRES=cpu=1,mem=972M,billing=1\n"
+                "   AllocTRES=\n"
+                "   CapWatts=n/a\n"
+                "   CurrentWatts=0 AveWatts=0\n"
+                "   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s\n"
+                "   ReservationName=root_5\n"
             ),
             (
                 "NodeName=queue1-st-compute-resource-1-1\nNodeAddr=192.168.123.191\n"
@@ -1057,6 +1094,10 @@ def test_get_nodes_info_argument_validation(
                 "SlurmdStartTime=2023-01-26T09:57:16\n"
                 "LastBusyTime=Unknown\n"
                 "Reason=Reboot ASAP : reboot issued [slurm@2023-01-26T10:11:40]\n######\n"
+                "NodeName=queue1-st-crt2micro-1\nNodeAddr=10.0.236.182\n"
+                "NodeHostName=queue1-st-crt2micro-1\nState=IDLE+CLOUD+MAINTENANCE+RESERVED\nPartitions=queue1\n"
+                "SlurmdStartTime=2023-10-13T10:13:17\n"
+                "LastBusyTime=2023-10-13T10:13:20\nReservationName=root_5######\n"
             ),
         )
     ],


### PR DESCRIPTION
### Description of changes

After this patch the `_parse_nodes_info` method is able to retrieve `ReservationName` field. 
This info will be saved in the `reservation` attribute of the SlurmNode.
This field is not used at the moment.

### Tests
* Extended unit tests.

### References
* https://slurm.schedmd.com/reservations.html

