### PR TITLE
[release-3.8] Avoid scale-all optimization for all-or-nothing when single job

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -676,15 +676,17 @@ class JobLevelScalingInstanceManager(InstanceManager):
         update_node_address,
         scaling_strategy: ScalingStrategy,
     ):
-        # Optimize job level scaling with preliminary scale-all nodes attempt
-        self._update_dict(
-            self.unused_launched_instances,
-            self._launch_instances(
-                nodes_to_launch=self._parse_nodes_resume_list(node_list),
-                launch_batch_size=launch_batch_size,
-                scaling_strategy=scaling_strategy,
-            ),
-        )
+        if not (scaling_strategy in [ScalingStrategy.ALL_OR_NOTHING] and len(job_list) <= 1):
+            # Optimize job level scaling with preliminary scale-all nodes attempt
+            # Except for the case all-or-nothing / single job, to avoid scaling twice the same node list
+            self._update_dict(
+                self.unused_launched_instances,
+                self._launch_instances(
+                    nodes_to_launch=self._parse_nodes_resume_list(node_list),
+                    launch_batch_size=launch_batch_size,
+                    scaling_strategy=scaling_strategy,
+                ),
+            )
 
         # Avoid a job level launch if scaling strategy is BEST_EFFORT or GREEDY_ALL_OR_NOTHING
         # The scale all-in launch has been performed already hence from this point we want to skip the extra


### PR DESCRIPTION
### Description of changes
* Avoid scale-all optimization for all-or-nothing when single job, so to avoid to scale twice in a row for the exact same nodes.


### Tests
* unit tests added
* manual tests on running cluster

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
