### PR TITLE
[release-3.8] Log when no instances are available for nodes assignment

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -907,7 +907,9 @@ class JobLevelScalingInstanceManager(InstanceManager):
                 # set limited capacity on the failed to launch nodes
                 self._update_failed_nodes(set(failed_launch_nodes), "LimitedInstanceCapacity", override=False)
         else:
-            # No instances launched at all, e.g. CreateFleet API returns no EC2 instances
+            # No instances launched at all, e.g. CreateFleet API returns no EC2 instances,
+            # or no left instances available from a best-effort EC2 launch
+            logger.info("No launched instances found for nodes %s", print_with_count(nodes_resume_list))
             self._update_failed_nodes(set(nodes_resume_list), "InsufficientInstanceCapacity", override=False)
 
     def all_or_nothing_node_assignment(
@@ -960,7 +962,9 @@ class JobLevelScalingInstanceManager(InstanceManager):
             self._update_dict(self.unused_launched_instances, instances_launched)
             self._update_failed_nodes(set(nodes_resume_list), "LimitedInstanceCapacity", override=False)
         else:
-            # No instances launched at all, e.g. CreateFleet API returns no EC2 instances
+            # No instances launched at all, e.g. CreateFleet API returns no EC2 instances,
+            # or no left instances available from a best-effort EC2 launch
+            logger.info("No launched instances found for nodes %s", print_with_count(nodes_resume_list))
             self._update_failed_nodes(set(nodes_resume_list), "InsufficientInstanceCapacity", override=False)
 
     def _launch_instances(  # noqa: C901


### PR DESCRIPTION
### Description of changes
Add log entry when no launched instances are available to be assigned to Slurm nodes


### Tests
manually tested on running cluster

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
