### PR TITLE
[release-3.8] Log the process ID of the currently running Slurm Resume Program

### DIFF
--- a/src/slurm_plugin/logging/parallelcluster_resume_logging.conf
+++ b/src/slurm_plugin/logging/parallelcluster_resume_logging.conf
@@ -12,7 +12,7 @@ level=INFO
 handlers=fileHandler
 
 [formatter_defaultFormatter]
-format=%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s
+format=%(asctime)s - %(process)d - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s
 
 [handler_fileHandler]
 class=FileHandler

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -243,7 +243,7 @@ def main():
     logging.basicConfig(
         filename=default_log_file,
         level=logging.INFO,
-        format="%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s",
+        format="%(asctime)s - %(process)d - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s",
     )
     log.info("ResumeProgram startup.")
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
### Description of changes
* The Slurm Resume Program outputs logs in the following format:
`%(asctime)s - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s`
* Due to the possibility of multiple Resume Programs running concurrently, we want to include the Process ID of the currently running Slurm Resume Program.
* The following format will be used to include the Process ID
`%(asctime)s - %(process)d - [%(name)s:%(funcName)s] - %(levelname)s - %(message)s`


Sample Logs:

```
2023-10-24 09:27:24,339 - 27807 - [slurm_plugin.resume:main] - INFO - ResumeProgram startup.
2023-10-24 09:27:24,339 - 27807 - [slurm_plugin.resume:_get_config] - INFO - Reading /etc/parallelcluster/slurm_plugin/parallelcluster_slurm_resume.conf
2023-10-24 09:27:24,341 - 27807 - [slurm_plugin.resume:main] - INFO - ResumeProgram config: SlurmResumeConfig(...)
2023-10-24 09:27:24,341 - 27807 - [slurm_plugin.resume:_get_slurm_resume] - INFO - Slurm Resume File content: {...}
2023-10-24 09:27:24,345 - 27807 - [slurm_plugin.common:is_clustermgtd_heartbeat_valid] - INFO - Latest heartbeat from clustermgtd: 2023-10-24 09:27:15.503146+00:00
2023-10-24 09:27:24,345 - 27807 - [slurm_plugin.resume:_resume] - INFO - Launching EC2 instances for the following Slurm nodes: queue-0-dy-compute-resource-0-[1-10]
2023-10-24 09:27:24,361 - 27807 - [slurm_plugin.resume:_resume] - INFO - Current state of Slurm nodes to resume: [('queue-0-dy-compute-resource-0-1', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-2', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-3', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-4', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-5', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-6', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-7', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-8', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-9', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-10', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP')]
2023-10-24 09:27:24,387 - 27807 - [botocore.credentials:load] - INFO - Found credentials from IAM Role: ...
2023-10-24 09:27:24,428 - 27807 - [slurm_plugin.instance_manager:_launch_instances] - INFO - Launching best-effort instances for nodes (x10) ['queue-0-dy-compute-resource-0-1', 'queue-0-dy-compute-resource-0-2', 'queue-0-dy-compute-resource-0-3', 'queue-0-dy-compute-resource-0-4', 'queue-0-dy-compute-resource-0-5', 'queue-0-dy-compute-resource-0-6', 'queue-0-dy-compute-resource-0-7', 'queue-0-dy-compute-resource-0-8', 'queue-0-dy-compute-resource-0-9', 'queue-0-dy-compute-resource-0-10']
2023-10-24 09:27:24,428 - 27807 - [slurm_plugin.fleet_manager:create_fleet] - INFO - Launching instances with create_fleet API. Parameters: {...}

...

2023-10-24 09:27:24,345 - 27807 - [slurm_plugin.common:is_clustermgtd_heartbeat_valid] - INFO - Latest heartbeat from clustermgtd: 2023-10-24 09:27:15.503146+00:00
2023-10-24 09:27:24,345 - 27807 - [slurm_plugin.resume:_resume] - INFO - Launching EC2 instances for the following Slurm nodes: queue-0-dy-compute-resource-0-[1-10]
2023-10-24 09:27:24,361 - 27807 - [slurm_plugin.resume:_resume] - INFO - Current state of Slurm nodes to resume: [('queue-0-dy-compute-resource-0-1', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-2', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-3', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-4', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-5', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-6', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-7', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-8', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-9', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('queue-0-dy-compute-resource-0-10', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP')]
2023-10-24 09:27:24,387 - 27807 - [botocore.credentials:load] - INFO - Found credentials from IAM Role: ...
2023-10-24 09:27:24,428 - 27807 - [slurm_plugin.instance_manager:_launch_instances] - INFO - Launching best-effort instances for nodes (x10) ['queue-0-dy-compute-resource-0-1', 'queue-0-dy-compute-resource-0-2', 'queue-0-dy-compute-resource-0-3', 'queue-0-dy-compute-resource-0-4', 'queue-0-dy-compute-resource-0-5', 'queue-0-dy-compute-resource-0-6', 'queue-0-dy-compute-resource-0-7', 'queue-0-dy-compute-resource-0-8', 'queue-0-dy-compute-resource-0-9', 'queue-0-dy-compute-resource-0-10']
2023-10-24 09:27:24,428 - 27807 - [slurm_plugin.fleet_manager:create_fleet] - INFO - Launching instances with create_fleet API. Parameters: {...}
2023-10-24 09:27:28,037 - 27807 - [slurm_plugin.fleet_manager:launch_ec2_instances] - INFO - Launched the following instances (x10) [...]

...

2023-10-24 09:27:28,637 - 27807 - [slurm_plugin.resume:main] - INFO - ResumeProgram finished.
```

### Tests
* Manually tested by submitting jobs and inspecting the slurm resume logs

### References
* [LogRecord attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes) / %(process)d

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
