### PR TITLE
[develop] Avoid scale-all optimization for all-or-nothing when single job

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -676,15 +676,17 @@ class JobLevelScalingInstanceManager(InstanceManager):
         update_node_address,
         scaling_strategy: ScalingStrategy,
     ):
-        # Optimize job level scaling with preliminary scale-all nodes attempt
-        self._update_dict(
-            self.unused_launched_instances,
-            self._launch_instances(
-                nodes_to_launch=self._parse_nodes_resume_list(node_list),
-                launch_batch_size=launch_batch_size,
-                scaling_strategy=scaling_strategy,
-            ),
-        )
+        if not (scaling_strategy in [ScalingStrategy.ALL_OR_NOTHING] and len(job_list) <= 1):
+            # Optimize job level scaling with preliminary scale-all nodes attempt
+            # Except for the case all-or-nothing / single job, to avoid scaling twice the same node list
+            self._update_dict(
+                self.unused_launched_instances,
+                self._launch_instances(
+                    nodes_to_launch=self._parse_nodes_resume_list(node_list),
+                    launch_batch_size=launch_batch_size,
+                    scaling_strategy=scaling_strategy,
+                ),
+            )
 
         # Avoid a job level launch if scaling strategy is BEST_EFFORT or GREEDY_ALL_OR_NOTHING
         # The scale all-in launch has been performed already hence from this point we want to skip the extra

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -4170,7 +4170,8 @@ class TestJobLevelScalingInstanceManager:
         "unused_launched_instances, "
         "mock_launch_instances, "
         "expected_unused_launched_instances, "
-        "expect_to_skip_job_level_launch",
+        "expect_to_skip_job_level_launch, "
+        "expect_optimize_launch_instances_called",
         [
             (
                 [],
@@ -4183,6 +4184,7 @@ class TestJobLevelScalingInstanceManager:
                 {},
                 {},
                 True,
+                True,
             ),
             (
                 [],
@@ -4194,6 +4196,7 @@ class TestJobLevelScalingInstanceManager:
                 {},
                 {},
                 {},
+                False,
                 False,
             ),
             (
@@ -4207,6 +4210,7 @@ class TestJobLevelScalingInstanceManager:
                 {},
                 {},
                 True,
+                True,
             ),
             (
                 [],
@@ -4235,6 +4239,7 @@ class TestJobLevelScalingInstanceManager:
                     }
                 },
                 True,
+                True,
             ),
             (
                 [],
@@ -4244,24 +4249,9 @@ class TestJobLevelScalingInstanceManager:
                 False,
                 ScalingStrategy.ALL_OR_NOTHING,
                 {},
-                {
-                    "q1": {
-                        "c1": [
-                            EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
-                            )
-                        ]
-                    }
-                },
-                {
-                    "q1": {
-                        "c1": [
-                            EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
-                            )
-                        ]
-                    }
-                },
+                {},
+                {},
+                False,
                 False,
             ),
             (
@@ -4295,12 +4285,10 @@ class TestJobLevelScalingInstanceManager:
                             EC2Instance(
                                 "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
                             ),
-                            EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
-                            ),
                         ]
                     }
                 },
+                False,
                 False,
             ),
             (
@@ -4309,6 +4297,48 @@ class TestJobLevelScalingInstanceManager:
                         job_id=140816,
                         nodes_alloc="queue3-st-c5xlarge-[7-10]",
                         nodes_resume="queue3-st-c5xlarge-[7-9]",
+                        oversubscribe="NO",
+                    ),
+                ],
+                ["queue4-st-c5xlarge-1"],
+                3,
+                2,
+                True,
+                ScalingStrategy.ALL_OR_NOTHING,
+                {
+                    "q1": {
+                        "c1": [
+                            EC2Instance(
+                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            )
+                        ]
+                    }
+                },
+                {},
+                {
+                    "q1": {
+                        "c1": [
+                            EC2Instance(
+                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                            ),
+                        ]
+                    },
+                },
+                False,
+                False,
+            ),
+            (
+                [
+                    SlurmResumeJob(
+                        job_id=140816,
+                        nodes_alloc="queue3-st-c5xlarge-[7-10]",
+                        nodes_resume="queue3-st-c5xlarge-[7-9]",
+                        oversubscribe="NO",
+                    ),
+                    SlurmResumeJob(
+                        job_id=140817,
+                        nodes_alloc="queue3-st-c5xlarge-[11-12]",
+                        nodes_resume="queue3-st-c5xlarge-[11-12]",
                         oversubscribe="NO",
                     ),
                 ],
@@ -4352,6 +4382,7 @@ class TestJobLevelScalingInstanceManager:
                     },
                 },
                 False,
+                True,
             ),
         ],
     )
@@ -4369,6 +4400,7 @@ class TestJobLevelScalingInstanceManager:
         mock_launch_instances,
         expected_unused_launched_instances,
         expect_to_skip_job_level_launch,
+        expect_optimize_launch_instances_called,
     ):
         # patch internal functions
         instance_manager._launch_instances = mocker.MagicMock(return_value=mock_launch_instances)
@@ -4393,6 +4425,11 @@ class TestJobLevelScalingInstanceManager:
             scaling_strategy=scaling_strategy,
             skip_launch=expect_to_skip_job_level_launch,
         )
+
+        if expect_optimize_launch_instances_called:
+            instance_manager._launch_instances.assert_called_once()
+        else:
+            instance_manager._launch_instances.assert_not_called()
 
         assert_that(instance_manager.unused_launched_instances).is_equal_to(expected_unused_launched_instances)
 


### PR DESCRIPTION
### Description of changes
* Avoid scale-all optimization for all-or-nothing when single job, so to avoid to scale twice in a row for the exact same nodes.


### Tests
* unit tests added
* manual tests on running cluster

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
