### PR TITLE
[develop] Add support for Capacity Blocks for ML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the aws-parallelcluste
 ------
 
 **ENHANCEMENTS**
+- Add support for EC2 Capacity Blocks for ML.
 
 **CHANGES**
 - Perform job-level scaling by default for all jobs, using information in the `SLURM_RESUME_FILE`. Job-level scaling

--- a/src/aws/__init__.py
+++ b/src/aws/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/aws/common.py
+++ b/src/aws/common.py
@@ -122,8 +122,9 @@ def _log_boto3_calls(params, **kwargs):
 class Boto3Client:
     """Boto3 client Class."""
 
-    def __init__(self, client_name: str, config: Config):
-        self._client = boto3.client(client_name, config=config if config else None)
+    def __init__(self, client_name: str, config: Config, region: str = None):
+        region = region if region else get_region()
+        self._client = boto3.client(client_name, region_name=region, config=config if config else None)
         self._client.meta.events.register("provide-client-params.*.*", _log_boto3_calls)
 
     def _paginate_results(self, method, **kwargs):

--- a/src/aws/common.py
+++ b/src/aws/common.py
@@ -1,0 +1,156 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import logging
+import time
+from enum import Enum
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError, ParamValidationError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AWSClientError(Exception):
+    """Error during execution of some AWS calls."""
+
+    class ErrorCode(Enum):
+        """Error codes for AWS ClientError."""
+
+        VALIDATION_ERROR = "ValidationError"
+        REQUEST_LIMIT_EXCEEDED = "RequestLimitExceeded"
+        THROTTLING_EXCEPTION = "ThrottlingException"
+        CONDITIONAL_CHECK_FAILED_EXCEPTION = "ConditionalCheckFailedException"
+
+        @classmethod
+        def throttling_error_codes(cls):
+            """Return a set of error codes returned when service rate limits are exceeded."""
+            return {cls.REQUEST_LIMIT_EXCEEDED.value, cls.THROTTLING_EXCEPTION.value}
+
+    def __init__(self, function_name: str, message: str, error_code: str = None):
+        super().__init__(message)
+        self.message = message
+        self.error_code = error_code
+        self.function_name = function_name
+
+
+class LimitExceededError(AWSClientError):
+    """Error caused by exceeding the limits of a downstream AWS service."""
+
+    def __init__(self, function_name: str, message: str, error_code: str = None):
+        super().__init__(function_name=function_name, message=message, error_code=error_code)
+
+
+class BadRequestError(AWSClientError):
+    """Error caused by a problem in the request."""
+
+    def __init__(self, function_name: str, message: str, error_code: str = None):
+        super().__init__(function_name=function_name, message=message, error_code=error_code)
+
+
+class AWSExceptionHandler:
+    """AWS Exception handler."""
+
+    @staticmethod
+    def handle_client_exception(func):
+        """Handle Boto3 errors, can be used as a decorator."""
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except ParamValidationError as validation_error:
+                error = BadRequestError(
+                    func.__name__,
+                    "Error validating parameter. Failed with exception: {0}".format(str(validation_error)),
+                )
+            except BotoCoreError as e:
+                error = AWSClientError(func.__name__, str(e))
+            except ClientError as e:
+                # add request id
+                message = e.response["Error"]["Message"]
+                error_code = e.response["Error"]["Code"]
+
+                if error_code in AWSClientError.ErrorCode.throttling_error_codes():
+                    error = LimitExceededError(func.__name__, message, error_code)
+                elif error_code == AWSClientError.ErrorCode.VALIDATION_ERROR:
+                    error = BadRequestError(func.__name__, message, error_code)
+                else:
+                    error = AWSClientError(func.__name__, message, error_code)
+            LOGGER.error("Encountered error when performing boto3 call in %s: %s", error.function_name, error.message)
+            raise error
+
+        return wrapper
+
+    @staticmethod
+    def retry_on_boto3_throttling(func):
+        """Retry boto3 calls on throttling, can be used as a decorator."""
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except ClientError as e:
+                    if e.response["Error"]["Code"] != "Throttling":
+                        raise
+                    LOGGER.debug("Throttling when calling %s function. Will retry in %d seconds.", func.__name__, 5)
+                    time.sleep(5)
+
+        return wrapper
+
+
+def _log_boto3_calls(params, **kwargs):
+    service = kwargs["event_name"].split(".")[-2]
+    operation = kwargs["event_name"].split(".")[-1]
+    region = kwargs["context"].get("client_region", boto3.session.Session().region_name)
+    LOGGER.info(
+        "Executing boto3 call: region=%s, service=%s, operation=%s, params=%s", region, service, operation, params
+    )
+
+
+class Boto3Client:
+    """Boto3 client Class."""
+
+    def __init__(self, client_name: str, config: Config):
+        self._client = boto3.client(client_name, config=config if config else None)
+        self._client.meta.events.register("provide-client-params.*.*", _log_boto3_calls)
+
+    def _paginate_results(self, method, **kwargs):
+        """
+        Return a generator for a boto3 call, this allows pagination over an arbitrary number of responses.
+
+        :param method: boto3 method
+        :param kwargs: arguments to method
+        :return: generator with boto3 results
+        """
+        paginator = self._client.get_paginator(method.__name__)
+        for page in paginator.paginate(**kwargs).result_key_iters():
+            for result in page:
+                yield result
+
+
+class Boto3Resource:
+    """Boto3 resource Class."""
+
+    def __init__(self, resource_name: str):
+        self._resource = boto3.resource(resource_name)
+        self._resource.meta.client.meta.events.register("provide-client-params.*.*", _log_boto3_calls)
+
+
+def get_region():
+    """Get region used internally for all the AWS calls."""
+    region = boto3.session.Session().region_name
+    if region is None:
+        raise AWSClientError("get_region", "AWS region not configured")
+    return region

--- a/src/aws/ec2.py
+++ b/src/aws/ec2.py
@@ -1,0 +1,110 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+
+from aws.common import AWSExceptionHandler, Boto3Client
+
+
+class CapacityReservationInfo:
+    """
+    Data object wrapping the result of a describe-capacity-reservations call.
+
+    {
+        "CapacityReservationId": "cr-abcdEXAMPLE9876ef ",
+        "EndDateType": "unlimited",
+        "AvailabilityZone": "eu-west-1a",
+        "InstanceMatchCriteria": "open",
+        "Tags": [],
+        "EphemeralStorage": false,
+        "CreateDate": "2019-08-07T11:34:19.000Z",
+        "AvailableInstanceCount": 3,
+        "InstancePlatform": "Linux/UNIX",
+        "TotalInstanceCount": 3,
+        "State": "cancelled",
+        "Tenancy": "default",
+        "EbsOptimized": true,
+        "InstanceType": "m5.large"
+    }
+    """
+
+    def __init__(self, capacity_reservation_data):
+        self.capacity_reservation_data = capacity_reservation_data
+
+    def capacity_reservation_id(self):
+        """Return the id of the Capacity Reservation."""
+        return self.capacity_reservation_data.get("CapacityReservationId")
+
+    def state(self):
+        """Return the state of the Capacity Reservation."""
+        return self.capacity_reservation_data.get("State")
+
+
+class CapacityBlockReservationInfo(CapacityReservationInfo):
+    """
+    Data object wrapping the result of a describe-capacity-reservations --capacity-type capacity-block call.
+
+    {   "CapacityReservationId": "cr-a1234567",
+        "EndDateType": "limited",
+        "ReservationType": "capacity-block",
+        "AvailabilityZone": "eu-east-2a",
+        "InstanceMatchCriteria":  "targeted",
+        "EphemeralStorage": false,
+        "CreateDate": "2023-07-29T14:22:45Z  ",
+        “StartDate": "2023-08-15T12:00:00Z",
+        “EndDate": "2023-08-19T12:00:00Z",
+        "AvailableInstanceCount": 0,
+        "InstancePlatform":  "Linux/UNIX",
+        "TotalInstanceCount": 16,
+        “State": "payment-pending",
+        "Tenancy":  "default",
+        "EbsOptimized": true,
+        "InstanceType": "p5.48xlarge“
+    }
+    """
+
+    def __init__(self, capacity_reservation_data):
+        super().__init__(capacity_reservation_data)
+
+    def start_date(self):
+        """Return the start date of the CB."""
+        return self.capacity_reservation_data.get("StartDate")
+
+    def end_date(self):
+        """Return the start date of the CB."""
+        return self.capacity_reservation_data.get("EndDate")
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+
+class Ec2Client(Boto3Client):
+    """Implement EC2 Boto3 client."""
+
+    def __init__(self, config=None):
+        super().__init__("ec2", config=config)
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_capacity_reservations(
+        self, capacity_reservation_ids: List[str], reservation_type=None
+    ) -> List[CapacityBlockReservationInfo]:
+        """Accept a space separated list of ids. Return a list of CapacityReservationInfo."""
+        result = []
+        response = list(
+            self._paginate_results(
+                self._client.describe_capacity_reservations,
+                CapacityReservationIds=capacity_reservation_ids,
+                ReservationType=reservation_type,
+            )
+        )
+        for capacity_reservation in response:
+            result.append(CapacityBlockReservationInfo(capacity_reservation))
+
+        return result

--- a/src/aws/ec2.py
+++ b/src/aws/ec2.py
@@ -69,8 +69,8 @@ class CapacityReservationInfo:
 class Ec2Client(Boto3Client):
     """Implement EC2 Boto3 client."""
 
-    def __init__(self, config=None):
-        super().__init__("ec2", config=config)
+    def __init__(self, config=None, region=None):
+        super().__init__("ec2", region=region, config=config)
 
     @AWSExceptionHandler.handle_client_exception
     def describe_capacity_reservations(self, capacity_reservation_ids: List[str]) -> List[CapacityReservationInfo]:

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -63,7 +63,7 @@ SINFO = f"{SLURM_BINARIES_DIR}/sinfo"
 SCONTROL_OUTPUT_AWK_PARSER = (
     'awk \'BEGIN{{RS="\\n\\n" ; ORS="######\\n";}} {{print}}\' | '
     + "grep -oP '^(NodeName=\\S+)|(NodeAddr=\\S+)|(NodeHostName=\\S+)|(?<!Next)(State=\\S+)|"
-    + "(Partitions=\\S+)|(SlurmdStartTime=\\S+)|(LastBusyTime=\\S+)|(Reason=.*)|(######)'"
+    + "(Partitions=\\S+)|(SlurmdStartTime=\\S+)|(LastBusyTime=\\S+)|(ReservationName=\\S+)|(Reason=.*)|(######)'"
 )
 
 # Set default timeouts for running different slurm commands.
@@ -389,8 +389,8 @@ def _parse_nodes_info(slurm_node_info: str) -> List[SlurmNode]:
     """Parse slurm node info into SlurmNode objects."""
     # [ec2-user@ip-10-0-0-58 ~]$ /opt/slurm/bin/scontrol show nodes compute-dy-c5xlarge-[1-3],compute-dy-c5xlarge-50001\
     # | awk 'BEGIN{{RS="\n\n" ; ORS="######\n";}} {{print}}' | grep -oP "^(NodeName=\S+)|(NodeAddr=\S+)
-    # |(NodeHostName=\S+)|(?<!Next)(State=\S+)|(Partitions=\S+)|(SlurmdStartTime=\S+)|(LastBusyTime=\\S+)|(Reason=.*)\
-    # |(######)"
+    # |(NodeHostName=\S+)|(?<!Next)(State=\S+)|(Partitions=\S+)|(SlurmdStartTime=\S+)|(LastBusyTime=\\S+)
+    # |(ReservationName=\S+)|(Reason=.*)|(######)"
     # NodeName=compute-dy-c5xlarge-1
     # NodeAddr=1.2.3.4
     # NodeHostName=compute-dy-c5xlarge-1
@@ -398,6 +398,7 @@ def _parse_nodes_info(slurm_node_info: str) -> List[SlurmNode]:
     # Partitions=compute,compute2
     # SlurmdStartTime=2023-01-26T09:57:15
     # Reason=some reason
+    # ReservationName=root_1
     # ######
     # NodeName=compute-dy-c5xlarge-2
     # NodeAddr=1.2.3.4
@@ -430,6 +431,7 @@ def _parse_nodes_info(slurm_node_info: str) -> List[SlurmNode]:
         "Reason": "reason",
         "SlurmdStartTime": "slurmdstarttime",
         "LastBusyTime": "lastbusytime",
+        "ReservationName": "reservation_name",
     }
 
     date_fields = ["SlurmdStartTime", "LastBusyTime"]

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -68,6 +68,7 @@ SCONTROL_OUTPUT_AWK_PARSER = (
 
 # Set default timeouts for running different slurm commands.
 # These timeouts might be needed when running on large scale
+DEFAULT_SCONTROL_COMMAND_TIMEOUT = 30
 DEFAULT_GET_INFO_COMMAND_TIMEOUT = 30
 DEFAULT_UPDATE_COMMAND_TIMEOUT = 60
 

--- a/src/common/schedulers/slurm_reservation_commands.py
+++ b/src/common/schedulers/slurm_reservation_commands.py
@@ -149,7 +149,7 @@ def _add_param(cmd, param_name, value):
     return cmd
 
 
-def does_slurm_reservation_exist(
+def is_slurm_reservation(
     name: str,
     command_timeout: int = DEFAULT_SCONTROL_COMMAND_TIMEOUT,
     raise_on_error: bool = True,

--- a/src/common/schedulers/slurm_reservation_commands.py
+++ b/src/common/schedulers/slurm_reservation_commands.py
@@ -1,0 +1,188 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess  # nosec B404
+from datetime import datetime
+
+from common.schedulers.slurm_commands import DEFAULT_SCONTROL_COMMAND_TIMEOUT, SCONTROL
+from common.utils import run_command, validate_subprocess_argument
+
+logger = logging.getLogger(__name__)
+
+
+def _create_or_update_reservation(
+    base_command: str,
+    name: str,
+    nodes: str = None,
+    partition: str = None,
+    user: str = None,
+    start_time: datetime = None,
+    duration: int = None,
+    number_of_nodes: int = None,
+    flags: str = None,
+    command_timeout=DEFAULT_SCONTROL_COMMAND_TIMEOUT,
+    raise_on_error=True,
+):
+    """
+    Create or update slurm reservation, adding all the parameters.
+
+    Official documentation is https://slurm.schedmd.com/reservations.html
+    """
+    cmd = _add_param(base_command, "ReservationName", name)
+    cmd = _add_param(cmd, "nodes", nodes)
+    cmd = _add_param(cmd, "partition", partition)
+    cmd = _add_param(cmd, "user", user)
+    if isinstance(start_time, datetime):
+        # Convert start time to format accepted by slurm command
+        cmd = _add_param(cmd, "starttime", start_time.strftime("%Y-%m-%dT%H:%M:%S"))
+    cmd = _add_param(cmd, "duration", duration)
+    cmd = _add_param(cmd, "nodecnt", number_of_nodes)
+    cmd = _add_param(cmd, "flags", flags)
+
+    run_command(cmd, raise_on_error=raise_on_error, timeout=command_timeout, shell=True)  # nosec B604
+
+
+def create_slurm_reservation(
+    name: str,
+    nodes: str = "ALL",
+    partition: str = None,
+    user: str = "slurm",
+    start_time: datetime = None,
+    duration: int = None,
+    number_of_nodes: int = None,
+    flags: str = "maint",
+    command_timeout: int = DEFAULT_SCONTROL_COMMAND_TIMEOUT,
+    raise_on_error: bool = True,
+):
+    """
+    Create slurm reservation with scontrol call.
+
+    The command to create a reservation is something like the following:
+    scontrol create reservation starttime=2009-02-06T16:00:00 duration=120 user=slurm flags=maint nodes=ALL
+    scontrol create reservation user=root partition=queue1 starttime=noon duration=60 nodecnt=10
+
+    We're using slurm as default user because it is the default Slurm administrator user in ParallelCluster,
+    this is the user running slurmctld daemon.
+    "maint" flag permits to overlap existing reservations.
+    Official documentation is https://slurm.schedmd.com/reservations.html
+    """
+    cmd = f"{SCONTROL} create reservation"
+
+    logger.info("Creating Slurm reservation with command: %s", cmd)
+    _create_or_update_reservation(
+        cmd, name, nodes, partition, user, start_time, duration, number_of_nodes, flags, command_timeout, raise_on_error
+    )
+
+
+def update_slurm_reservation(
+    name: str,
+    nodes: str = None,
+    partition: str = None,
+    user: str = None,
+    start_time: datetime = None,
+    duration: int = None,
+    number_of_nodes: int = None,
+    flags: str = None,
+    command_timeout: int = DEFAULT_SCONTROL_COMMAND_TIMEOUT,
+    raise_on_error: bool = True,
+):
+    """
+    Update slurm reservation with scontrol call.
+
+    The command to update a reservation is something like the following:
+    scontrol update ReservationName=root_3 duration=150 users=admin
+
+    Official documentation is https://slurm.schedmd.com/reservations.html
+    """
+    cmd = f"{SCONTROL} update"
+
+    logger.info("Updating Slurm reservation with command: %s", cmd)
+    _create_or_update_reservation(
+        cmd, name, nodes, partition, user, start_time, duration, number_of_nodes, flags, command_timeout, raise_on_error
+    )
+
+
+def delete_slurm_reservation(
+    name: str,
+    command_timeout: int = DEFAULT_SCONTROL_COMMAND_TIMEOUT,
+    raise_on_error: bool = True,
+):
+    """
+    Delete slurm reservation with scontrol call.
+
+    The command to delete a reservation is something like the following:
+    scontrol delete ReservationName=root_6
+
+    Official documentation is https://slurm.schedmd.com/reservations.html
+    """
+    cmd = f"{SCONTROL} delete reservation"
+    cmd = _add_param(cmd, "ReservationName", name)
+
+    logger.info("Deleting Slurm reservation with command: %s", cmd)
+    run_command(cmd, raise_on_error=raise_on_error, timeout=command_timeout, shell=True)  # nosec B604
+
+
+def _add_param(cmd, param_name, value):
+    """If the given value is not None, validate it and concatenate ' param_name=value' to cmd."""
+    if value:
+        validate_subprocess_argument(value)
+        cmd += f" {param_name}={value}"
+    return cmd
+
+
+def does_slurm_reservation_exist(
+    name: str,
+    command_timeout: int = DEFAULT_SCONTROL_COMMAND_TIMEOUT,
+    raise_on_error: bool = True,
+):
+    """
+    Check if slurm reservation exists, by retrieving information with scontrol call.
+
+    Return True if reservation exists, False otherwise.
+    Raise a CalledProcessError if the command fails for other reasons.
+
+    $ scontrol show ReservationName=root_5
+    Reservation root_5 not found
+    $ echo $?
+    1
+
+    $ scontrol show ReservationName=root_6
+    ReservationName=root_6 StartTime=2023-10-13T15:57:03 EndTime=2024-10-12T15:57:03 Duration=365-00:00:00
+    Nodes=q1-st-cr2-1,q2-dy-cr4-[1-5] NodeCnt=6 CoreCnt=481 Features=(null) PartitionName=(null) Flags=MAINT,SPEC_NODES
+    TRES=cpu=481
+    Users=root Groups=(null) Accounts=(null) Licenses=(null) State=ACTIVE BurstBuffer=(null) Watts=n/a
+    MaxStartDelay=(null)
+    $ echo $?
+    0
+
+    Official documentation is https://slurm.schedmd.com/reservations.html
+    """
+    cmd = f"{SCONTROL} show"
+    cmd = _add_param(cmd, "ReservationName", name)
+
+    try:
+        logger.debug("Retrieving Slurm reservation with command: %s", cmd)
+        run_command(cmd, raise_on_error=raise_on_error, timeout=command_timeout, shell=True)  # nosec B604
+        reservation_exists = True
+
+    except subprocess.CalledProcessError as e:
+        output = e.stdout.rstrip()
+        if output == f"Reservation {name} not found":
+            logger.info(f"Slurm reservation {name} not found.")
+            reservation_exists = False
+        else:
+            logger.error("Failed when retrieving Slurm reservation info with command %s. Error: %s", cmd, output)
+            raise e
+
+    return reservation_exists

--- a/src/common/schedulers/slurm_reservation_commands.py
+++ b/src/common/schedulers/slurm_reservation_commands.py
@@ -14,7 +14,7 @@ import logging
 # In this file the input of the module subprocess is trusted.
 import subprocess  # nosec B404
 from datetime import datetime
-from typing import List
+from typing import List, Union
 
 from common.schedulers.slurm_commands import DEFAULT_SCONTROL_COMMAND_TIMEOUT, SCONTROL
 from common.utils import (
@@ -42,8 +42,8 @@ def _create_or_update_reservation(
     nodes: str = None,
     partition: str = None,
     user: str = None,
-    start_time: datetime = None,
-    duration: int = None,
+    start_time: Union[datetime, str] = None,  # 'now' is accepted as a value
+    duration: Union[int, str] = None,  # 'infinite' is accepted as a value
     number_of_nodes: int = None,
     flags: str = None,
     command_timeout=DEFAULT_SCONTROL_COMMAND_TIMEOUT,
@@ -61,6 +61,8 @@ def _create_or_update_reservation(
     if isinstance(start_time, datetime):
         # Convert start time to format accepted by slurm command
         cmd = _add_param(cmd, "starttime", start_time.strftime("%Y-%m-%dT%H:%M:%S"))
+    elif start_time:
+        cmd = _add_param(cmd, "starttime", start_time)
     cmd = _add_param(cmd, "duration", duration)
     cmd = _add_param(cmd, "nodecnt", number_of_nodes)
     cmd = _add_param(cmd, "flags", flags)
@@ -79,8 +81,8 @@ def create_slurm_reservation(
     nodes: str = "ALL",
     partition: str = None,
     user: str = "slurm",
-    start_time: datetime = None,
-    duration: int = None,
+    start_time: Union[datetime, str] = None,  # 'now' is accepted as a value
+    duration: Union[int, str] = None,  # 'infinite' is accepted as a value
     number_of_nodes: int = None,
     flags: str = "maint",
     command_timeout: int = DEFAULT_SCONTROL_COMMAND_TIMEOUT,
@@ -117,8 +119,8 @@ def update_slurm_reservation(
     nodes: str = None,
     partition: str = None,
     user: str = None,
-    start_time: datetime = None,
-    duration: int = None,
+    start_time: Union[datetime, str] = None,  # 'now' is accepted as a value
+    duration: Union[int, str] = None,  # 'infinite' is accepted as a value
     number_of_nodes: int = None,
     flags: str = None,
     command_timeout: int = DEFAULT_SCONTROL_COMMAND_TIMEOUT,

--- a/src/common/schedulers/slurm_reservation_commands.py
+++ b/src/common/schedulers/slurm_reservation_commands.py
@@ -100,7 +100,7 @@ def create_slurm_reservation(
     """
     cmd = f"{SCONTROL} create reservation"
 
-    logger.info("Creating Slurm reservation with command: %s", cmd)
+    logger.debug("Creating Slurm reservation with command: %s", cmd)
     _create_or_update_reservation(
         cmd, name, nodes, partition, user, start_time, duration, number_of_nodes, flags, command_timeout, raise_on_error
     )
@@ -134,7 +134,7 @@ def update_slurm_reservation(
     """
     cmd = f"{SCONTROL} update"
 
-    logger.info("Updating Slurm reservation with command: %s", cmd)
+    logger.debug("Updating Slurm reservation with command: %s", cmd)
     _create_or_update_reservation(
         cmd, name, nodes, partition, user, start_time, duration, number_of_nodes, flags, command_timeout, raise_on_error
     )
@@ -162,7 +162,7 @@ def delete_slurm_reservation(
     cmd = f"{SCONTROL} delete reservation"
     cmd = _add_param(cmd, "ReservationName", name)
 
-    logger.info("Deleting Slurm reservation with command: %s", cmd)
+    logger.debug("Deleting Slurm reservation with command: %s", cmd)
     run_command(cmd, raise_on_error=raise_on_error, timeout=command_timeout, shell=True)  # nosec B604
 
 
@@ -213,7 +213,7 @@ def is_slurm_reservation(
     try:
         logger.debug("Retrieving Slurm reservation with command: %s", cmd)
         output = check_command_output(
-            cmd, raise_on_error=raise_on_error, timeout=command_timeout, shell=True
+            cmd, raise_on_error=raise_on_error, timeout=command_timeout, shell=True, log_error=False
         )  # nosec B604
         reservation_exists = f"ReservationName={name}" in output
 
@@ -222,7 +222,7 @@ def is_slurm_reservation(
         error = f" Error is: {e.stderr.rstrip()}." if e.stderr else ""
         output = f" Output is: {e.stdout.rstrip()}." if e.stdout else ""
         if expected_output in error or expected_output in output:
-            logger.info(f"Slurm reservation {name} not found.")
+            logger.debug(f"Slurm reservation {name} not found.")
             reservation_exists = False
         else:
             msg = f"Failed when retrieving Slurm reservation info with command {cmd}.{error}{output} {e}"

--- a/src/common/time_utils.py
+++ b/src/common/time_utils.py
@@ -19,3 +19,8 @@ def minutes(min):
 def seconds(sec):
     """Convert seconds to milliseconds."""
     return sec * 1000
+
+
+def seconds_to_minutes(value):
+    """Convert seconds to minutes."""
+    return int(value / 60)

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -137,7 +137,7 @@ class CapacityBlockManager:
             reserved_nodenames = []
 
             # update list of capacity blocks from fleet config
-            self._capacity_blocks = self._capacity_blocks_from_config()
+            self._capacity_blocks = self._retrieve_capacity_blocks_from_fleet_config()
 
             if self._capacity_blocks:
                 # update capacity blocks details from ec2 (e.g. state)
@@ -270,7 +270,7 @@ class CapacityBlockManager:
 
     def _update_capacity_blocks_info_from_ec2(self):
         """
-        Store in the _capacity_reservations a dict for CapacityReservation info.
+        Update capacity blocks in self._capacity_blocks by adding capacity reservation info.
 
         This method is called every time the CapacityBlockManager is re-initialized,
         so when it starts/is restarted or when fleet configuration changes.
@@ -293,7 +293,7 @@ class CapacityBlockManager:
                     f"Unable to find capacity block {capacity_block_id} in the internal map"
                 )
 
-    def _capacity_blocks_from_config(self):
+    def _retrieve_capacity_blocks_from_fleet_config(self):
         """
         Collect list of capacity reservation target from all queues/compute-resources in the fleet config.
 
@@ -303,7 +303,7 @@ class CapacityBlockManager:
                 "my-compute-resource": {
                    "Api": "create-fleet",
                     "CapacityType": "on-demand|spot|capacity-block",
-                    "AllocationStrategy": "lowest-price|capacity-optimized|use-capacity-reservations-first",
+                    "AllocationStrategy": "lowest-price|capacity-optimized",
                     "Instances": [
                         { "InstanceType": "p4d.24xlarge" }
                     ],

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -308,10 +308,7 @@ class CapacityBlockManager:
         so when it starts/is restarted or when fleet configuration changes.
         """
         capacity_block_ids = capacity_blocks.keys()
-        logger.info(
-            "Retrieving Capacity Block reservation information from EC2 for %s",
-            ",".join(capacity_block_ids),
-        )
+        logger.info("Retrieving Capacity Blocks information from EC2 for %s", ",".join(capacity_block_ids))
         try:
             capacity_block_reservations_info: List[
                 CapacityReservationInfo
@@ -355,7 +352,7 @@ class CapacityBlockManager:
         }
         """
         capacity_blocks: Dict[str, CapacityBlock] = {}
-        logger.info("Retrieving Capacity Block reservation information for fleet config.")
+        logger.info("Retrieving Capacity Blocks from fleet configuration.")
 
         for queue_name, queue_config in self._fleet_config.items():
             for compute_resource_name, compute_resource_config in queue_config.items():

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -1,0 +1,326 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List
+
+from common.schedulers.slurm_reservation_commands import (
+    create_slurm_reservation,
+    delete_slurm_reservation,
+    does_slurm_reservation_exist,
+    update_slurm_reservation,
+)
+from common.time_utils import seconds_to_minutes
+from slurm_plugin.slurm_resources import SlurmNode
+
+from aws.ec2 import CapacityBlockReservationInfo, Ec2Client
+
+logger = logging.getLogger(__name__)
+
+# Time in minutes to wait to retrieve Capacity Block Reservation information from EC2
+CAPACITY_BLOCK_RESERVATION_UPDATE_PERIOD = 10
+SLURM_RESERVATION_NAME_PREFIX = "pcluster-"
+
+
+class CapacityType(Enum):
+    """Enum to identify the type compute supported by the queues."""
+
+    CAPACITY_BLOCK = "capacity-block"
+    ONDEMAND = "on-demand"
+    SPOT = "spot"
+
+
+class CapacityBlock:
+    """
+    Class to store Capacity Block info from EC2 and fleet config.
+
+    Contains info like:
+    - queue and compute resource from the config,
+    - state from EC2,
+    - name of the related slurm reservation.
+    """
+
+    def __init__(self, capacity_block_id, queue_name, compute_resource_name):
+        self.capacity_block_id = capacity_block_id
+        self.queue_name = queue_name
+        self.compute_resource_name = compute_resource_name
+        self._capacity_block_reservation_info = None
+        self._nodenames = []
+
+    def update_ec2_info(self, capacity_block_reservation_info: CapacityBlockReservationInfo):
+        """Update info from CapacityBlockReservationInfo."""
+        self._capacity_block_reservation_info = capacity_block_reservation_info
+
+    def slurm_reservation_name(self):
+        """Retrieve slurm reservation associated."""
+        return f"{SLURM_RESERVATION_NAME_PREFIX}{self.capacity_block_id}"
+
+    def add_nodename(self, nodename: str):
+        """Add node name to the list of nodenames associated to the capacity block."""
+        self._nodenames.append(nodename)
+
+    def nodenames(self):
+        """Return list of nodenames associated with the capacity block."""
+        return self._nodenames
+
+    def state(self):
+        """Return state of the CB: payment-pending, pending, active, expired, and payment-failed."""
+        return self._capacity_block_reservation_info.state()
+
+    def is_active(self):
+        """Return true if CB is in active state."""
+        return self.state() == "active"
+
+    def does_node_belong_to(self, node):
+        """Return true if the node belongs to the CB."""
+        return node.queue_name == self.queue_name and node.compute_resource_name == self.compute_resource_name
+
+    @staticmethod
+    def slurm_reservation_name_to_id(slurm_reservation_name: str):
+        """Parse slurm reservation name to retrieve related capacity block id."""
+        return slurm_reservation_name[len(SLURM_RESERVATION_NAME_PREFIX) :]  # noqa E203
+
+    @staticmethod
+    def is_capacity_block_slurm_reservation(slurm_reservation_name: str):
+        """Return true if slurm reservation name is related to a CB, if it matches a specific internal convention."""
+        return slurm_reservation_name.startswith(SLURM_RESERVATION_NAME_PREFIX)
+
+    def __eq__(self, other):
+        return (
+            self.capacity_block_id == other.capacity_block_id
+            and self.queue_name == other.queue_name
+            and self.compute_resource_name == other.compute_resource_name
+        )
+
+
+class CapacityBlockManager:
+    """Capacity Block Reservation Manager."""
+
+    def __init__(self, region, fleet_config, boto3_config):
+        self._region = region
+        self._fleet_config = fleet_config
+        self._boto3_config = boto3_config
+        self._ec2_client = None
+        # internal variables to store Capacity Block info from fleet config and EC2
+        self._capacity_blocks: Dict[str, CapacityBlock] = {}
+        self._capacity_blocks_update_time = None
+        self._reserved_nodenames: List[str] = []
+
+    @property
+    def ec2_client(self):
+        if not self._ec2_client:
+            self._ec2_client = Ec2Client(config=self._boto3_config)
+        return self._ec2_client
+
+    def get_reserved_nodenames(self, nodes: List[SlurmNode]):
+        """Manage nodes part of capacity block reservation. Returns list of reserved nodes."""
+        # evaluate if it's the moment to update info
+        is_time_to_update = (
+            self._capacity_blocks_update_time
+            and seconds_to_minutes(datetime.now(tz=timezone.utc) - self._capacity_blocks_update_time)
+            > CAPACITY_BLOCK_RESERVATION_UPDATE_PERIOD
+        )
+        if is_time_to_update:  # TODO: evaluate time to update accordingly to capacity block start time
+            reserved_nodenames = []
+
+            # update capacity blocks details from ec2 (e.g. state)
+            self._update_capacity_blocks_info_from_ec2()
+            # associate nodenames to capacity blocks, according to queues and compute resources from fleet configuration
+            self._associate_nodenames_to_capacity_blocks(nodes)
+
+            # create, update or delete slurm reservation for the nodes according to CB details.
+            for capacity_block in self._capacity_blocks.values():
+                reserved_nodenames.extend(self._update_slurm_reservation(capacity_block))
+            self._reserved_nodenames = reserved_nodenames
+
+            # delete slurm reservations created by CapacityBlockManager not associated to existing capacity blocks,
+            # by checking slurm reservation info of the given nodes
+            self._cleanup_leftover_slurm_reservations(nodes)
+
+        return self._reserved_nodenames
+
+    def _associate_nodenames_to_capacity_blocks(self, nodes: List[SlurmNode]):
+        """
+        Update capacity_block info adding nodenames list.
+
+        Check configured CBs and associate nodes to them according to queue and compute resource info.
+        """
+        for node in nodes:
+            capacity_block: CapacityBlock
+            for capacity_block in self._capacity_blocks.values():
+                if capacity_block.does_node_belong_to(node):
+                    capacity_block.add_nodename(node.name)
+                    break
+
+    def _cleanup_leftover_slurm_reservations(self, nodes: List[StaticNode]):
+        """Find list of slurm reservations associated to the nodes not part of the configured CBs."""
+        for node in nodes:
+            if node.reservation_name:
+                # nodes with a slurm reservation already in place
+                slurm_reservation_name = node.reservation_name
+                if CapacityBlock.is_capacity_block_slurm_reservation(slurm_reservation_name):
+                    capacity_block_id = CapacityBlock.slurm_reservation_name_to_id(slurm_reservation_name)
+                    if capacity_block_id not in self._capacity_blocks.keys():
+                        logger.info(
+                            (
+                                "Found leftover slurm reservation %s. "
+                                "Related Capacity Block %s is no longer in the cluster configuration. Deleting it."
+                            ),
+                            slurm_reservation_name,
+                            capacity_block_id,
+                        )
+                        delete_slurm_reservation(name=slurm_reservation_name)
+                else:
+                    logger.debug(
+                        "Slurm reservation %s is not managed by ParallelCluster. Skipping it.", slurm_reservation_name
+                    )
+
+    @staticmethod
+    def _update_slurm_reservation(capacity_block: CapacityBlock):
+        """
+        Update Slurm reservation associated to the given Capacity Block.
+
+        A CB has five possible states: payment-pending, pending, active, expired and payment-failed,
+        we need to create/delete Slurm reservation accordingly.
+
+        returns list of nodes reserved for that capacity block, if it's not active.
+        """
+
+        def _log_cb_info(action_info):
+            logger.info(
+                "Capacity Block reservation %s is in state %s. %s Slurm reservation %s for nodes %s.",
+                capacity_block.capacity_block_id,
+                capacity_block.state(),
+                action_info,
+                slurm_reservation_name,
+                capacity_block_nodenames,
+            )
+
+        nodes_in_slurm_reservation = []
+
+        # retrieve list of nodes associated to a given slurm reservation/capacity block
+        slurm_reservation_name = capacity_block.slurm_reservation_name()
+        capacity_block_nodes = capacity_block.nodenames()
+        capacity_block_nodenames = ",".join(capacity_block_nodes)
+
+        reservation_exists = does_slurm_reservation_exist(name=slurm_reservation_name)
+        # if CB is active we need to remove Slurm reservation and start nodes
+        if capacity_block.is_active():
+            # if Slurm reservation exists, delete it.
+            if reservation_exists:
+                _log_cb_info("Deleting related")
+                delete_slurm_reservation(name=slurm_reservation_name)
+            else:
+                _log_cb_info("Nothing to do. No existing")
+
+        # if CB is expired or not active we need to (re)create Slurm reservation
+        # to avoid considering nodes as unhealthy
+        else:
+            nodes_in_slurm_reservation = capacity_block_nodes
+            # create or update Slurm reservation
+            if reservation_exists:
+                _log_cb_info("Updating existing related")
+                update_slurm_reservation(name=slurm_reservation_name, nodes=capacity_block_nodenames)
+            else:
+                _log_cb_info("Creating related")
+                create_slurm_reservation(
+                    name=slurm_reservation_name,
+                    start_time=datetime.now(tz=timezone.utc),
+                    nodes=capacity_block_nodenames,
+                )
+
+        return nodes_in_slurm_reservation
+
+    def _update_capacity_blocks_info_from_ec2(self):
+        """
+        Store in the _capacity_reservations a dict for CapacityReservation info.
+
+        This method is called every time the CapacityBlockManager is re-initialized,
+        so when it starts/is restarted or when fleet configuration changes.
+        """
+        # Retrieve updated capacity reservation information at initialization time, and every tot minutes
+        self._capacity_blocks = self._capacity_blocks_from_config()
+
+        if self._capacity_blocks:
+            capacity_block_ids = self._capacity_blocks.keys()
+            logger.info(
+                "Retrieving updated Capacity Block reservation information from EC2 for %s",
+                ",".join(capacity_block_ids),
+            )
+            capacity_block_reservations_info: List[
+                CapacityBlockReservationInfo
+            ] = self.ec2_client().describe_capacity_reservations(capacity_block_ids)
+
+            for capacity_block_reservation_info in capacity_block_reservations_info:
+                capacity_block_id = capacity_block_reservation_info.capacity_reservation_id()
+                self._capacity_blocks[capacity_block_id].update_ec2_info(capacity_block_reservation_info)
+
+        self._capacity_blocks_update_time = datetime.now(tz=timezone.utc)
+
+    def _capacity_blocks_from_config(self):
+        """
+        Collect list of capacity reservation target from all queues/compute-resources in the fleet config.
+
+        Fleet config json has the following format:
+        {
+            "my-queue": {
+                "my-compute-resource": {
+                   "Api": "create-fleet",
+                    "CapacityType": "on-demand|spot|capacity-block",
+                    "AllocationStrategy": "lowest-price|capacity-optimized|use-capacity-reservations-first",
+                    "Instances": [
+                        { "InstanceType": "p4d.24xlarge" }
+                    ],
+                    "MaxPrice": "",
+                    "Networking": {
+                        "SubnetIds": ["subnet-123456"]
+                    },
+                    "CapacityReservationId": "id"
+                }
+            }
+        }
+        """
+        capacity_blocks: Dict[str, CapacityBlock] = {}
+        logger.info("Retrieving Capacity Block reservation information for fleet config.")
+
+        for queue_name, queue_config in self._fleet_config.items():
+            for compute_resource_name, compute_resource_config in queue_config.items():
+                if self._is_compute_resource_associated_to_capacity_block(compute_resource_config):
+                    capacity_block_id = self._capacity_reservation_id_from_compute_resource_config(
+                        compute_resource_config
+                    )
+                    capacity_block = CapacityBlock(
+                        capacity_block_id=capacity_block_id,
+                        queue_name=queue_name,
+                        compute_resource_name=compute_resource_name,
+                    )
+                    capacity_blocks.update({capacity_block_id: capacity_block})
+
+        return capacity_blocks
+
+    @staticmethod
+    def _is_compute_resource_associated_to_capacity_block(compute_resource_config):
+        """Return True if compute resource is associated to a Capacity Block reservation."""
+        capacity_type = compute_resource_config.get("CapacityType", CapacityType.ONDEMAND)
+        return capacity_type == CapacityType.CAPACITY_BLOCK.value
+
+    @staticmethod
+    def _capacity_reservation_id_from_compute_resource_config(compute_resource_config):
+        """Return capacity reservation target if present, None otherwise."""
+        try:
+            return compute_resource_config["CapacityReservationId"]
+        except KeyError as e:
+            # This should never happen because this file is created by cookbook config parser
+            logger.error(
+                "Unable to retrieve CapacityReservationId from compute resource info: %s", compute_resource_config
+            )
+            raise e

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -128,7 +128,7 @@ class CapacityBlockManager:
     @property
     def ec2_client(self):
         if not self._ec2_client:
-            self._ec2_client = Ec2Client(config=self._boto3_config)
+            self._ec2_client = Ec2Client(config=self._boto3_config, region=self._region)
         return self._ec2_client
 
     def get_reserved_nodenames(self, nodes: List[SlurmNode]):

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -287,10 +287,12 @@ class CapacityBlockManager:
                     update_slurm_reservation(name=slurm_reservation_name, nodes=capacity_block_nodenames)
                 else:
                     _log_cb_info("Creating")
+                    # The reservation should start now, and will be removed when the capacity block will become active
                     create_slurm_reservation(
                         name=slurm_reservation_name,
-                        start_time=datetime.now(tz=timezone.utc),
+                        start_time="now",
                         nodes=capacity_block_nodenames,
+                        duration="infinite",
                     )
         except SlurmCommandError as e:
             logger.error(

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -25,7 +25,7 @@ from common.utils import SlurmCommandError
 from slurm_plugin.slurm_resources import SlurmNode
 
 from aws.common import AWSClientError
-from aws.ec2 import CapacityBlockReservationInfo, Ec2Client
+from aws.ec2 import CapacityReservationInfo, Ec2Client
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +66,8 @@ class CapacityBlock:
         self._capacity_block_reservation_info = None
         self._nodenames = []
 
-    def update_capacity_block_reservation_info(self, capacity_block_reservation_info: CapacityBlockReservationInfo):
-        """Update info from CapacityBlockReservationInfo."""
+    def update_capacity_block_reservation_info(self, capacity_block_reservation_info: CapacityReservationInfo):
+        """Update info from CapacityReservationInfo."""
         self._capacity_block_reservation_info = capacity_block_reservation_info
 
     def slurm_reservation_name(self):
@@ -314,7 +314,7 @@ class CapacityBlockManager:
         )
         try:
             capacity_block_reservations_info: List[
-                CapacityBlockReservationInfo
+                CapacityReservationInfo
             ] = self.ec2_client().describe_capacity_reservations(capacity_block_ids)
 
             for capacity_block_reservation_info in capacity_block_reservations_info:

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -277,7 +277,7 @@ class CapacityBlockManager:
         """
         capacity_block_ids = self._capacity_blocks.keys()
         logger.info(
-            "Retrieving updated Capacity Block reservation information from EC2 for %s",
+            "Retrieving Capacity Block reservation information from EC2 for %s",
             ",".join(capacity_block_ids),
         )
         capacity_block_reservations_info: List[
@@ -289,9 +289,8 @@ class CapacityBlockManager:
             try:
                 self._capacity_blocks[capacity_block_id].update_ec2_info(capacity_block_reservation_info)
             except KeyError:
-                raise CapacityBlockManagerError(
-                    f"Unable to find capacity block {capacity_block_id} in the internal map"
-                )
+                # should never happen
+                logger.error(f"Unable to find capacity block {capacity_block_id} in the internal map.")
 
     def _retrieve_capacity_blocks_from_fleet_config(self):
         """

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -184,7 +184,6 @@ class CapacityBlockManager:
         Check configured CBs and associate nodes to them according to queue and compute resource info.
         """
         for node in nodes:
-            capacity_block: CapacityBlock
             for capacity_block in self._capacity_blocks.values():
                 if capacity_block.does_node_belong_to(node):
                     capacity_block.add_nodename(node.name)
@@ -208,6 +207,14 @@ class CapacityBlockManager:
                         capacity_block_id,
                     )
                     delete_slurm_reservation(name=slurm_reservation.name)
+                else:
+                    logger.debug(
+                        (
+                            "Slurm reservation %s is managed by ParallelCluster "
+                            "and related to an existing Capacity Block. Skipping it."
+                        ),
+                        slurm_reservation.name,
+                    )
             else:
                 logger.debug(
                     "Slurm reservation %s is not managed by ParallelCluster. Skipping it.", slurm_reservation.name
@@ -241,7 +248,7 @@ class CapacityBlockManager:
         if capacity_block.is_active():
             # if Slurm reservation exists, delete it.
             if reservation_exists:
-                _log_cb_info("Deleting related")
+                _log_cb_info("Deleting")
                 delete_slurm_reservation(name=slurm_reservation_name)
             else:
                 _log_cb_info("Nothing to do. No existing")
@@ -251,10 +258,10 @@ class CapacityBlockManager:
         else:
             # create or update Slurm reservation
             if reservation_exists:
-                _log_cb_info("Updating existing related")
+                _log_cb_info("Updating existing")
                 update_slurm_reservation(name=slurm_reservation_name, nodes=capacity_block_nodenames)
             else:
-                _log_cb_info("Creating related")
+                _log_cb_info("Creating")
                 create_slurm_reservation(
                     name=slurm_reservation_name,
                     start_time=datetime.now(tz=timezone.utc),

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -95,7 +95,7 @@ class CapacityBlock:
         return node.queue_name == self.queue_name and node.compute_resource_name == self.compute_resource_name
 
     @staticmethod
-    def slurm_reservation_name_to_id(slurm_reservation_name: str):
+    def capacity_block_id_from_slurm_reservation_name(slurm_reservation_name: str):
         """Parse slurm reservation name to retrieve related capacity block id."""
         return slurm_reservation_name[len(SLURM_RESERVATION_NAME_PREFIX) :]  # noqa E203
 
@@ -211,7 +211,9 @@ class CapacityBlockManager:
         try:
             for slurm_reservation in get_slurm_reservations_info():
                 if CapacityBlock.is_capacity_block_slurm_reservation(slurm_reservation.name):
-                    capacity_block_id = CapacityBlock.slurm_reservation_name_to_id(slurm_reservation.name)
+                    capacity_block_id = CapacityBlock.capacity_block_id_from_slurm_reservation_name(
+                        slurm_reservation.name
+                    )
                     if capacity_block_id not in self._capacity_blocks.keys():
                         logger.info(
                             (

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -307,12 +307,12 @@ class CapacityBlockManager:
         This method is called every time the CapacityBlockManager is re-initialized,
         so when it starts/is restarted or when fleet configuration changes.
         """
-        capacity_block_ids = capacity_blocks.keys()
+        capacity_block_ids = list(capacity_blocks.keys())
         logger.info("Retrieving Capacity Blocks information from EC2 for %s", ",".join(capacity_block_ids))
         try:
             capacity_block_reservations_info: List[
                 CapacityReservationInfo
-            ] = self.ec2_client().describe_capacity_reservations(capacity_block_ids)
+            ] = self.ec2_client.describe_capacity_reservations(capacity_block_ids)
 
             for capacity_block_reservation_info in capacity_block_reservations_info:
                 capacity_block_id = capacity_block_reservation_info.capacity_reservation_id()

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -16,8 +16,8 @@ from typing import Dict, List
 from common.schedulers.slurm_reservation_commands import (
     create_slurm_reservation,
     delete_slurm_reservation,
-    does_slurm_reservation_exist,
     get_slurm_reservations_info,
+    is_slurm_reservation,
     update_slurm_reservation,
 )
 from common.time_utils import seconds_to_minutes
@@ -212,7 +212,7 @@ class CapacityBlockManager:
         capacity_block_nodes = capacity_block.nodenames()
         capacity_block_nodenames = ",".join(capacity_block_nodes)
 
-        reservation_exists = does_slurm_reservation_exist(name=slurm_reservation_name)
+        reservation_exists = is_slurm_reservation(name=slurm_reservation_name)
         # if CB is active we need to remove Slurm reservation and start nodes
         if capacity_block.is_active():
             # if Slurm reservation exists, delete it.

--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -191,7 +191,7 @@ class CapacityBlockManager:
 
         return self._reserved_nodenames
 
-    def _is_time_to_update_capacity_blocks_info(self, now: datetime):
+    def _is_time_to_update_capacity_blocks_info(self, current_time: datetime):
         """
         Return true if it's the moment to update capacity blocks info, from ec2 and from config.
 
@@ -199,8 +199,10 @@ class CapacityBlockManager:
         and every 10 minutes.
         # TODO: evaluate time to update accordingly to capacity block start time
         """
-        return not self._is_initialized() or seconds_to_minutes(
-            (now - self._capacity_blocks_update_time).total_seconds() > CAPACITY_BLOCK_RESERVATION_UPDATE_PERIOD
+        return (
+            not self._is_initialized()
+            or seconds_to_minutes((current_time - self._capacity_blocks_update_time).total_seconds())
+            > CAPACITY_BLOCK_RESERVATION_UPDATE_PERIOD
         )
 
     @staticmethod

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -758,6 +758,7 @@ class ClusterManager:
             if not node.is_healthy(
                 consider_drain_as_unhealthy=self._config.terminate_drain_nodes,
                 consider_down_as_unhealthy=self._config.terminate_down_nodes,
+                log_warn_if_unhealthy=node.name not in reserved_nodenames,
             ):
                 if not self._config.disable_capacity_blocks_management and node.name in reserved_nodenames:
                     # do not consider as unhealthy the nodes reserved for capacity blocks

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -755,7 +755,10 @@ class ClusterManager:
             )
 
         for node in slurm_nodes:
-            if not node.is_healthy(self._config.terminate_drain_nodes, self._config.terminate_down_nodes):
+            if not node.is_healthy(
+                consider_drain_as_unhealthy=self._config.terminate_drain_nodes,
+                consider_down_as_unhealthy=self._config.terminate_down_nodes,
+            ):
                 if not self._config.disable_capacity_blocks_management and node.name in reserved_nodenames:
                     # do not consider as unhealthy the nodes reserved for capacity blocks
                     continue

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -741,18 +741,18 @@ class ClusterManager:
         ice_compute_resources_and_nodes_map = {}
         all_unhealthy_nodes = []
 
-        # Remove the nodes part of unactive Capacity Blocks from the list of unhealthy nodes.
+        # Remove the nodes part of inactive Capacity Blocks from the list of unhealthy nodes.
         # Nodes from active Capacity Blocks will be instead managed as unhealthy instances.
         reserved_nodenames = []
         if not self._config.disable_capacity_blocks_management:
             reserved_nodenames = self._capacity_block_manager.get_reserved_nodenames(slurm_nodes)
-            log.info(
-                (
-                    "The nodes %s are associated to unactive Capacity Blocks, "
-                    "they will not be considered as unhealthy nodes."
-                ),
-                ",".join(reserved_nodenames),
-            )
+            if reserved_nodenames:
+                log.info(
+                    "The nodes associated with inactive Capacity Blocks and not considered as unhealthy nodes are: %s",
+                    ",".join(reserved_nodenames),
+                )
+            else:
+                log.debug("No nodes found associated with inactive Capacity Blocks.")
 
         for node in slurm_nodes:
             if not node.is_healthy(

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -187,6 +187,9 @@ class SlurmNode(metaclass=ABCMeta):
     SLURM_SCONTROL_REBOOT_REQUESTED_STATE = "REBOOT_REQUESTED"
     SLURM_SCONTROL_REBOOT_ISSUED_STATE = "REBOOT_ISSUED"
     SLURM_SCONTROL_INVALID_REGISTRATION_STATE = "INVALID_REG"
+    # Reservation related state
+    SLURM_SCONTROL_RESERVED_STATE = "RESERVED"
+    SLURM_SCONTROL_MAINTENANCE_STATE = "MAINTENANCE"
 
     SLURM_SCONTROL_NODE_DOWN_NOT_RESPONDING_REASON = re.compile(r"Not responding \[slurm@.+\]")
 
@@ -294,6 +297,14 @@ class SlurmNode(metaclass=ABCMeta):
     def is_up(self):
         """Check if slurm node is in a healthy state."""
         return not self._is_drain() and not self.is_down() and not self.is_powering_down()
+
+    def _is_reserved(self):
+        """Check if slurm node is reserved."""
+        return self.SLURM_SCONTROL_RESERVED_STATE in self.states
+
+    def is_in_maintenance(self):
+        """Check if slurm node is reserved and in maintenance."""
+        return self.SLURM_SCONTROL_MAINTENANCE_STATE in self.states and self._is_reserved()
 
     def is_powering_up(self):
         """Check if slurm node is in powering up state."""

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -213,7 +213,7 @@ class SlurmNode(metaclass=ABCMeta):
         instance=None,
         slurmdstarttime: datetime = None,
         lastbusytime: datetime = None,
-        reservation_name=None,
+        reservation_name: str = None,
     ):
         """Initialize slurm node with attributes."""
         self.name = name

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -160,6 +160,14 @@ class SlurmResumeData:
     multi_node: List[str]
 
 
+@dataclass
+class SlurmReservation:
+    name: str
+    state: str
+    nodes: str
+    users: str
+
+
 class SlurmNode(metaclass=ABCMeta):
     SLURM_SCONTROL_COMPLETING_STATE = "COMPLETING"
     SLURM_SCONTROL_BUSY_STATES = {"MIXED", "ALLOCATED", SLURM_SCONTROL_COMPLETING_STATE}

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -526,7 +526,7 @@ class StaticNode(SlurmNode):
         if not self.is_nodeaddr_set():
             if log_warn_if_unhealthy:
                 logger.warning(
-                    "Node state check: static node without nodeaddr set, node %s, node state %s:",
+                    "Node state check: static node without nodeaddr set, node: %s, node state: %s",
                     self,
                     self.state_string,
                 )
@@ -538,7 +538,7 @@ class StaticNode(SlurmNode):
         if self.is_static_nodes_in_replacement and not self.is_backing_instance_valid(log_warn_if_unhealthy=False):
             # Node is currently in replacement and no backing instance
             logger.warning(
-                "Node bootstrap error: Node %s is currently in replacement and no backing instance, node state %s:",
+                "Node bootstrap error: Node %s is currently in replacement and no backing instance, node state: %s",
                 self,
                 self.state_string,
             )
@@ -546,14 +546,14 @@ class StaticNode(SlurmNode):
             # Replacement timeout expires for node in replacement
         elif self.is_bootstrap_timeout():
             logger.warning(
-                "Node bootstrap error: Replacement timeout expires for node %s in replacement, node state %s:",
+                "Node bootstrap error: Replacement timeout expires for node %s in replacement, node state: %s",
                 self,
                 self.state_string,
             )
             return True
         elif self.is_failing_health_check and self.is_static_nodes_in_replacement:
             logger.warning(
-                "Node bootstrap error: Node %s failed during bootstrap when performing health check, node state %s:",
+                "Node bootstrap error: Node %s failed during bootstrap when performing health check, node state: %s",
                 self,
                 self.state_string,
             )

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -202,6 +202,7 @@ class SlurmNode(metaclass=ABCMeta):
         instance=None,
         slurmdstarttime: datetime = None,
         lastbusytime: datetime = None,
+        reservation_name=None,
     ):
         """Initialize slurm node with attributes."""
         self.name = name
@@ -214,6 +215,7 @@ class SlurmNode(metaclass=ABCMeta):
         self.instance = instance
         self.slurmdstarttime = slurmdstarttime
         self.lastbusytime = lastbusytime
+        self.reservation_name = reservation_name
         self.is_static_nodes_in_replacement = False
         self.is_being_replaced = False
         self._is_replacement_timeout = False
@@ -441,6 +443,7 @@ class StaticNode(SlurmNode):
         instance=None,
         slurmdstarttime=None,
         lastbusytime=None,
+        reservation_name=None,
     ):
         """Initialize slurm node with attributes."""
         super().__init__(
@@ -453,6 +456,7 @@ class StaticNode(SlurmNode):
             instance,
             slurmdstarttime,
             lastbusytime=lastbusytime,
+            reservation_name=reservation_name,
         )
 
     def is_healthy(self, terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=True):
@@ -558,6 +562,7 @@ class DynamicNode(SlurmNode):
         instance=None,
         slurmdstarttime=None,
         lastbusytime=None,
+        reservation_name=None,
     ):
         """Initialize slurm node with attributes."""
         super().__init__(
@@ -570,6 +575,7 @@ class DynamicNode(SlurmNode):
             instance,
             slurmdstarttime,
             lastbusytime=lastbusytime,
+            reservation_name=reservation_name,
         )
 
     def is_state_healthy(self, terminate_drain_nodes, terminate_down_nodes, log_warn_if_unhealthy=True):

--- a/tests/aws/test_ec2.py
+++ b/tests/aws/test_ec2.py
@@ -1,0 +1,76 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from collections import namedtuple
+
+import pytest
+from assertpy import assert_that
+
+from aws.common import AWSClientError
+from aws.ec2 import CapacityReservationInfo, Ec2Client
+
+MockedBoto3Request = namedtuple(
+    "MockedBoto3Request", ["method", "response", "expected_params", "generate_error", "error_code"]
+)
+# Set defaults for attributes of the namedtuple. Since fields with a default value must come after any fields without
+# a default, the defaults are applied to the rightmost parameters. In this case generate_error = False and
+# error_code = None
+MockedBoto3Request.__new__.__defaults__ = (False, None)
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    # we need to set the region in the environment because the Boto3ClientFactory requires it.
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    return "aws.common.boto3"
+
+
+FAKE_CAPACITY_BLOCK_ID = "cr-a1234567"
+FAKE_CAPACITY_BLOCK_INFO = {
+    "CapacityReservationId": FAKE_CAPACITY_BLOCK_ID,
+    "EndDateType": "limited",
+    # "ReservationType": "capacity-block",
+    "AvailabilityZone": "eu-east-2a",
+    "InstanceMatchCriteria": "targeted",
+    "EphemeralStorage": False,
+    "CreateDate": "2023-07-29T14:22:45Z  ",
+    "StartDate": "2023-08-15T12:00:00Z",
+    "EndDate": "2023-08-19T12:00:00Z",
+    "AvailableInstanceCount": 0,
+    "InstancePlatform": "Linux/UNIX",
+    "TotalInstanceCount": 16,
+    "State": "payment-pending",
+    "Tenancy": "default",
+    "EbsOptimized": True,
+    "InstanceType": "p5.48xlarge",
+}
+
+
+@pytest.mark.parametrize("generate_error", [True, False])
+def test_describe_capacity_reservations(boto3_stubber, generate_error):
+    """Verify that describe_capacity_reservations behaves as expected."""
+    dummy_message = "dummy error message"
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_capacity_reservations",
+            expected_params={"CapacityReservationIds": [FAKE_CAPACITY_BLOCK_ID]},
+            response=dummy_message if generate_error else {"CapacityReservations": [FAKE_CAPACITY_BLOCK_INFO]},
+            generate_error=generate_error,
+            error_code=None,
+        )
+    ]
+    boto3_stubber("ec2", mocked_requests)
+    if generate_error:
+        with pytest.raises(AWSClientError, match=dummy_message):
+            Ec2Client().describe_capacity_reservations(capacity_reservation_ids=[FAKE_CAPACITY_BLOCK_ID])
+    else:
+        return_value = Ec2Client().describe_capacity_reservations(capacity_reservation_ids=[FAKE_CAPACITY_BLOCK_ID])
+        assert_that(return_value).is_equal_to([CapacityReservationInfo(FAKE_CAPACITY_BLOCK_INFO)])

--- a/tests/common.py
+++ b/tests/common.py
@@ -94,6 +94,22 @@ FLEET_CONFIG = {
             "Networking": MULTIPLE_SUBNETS,
         },
     },
+    "queue-cb": {
+        "run-instances-capacity-block": {
+            "Api": "run-instances",
+            "Instances": [{"InstanceType": "c5.xlarge"}],
+            "CapacityType": "capacity-block",
+            "Networking": SINGLE_SUBNET,
+            "CapacityReservationId": "cr-123456",
+        },
+        "fleet-capacity-block": {
+            "Api": "create-fleet",
+            "Instances": [{"InstanceType": "t2.medium"}, {"InstanceType": "t2.large"}],
+            "CapacityType": "capacity-block",
+            "Networking": SINGLE_SUBNET,
+            "CapacityReservationId": "cr-234567",
+        },
+    },
 }
 
 LAUNCH_OVERRIDES = {}

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -129,6 +129,49 @@ def test_is_static_node(nodename, expected_is_static):
             False,
         ),
         (
+            "NodeName=queue1-st-crt2micro-1\n"
+            "NodeAddr=10.0.236.182\n"
+            "NodeHostName=queue1-st-crt2micro-1\n"
+            "State=IDLE+CLOUD+MAINTENANCE+RESERVED\n"
+            "Partitions=queue1\n"
+            "SlurmdStartTime=2023-01-23T17:57:07\n"
+            "LastBusyTime=2023-10-13T10:13:20\n"
+            "ReservationName=root_1\n"
+            "######\n"
+            "NodeName=queuep4d-dy-crp4d-1\n"
+            "NodeAddr=queuep4d-dy-crp4d-1\n"
+            "NodeHostName=queuep4d-dy-crp4d-1\n"
+            "State=DOWN+CLOUD+MAINTENANCE+POWERED_DOWN+RESERVED\n"
+            "Partitions=queuep4d\n"
+            "SlurmdStartTime=None\n"
+            "LastBusyTime=Unknown\n"
+            "Reason=test [slurm@2023-10-20T07:18:35]\n"
+            "ReservationName=root_6\n"
+            "######\n",
+            [
+                StaticNode(
+                    "queue1-st-crt2micro-1",
+                    "10.0.236.182",
+                    "queue1-st-crt2micro-1",
+                    "IDLE+CLOUD+MAINTENANCE+RESERVED",
+                    "queue1",
+                    slurmdstarttime=datetime(2023, 1, 23, 17, 57, 7).astimezone(tz=timezone.utc),
+                    lastbusytime=datetime(2023, 10, 13, 10, 13, 20).astimezone(tz=timezone.utc),
+                    reservation_name="root_1",
+                ),
+                DynamicNode(
+                    "queuep4d-dy-crp4d-1",
+                    "queuep4d-dy-crp4d-1",
+                    "queuep4d-dy-crp4d-1",
+                    "DOWN+CLOUD+MAINTENANCE+POWERED_DOWN+RESERVED",
+                    "queuep4d",
+                    reservation_name="root_6",
+                    reason="test [slurm@2023-10-20T07:18:35]",
+                ),
+            ],
+            False,
+        ),
+        (
             "NodeName=multiple-dy-c5xlarge-3\n"
             "NodeAddr=multiple-dy-c5xlarge-3\n"
             "NodeHostName=multiple-dy-c5xlarge-3\n"
@@ -1043,7 +1086,25 @@ def test_get_nodes_info_argument_validation(
                 "   CurrentWatts=0 AveWatts=0\n"
                 "   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s\n"
                 "   Reason=Reboot ASAP : reboot issued [slurm@2023-01-26T10:11:40]\n"
-                "   Comment=some comment \n"
+                "   Comment=some comment \n\n"
+                "NodeName=queue1-st-crt2micro-1 Arch=x86_64 CoresPerSocket=1\n"
+                "   CPUAlloc=0 CPUEfctv=1 CPUTot=1 CPULoad=0.00\n"
+                "   AvailableFeatures=static,t2.micro,crt2micro\n"
+                "   ActiveFeatures=static,t2.micro,crt2micro\n"
+                "   Gres=(null)\n"
+                "   NodeAddr=10.0.236.182 NodeHostName=queue1-st-crt2micro-1 Version=23.02.4\n"
+                "   OS=Linux 5.10.186-179.751.amzn2.x86_64 #1 SMP Tue Aug 1 20:51:38 UTC 2023\n"
+                "   RealMemory=972 AllocMem=0 FreeMem=184 Sockets=1 Boards=1\n"
+                "   State=IDLE+CLOUD+MAINTENANCE+RESERVED ThreadsPerCore=1 TmpDisk=0 Weight=1 Owner=N/A MCS_label=N/A\n"
+                "   Partitions=queue1\n"
+                "   BootTime=2023-10-13T10:09:58 SlurmdStartTime=2023-10-13T10:13:17\n"
+                "   LastBusyTime=2023-10-13T10:13:20 ResumeAfterTime=None\n"
+                "   CfgTRES=cpu=1,mem=972M,billing=1\n"
+                "   AllocTRES=\n"
+                "   CapWatts=n/a\n"
+                "   CurrentWatts=0 AveWatts=0\n"
+                "   ExtSensorsJoules=n/s ExtSensorsWatts=0 ExtSensorsTemp=n/s\n"
+                "   ReservationName=root_5\n"
             ),
             (
                 "NodeName=queue1-st-compute-resource-1-1\nNodeAddr=192.168.123.191\n"
@@ -1056,6 +1117,10 @@ def test_get_nodes_info_argument_validation(
                 "SlurmdStartTime=2023-01-26T09:57:16\n"
                 "LastBusyTime=Unknown\n"
                 "Reason=Reboot ASAP : reboot issued [slurm@2023-01-26T10:11:40]\n######\n"
+                "NodeName=queue1-st-crt2micro-1\nNodeAddr=10.0.236.182\n"
+                "NodeHostName=queue1-st-crt2micro-1\nState=IDLE+CLOUD+MAINTENANCE+RESERVED\nPartitions=queue1\n"
+                "SlurmdStartTime=2023-10-13T10:13:17\n"
+                "LastBusyTime=2023-10-13T10:13:20\nReservationName=root_5######\n"
             ),
         )
     ],

--- a/tests/common/schedulers/test_slurm_reservation_commands.py
+++ b/tests/common/schedulers/test_slurm_reservation_commands.py
@@ -1,0 +1,292 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+
+import pytest
+from assertpy import assert_that
+from common.schedulers.slurm_commands import DEFAULT_SCONTROL_COMMAND_TIMEOUT, SCONTROL
+from common.schedulers.slurm_reservation_commands import (
+    _add_param,
+    _create_or_update_reservation,
+    create_slurm_reservation,
+    delete_slurm_reservation,
+    update_slurm_reservation,
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "base_cmd, name, nodes, partition, user, start_time, duration, "
+        "number_of_nodes, flags, raise_on_error, timeout, expected_cmd"
+    ),
+    [
+        (
+            f"{SCONTROL} create reservation",
+            "root_1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            f"{SCONTROL} create reservation ReservationName=root_1",
+        ),
+        (
+            f"{SCONTROL} create reservation",
+            "root_1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            f"{SCONTROL} create reservation ReservationName=root_1",
+        ),
+        (
+            f"{SCONTROL} update",
+            "root_2",
+            "nodes-1,nodes[2-6]",
+            "queue1",
+            "user1",
+            datetime(2023, 1, 23, 17, 57, 7),
+            180,
+            10,
+            "testflag",
+            True,
+            10,
+            (
+                f"{SCONTROL} update ReservationName=root_2 nodes=nodes-1,nodes[2-6] partition=queue1"
+                " user=user1 starttime=2023-01-23T17:57:07 duration=180 nodecnt=10 flags=testflag"
+            ),
+        ),
+    ],
+)
+def test_create_or_update_reservation(
+    base_cmd,
+    name,
+    nodes,
+    partition,
+    user,
+    start_time,
+    duration,
+    number_of_nodes,
+    flags,
+    expected_cmd,
+    raise_on_error,
+    timeout,
+    mocker,
+):
+    run_cmd_mock = mocker.patch("common.schedulers.slurm_reservation_commands.run_command")
+    kwargs = {"name": name}
+
+    if nodes:
+        kwargs.update({"nodes": nodes})
+    if partition:
+        kwargs.update({"partition": partition})
+    if user:
+        kwargs.update({"user": user})
+    if start_time:
+        kwargs.update({"start_time": start_time})
+    if duration:
+        kwargs.update({"duration": duration})
+    if number_of_nodes:
+        kwargs.update({"number_of_nodes": number_of_nodes})
+    if flags:
+        kwargs.update({"flags": flags})
+
+    raise_on_error = raise_on_error is True
+    kwargs.update({"raise_on_error": raise_on_error})
+    command_timeout = timeout if timeout else DEFAULT_SCONTROL_COMMAND_TIMEOUT
+    kwargs.update({"command_timeout": command_timeout})
+
+    _create_or_update_reservation(base_cmd, **kwargs)
+    run_cmd_mock.assert_called_with(expected_cmd, raise_on_error=raise_on_error, timeout=command_timeout, shell=True)
+
+
+@pytest.mark.parametrize(
+    "name, nodes, partition, user, start_time, duration, number_of_nodes, flags",
+    [
+        (
+            "root_1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "root_2",
+            "nodes-1,nodes[2-6]",
+            "queue1",
+            "user1",
+            datetime(2023, 1, 23, 17, 57, 7),
+            180,
+            10,
+            "testflag",
+        ),
+    ],
+)
+def test_create_slurm_reservation(
+    name,
+    nodes,
+    partition,
+    user,
+    start_time,
+    duration,
+    number_of_nodes,
+    flags,
+    mocker,
+):
+    run_cmd_mock = mocker.patch("common.schedulers.slurm_reservation_commands._create_or_update_reservation")
+
+    # Compose command to avoid passing None values
+    kwargs = {"name": name}
+    if nodes:
+        kwargs.update({"nodes": nodes})
+    if partition:
+        kwargs.update({"partition": partition})
+    if user:
+        kwargs.update({"user": user})
+    if start_time:
+        kwargs.update({"start_time": start_time})
+    if duration:
+        kwargs.update({"duration": duration})
+    if number_of_nodes:
+        kwargs.update({"number_of_nodes": number_of_nodes})
+    if flags:
+        kwargs.update({"flags": flags})
+
+    create_slurm_reservation(**kwargs)
+
+    # check expected internal call
+    nodes = nodes if nodes else "ALL"
+    user = user if user else "slurm"
+    flags = flags if flags else "maint"
+    run_cmd_mock.assert_called_with(
+        f"{SCONTROL} create reservation",
+        name,
+        nodes,
+        partition,
+        user,
+        start_time,
+        duration,
+        number_of_nodes,
+        flags,
+        DEFAULT_SCONTROL_COMMAND_TIMEOUT,
+        True,
+    )
+
+
+@pytest.mark.parametrize(
+    "name, nodes, partition, user, start_time, duration, number_of_nodes, flags",
+    [
+        (
+            "root_1",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "root_2",
+            "nodes-1,nodes[2-6]",
+            "queue1",
+            "user1",
+            datetime(2023, 1, 23, 17, 57, 7),
+            180,
+            10,
+            "testflag",
+        ),
+    ],
+)
+def test_update_slurm_reservation(
+    name,
+    nodes,
+    partition,
+    user,
+    start_time,
+    duration,
+    number_of_nodes,
+    flags,
+    mocker,
+):
+    run_cmd_mock = mocker.patch("common.schedulers.slurm_reservation_commands._create_or_update_reservation")
+
+    # Compose command to avoid passing None values
+    kwargs = {"name": name}
+    if nodes:
+        kwargs.update({"nodes": nodes})
+    if partition:
+        kwargs.update({"partition": partition})
+    if user:
+        kwargs.update({"user": user})
+    if start_time:
+        kwargs.update({"start_time": start_time})
+    if duration:
+        kwargs.update({"duration": duration})
+    if number_of_nodes:
+        kwargs.update({"number_of_nodes": number_of_nodes})
+    if flags:
+        kwargs.update({"flags": flags})
+
+    update_slurm_reservation(**kwargs)
+
+    # check expected internal call
+    run_cmd_mock.assert_called_with(
+        f"{SCONTROL} update",
+        name,
+        nodes,
+        partition,
+        user,
+        start_time,
+        duration,
+        number_of_nodes,
+        flags,
+        DEFAULT_SCONTROL_COMMAND_TIMEOUT,
+        True,
+    )
+
+
+@pytest.mark.parametrize(
+    "name, cmd_call_kwargs",
+    [
+        ("root_1", {"name": "root_1"}),
+    ],
+)
+def test_delete_reservation(name, cmd_call_kwargs, mocker):
+    run_cmd_mock = mocker.patch("common.schedulers.slurm_reservation_commands.run_command")
+    delete_slurm_reservation(name)
+
+    cmd = f"{SCONTROL} delete reservation ReservationName={name}"
+    run_cmd_mock.assert_called_with(cmd, raise_on_error=True, timeout=DEFAULT_SCONTROL_COMMAND_TIMEOUT, shell=True)
+
+
+@pytest.mark.parametrize(
+    "cmd, param_name, value, expected_cmd",
+    [
+        ("cmd", "", "", "cmd"),
+        ("cmd", "param", None, "cmd"),
+        ("cmd", "param", "value", "cmd param=value"),
+    ],
+)
+def test_add_param(cmd, param_name, value, expected_cmd):
+    assert_that(_add_param(cmd, param_name, value)).is_equal_to(expected_cmd)

--- a/tests/common/schedulers/test_slurm_reservation_commands.py
+++ b/tests/common/schedulers/test_slurm_reservation_commands.py
@@ -22,8 +22,8 @@ from common.schedulers.slurm_reservation_commands import (
     _parse_reservations_info,
     create_slurm_reservation,
     delete_slurm_reservation,
-    does_slurm_reservation_exist,
     get_slurm_reservations_info,
+    is_slurm_reservation,
     update_slurm_reservation,
 )
 from slurm_plugin.slurm_resources import SlurmReservation
@@ -288,7 +288,7 @@ def test_add_param(cmd, param_name, value, expected_cmd):
         ("root_1", CalledProcessError(1, "", "Generic error"), False, True, "Failed when retrieving"),
     ],
 )
-def test_does_slurm_reservation_exist(
+def test_is_slurm_reservation(
     mocker, name, mocked_output, expected_output, expected_message, expected_exception, caplog
 ):
     caplog.set_level(logging.INFO)
@@ -298,9 +298,9 @@ def test_does_slurm_reservation_exist(
 
     if expected_exception:
         with pytest.raises(CalledProcessError):
-            does_slurm_reservation_exist(name)
+            is_slurm_reservation(name)
     else:
-        assert_that(does_slurm_reservation_exist(name)).is_equal_to(expected_output)
+        assert_that(is_slurm_reservation(name)).is_equal_to(expected_output)
         if expected_message:
             assert_that(caplog.text).contains(expected_message)
 

--- a/tests/common/schedulers/test_slurm_reservation_commands.py
+++ b/tests/common/schedulers/test_slurm_reservation_commands.py
@@ -454,7 +454,7 @@ def test_is_slurm_reservation(
     mocker, name, mocked_output, expected_output, expected_message, expected_exception, caplog
 ):
     mocker.patch("time.sleep")
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
     run_cmd_mock = mocker.patch(
         "common.schedulers.slurm_reservation_commands.check_command_output", side_effect=mocked_output
     )
@@ -468,7 +468,9 @@ def test_is_slurm_reservation(
             assert_that(caplog.text).contains(expected_message)
 
     cmd = f"{SCONTROL} show ReservationName={name}"
-    run_cmd_mock.assert_called_with(cmd, raise_on_error=True, timeout=DEFAULT_SCONTROL_COMMAND_TIMEOUT, shell=True)
+    run_cmd_mock.assert_called_with(
+        cmd, raise_on_error=True, timeout=DEFAULT_SCONTROL_COMMAND_TIMEOUT, shell=True, log_error=False
+    )
 
 
 def test_get_slurm_reservations_info(mocker):

--- a/tests/common/test_time_utils.py
+++ b/tests/common/test_time_utils.py
@@ -1,0 +1,18 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from assertpy import assert_that
+from common.time_utils import seconds_to_minutes
+
+
+@pytest.mark.parametrize("value_in_seconds, expected_output", [(0, 0), (12, 0), (60, 1), (66, 1), (1202, 20)])
+def test_seconds_to_minutes(value_in_seconds, expected_output):
+    assert_that(seconds_to_minutes(value_in_seconds)).is_equal_to(expected_output)

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -556,7 +556,7 @@ def test_partition_is_inactive(nodes, expected_output):
 
 
 @pytest.mark.parametrize(
-    "node, terminate_drain_nodes, terminate_down_nodes, mock_is_node_being_replaced, expected_result",
+    "node, consider_drain_as_unhealthy, consider_down_as_unhealthy, mock_is_node_being_replaced, expected_result",
     [
         pytest.param(
             DynamicNode("queue-dy-c5xlarge-1", "some_ip", "hostname", "MIXED+CLOUD", "queue"),
@@ -709,10 +709,12 @@ def test_partition_is_inactive(nodes, expected_output):
     ],
 )
 def test_slurm_node_is_state_healthy(
-    node, mock_is_node_being_replaced, terminate_drain_nodes, terminate_down_nodes, expected_result
+    node, mock_is_node_being_replaced, consider_drain_as_unhealthy, consider_down_as_unhealthy, expected_result
 ):
     node.is_being_replaced = mock_is_node_being_replaced
-    assert_that(node.is_state_healthy(terminate_drain_nodes, terminate_down_nodes)).is_equal_to(expected_result)
+    assert_that(node.is_state_healthy(consider_drain_as_unhealthy, consider_down_as_unhealthy)).is_equal_to(
+        expected_result
+    )
 
 
 @pytest.mark.parametrize(
@@ -1005,7 +1007,9 @@ def test_slurm_node_is_bootstrap_failure(
 )
 def test_slurm_node_is_healthy(node, instance, expected_result):
     node.instance = instance
-    assert_that(node.is_healthy(terminate_drain_nodes=True, terminate_down_nodes=True)).is_equal_to(expected_result)
+    assert_that(node.is_healthy(consider_drain_as_unhealthy=True, consider_down_as_unhealthy=True)).is_equal_to(
+        expected_result
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -292,6 +292,65 @@ def test_slurm_node_is_up(node, expected_output):
     [
         (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), False),
         (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+MAINTENANCE+RESERVED", "queue1"),
+            True,
+        ),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD+MAINTENANCE+POWERED_DOWN+RESERVED",
+                "queue1",
+            ),
+            True,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+RESERVED", "queue1"),
+            True,
+        ),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "RESERVED", "queue1"), True),
+    ],
+)
+def test_slurm_node_is_reserved(node, expected_output):
+    assert_that(node._is_reserved()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), False),
+        (
+            StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+MAINTENANCE+RESERVED", "queue1"),
+            True,
+        ),
+        (
+            StaticNode(
+                "queue1-st-c5xlarge-1",
+                "nodeip",
+                "nodehostname",
+                "DOWN+CLOUD+MAINTENANCE+POWERED_DOWN+RESERVED",
+                "queue1",
+            ),
+            True,
+        ),
+        (
+            DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+MAINTENANCE", "queue1"),
+            False,  # RESERVED is required as well
+        ),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MAINTENANCE", "queue1"), False),
+        (DynamicNode("queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MAINTENANCE+RESERVED", "queue1"), True),
+    ],
+)
+def test_slurm_node_is_in_maintenance(node, expected_output):
+    assert_that(node.is_in_maintenance()).is_equal_to(expected_output)
+
+
+@pytest.mark.parametrize(
+    "node, expected_output",
+    [
+        (StaticNode("queue1-st-c5xlarge-1", "nodeip", "nodehostname", "IDLE+CLOUD+POWER", "queue1"), False),
+        (
             DynamicNode(
                 "queue1-dy-c5xlarge-1", "nodeip", "nodehostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"
             ),

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -1,0 +1,469 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from datetime import datetime
+from unittest.mock import call
+
+import pytest
+from assertpy import assert_that
+from slurm_plugin.capacity_block_manager import SLURM_RESERVATION_NAME_PREFIX, CapacityBlock, CapacityBlockManager
+from slurm_plugin.slurm_resources import StaticNode
+
+from aws.ec2 import CapacityBlockReservationInfo
+
+FAKE_CAPACITY_BLOCK_ID = "cr-a1234567"
+FAKE_CAPACITY_BLOCK_INFO = {
+    "CapacityReservationId": FAKE_CAPACITY_BLOCK_ID,
+    "EndDateType": "limited",
+    "ReservationType": "capacity-block",
+    "AvailabilityZone": "eu-east-2a",
+    "InstanceMatchCriteria": "targeted",
+    "EphemeralStorage": False,
+    "CreateDate": "2023-07-29T14:22:45Z  ",
+    "StartDate": "2023-08-15T12:00:00Z",
+    "EndDate": "2023-08-19T12:00:00Z",
+    "AvailableInstanceCount": 0,
+    "InstancePlatform": "Linux/UNIX",
+    "TotalInstanceCount": 16,
+    "State": "payment-pending",
+    "Tenancy": "default",
+    "EbsOptimized": True,
+    "InstanceType": "p5.48xlarge",
+}
+
+
+@pytest.fixture
+def capacity_block():
+    return CapacityBlock(FAKE_CAPACITY_BLOCK_ID, "queue-cb", "compute-resource-cb")
+
+
+class TestCapacityBlock:
+    @pytest.mark.parametrize(
+        ("state", "expected_output"),
+        [("active", True), ("anything-else", False)],
+    )
+    def test_is_active(self, capacity_block, state, expected_output):
+        capacity_block_reservation_info = CapacityBlockReservationInfo({**FAKE_CAPACITY_BLOCK_INFO, "State": state})
+        capacity_block.update_ec2_info(capacity_block_reservation_info)
+        assert_that(capacity_block.is_active()).is_equal_to(expected_output)
+
+    @pytest.mark.parametrize(
+        "nodes_to_add",
+        [(["node1"]), (["node1", "node2"])],
+    )
+    def test_add_nodename(self, capacity_block, nodes_to_add):
+        for nodename in nodes_to_add:
+            capacity_block.add_nodename(nodename)
+        assert_that(capacity_block.nodenames()).is_equal_to(nodes_to_add)
+
+    @pytest.mark.parametrize(
+        ("node", "expected_output"),
+        [
+            (StaticNode("queue-cb-st-compute-resource-cb-4", "ip-1", "hostname-1", "some_state", "queue-cb"), True),
+            (StaticNode("queue1-st-c5xlarge-4", "ip-1", "hostname-1", "some_state", "queue1"), False),
+            (StaticNode("queue2-st-compute-resource1-4", "ip-1", "hostname-1", "some_state", "queue2"), False),
+        ],
+    )
+    def test_does_node_belong_to(self, capacity_block, node, expected_output):
+        assert_that(capacity_block.does_node_belong_to(node)).is_equal_to(expected_output)
+
+    @pytest.mark.parametrize(
+        ("reservation_name", "expected_output"),
+        [("test", ""), (f"{SLURM_RESERVATION_NAME_PREFIX}anything-else", "anything-else")],
+    )
+    def test_slurm_reservation_name_to_id(self, reservation_name, expected_output):
+        assert_that(CapacityBlock.slurm_reservation_name_to_id(reservation_name)).is_equal_to(expected_output)
+
+    @pytest.mark.parametrize(
+        ("reservation_name", "expected_output"),
+        [("test", False), (f"{SLURM_RESERVATION_NAME_PREFIX}anything-else", True)],
+    )
+    def test_is_capacity_block_slurm_reservation(self, reservation_name, expected_output):
+        assert_that(CapacityBlock.is_capacity_block_slurm_reservation(reservation_name)).is_equal_to(expected_output)
+
+
+class TestCapacityBlockManager:
+    @pytest.fixture
+    def capacity_block_manager(self):
+        return CapacityBlockManager("eu-west-2", {}, "fake_boto3_config")
+
+    def test_ec2_client(self, capacity_block_manager, mocker):
+        ec2_mock = mocker.patch("slurm_plugin.capacity_block_manager.Ec2Client", return_value=mocker.MagicMock())
+        capacity_block_manager.ec2_client()
+        ec2_mock.assert_called_with(config="fake_boto3_config")
+        capacity_block_manager.ec2_client()
+        ec2_mock.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("capacity_blocks", "nodes", "expected_nodenames_in_capacity_block"),
+        [
+            (
+                {
+                    "cr-123456": CapacityBlock("id", "queue-cb", "compute-resource-cb"),
+                    "cr-234567": CapacityBlock("id2", "queue-cb2", "compute-resource-cb2"),
+                },
+                [
+                    StaticNode("queue-cb-st-compute-resource-cb-1", "ip-1", "hostname-1", "some_state", "queue-cb"),
+                    StaticNode("queue1-st-compute-resource1-2", "ip-1", "hostname-1", "some_state", "queue1"),
+                    StaticNode("queue-cb-st-compute-resource-cb-3", "ip-1", "hostname-1", "some_state", "queue-cb"),
+                    StaticNode("queue1-st-compute-resource1-4", "ip-1", "hostname-1", "some_state", "queue1"),
+                    StaticNode("queue-cb2-st-compute-resource-cb2-5", "ip-1", "hostname-1", "some_state", "queue-cb2"),
+                    StaticNode("queue-cb-st-othercr-6", "ip-1", "hostname-1", "some_state", "queue1"),
+                    StaticNode("otherqueue-st-compute-resource-cb-7", "ip-1", "hostname-1", "some_state", "otherqueue"),
+                ],
+                {
+                    "cr-123456": ["queue-cb-st-compute-resource-cb-1", "queue-cb-st-compute-resource-cb-3"],
+                    "cr-234567": ["queue-cb2-st-compute-resource-cb2-5"],
+                },
+            )
+        ],
+    )
+    def test_associate_nodenames_to_capacity_blocks(
+        self,
+        capacity_block_manager,
+        capacity_blocks,
+        nodes,
+        expected_nodenames_in_capacity_block,
+    ):
+        capacity_block_manager._capacity_blocks = capacity_blocks
+        capacity_block_manager._associate_nodenames_to_capacity_blocks(nodes)
+
+        for capacity_block_id in capacity_block_manager._capacity_blocks.keys():
+            # assert in the nodenames list there are only nodes associated to the right queue and compute resource
+            assert_that(capacity_block_manager._capacity_blocks.get(capacity_block_id).nodenames()).is_equal_to(
+                expected_nodenames_in_capacity_block.get(capacity_block_id)
+            )
+
+    @pytest.mark.parametrize(
+        ("nodes", "expected_leftover_slurm_reservations"),
+        [
+            (
+                [
+                    # node without a slurm reservation -> skipped
+                    StaticNode("queue1-st-compute-resource1-1", "ip-1", "hostname-1", "some_state", "queue1"),
+                    # node with a reservation from the customer -> skipped
+                    StaticNode(
+                        "queue4-st-compute-resource1-1",
+                        "ip-1",
+                        "hostname-1",
+                        "some_state",
+                        "queue4",
+                        reservation_name="other-reservation",
+                    ),
+                    # node associated with CB, not yet part of slurm reservation -> skipped
+                    StaticNode("queue-cb-st-compute-resource-cb-1", "ip-1", "hostname-1", "some_state", "queue-cb"),
+                    # node with a reservation associated with CB -> skipped
+                    StaticNode(
+                        "queue-cb-st-compute-resource-cb-2",
+                        "ip-1",
+                        "hostname-1",
+                        "some_state",
+                        "queue-cb",
+                        reservation_name=f"{SLURM_RESERVATION_NAME_PREFIX}cr-123456",
+                    ),
+                    # node with a reservation associated with an old CB but in the queue/cr associated to a new CB,
+                    # this is a leftover reservation
+                    StaticNode(
+                        "queue-cb-st-compute-resource-cb-3",
+                        "ip-1",
+                        "hostname-1",
+                        "some_state",
+                        "queue-cb",
+                        reservation_name=f"{SLURM_RESERVATION_NAME_PREFIX}cr-876543",
+                    ),
+                    # node with a reservation associated with existing CB,
+                    # but from an older queue/cr no longer in config -> skipped
+                    StaticNode(
+                        "queue2-st-compute-resource1-1",
+                        "ip-1",
+                        "hostname-1",
+                        "some_state",
+                        "queue2",
+                        reservation_name=f"{SLURM_RESERVATION_NAME_PREFIX}cr-123456",
+                    ),
+                    # node associated with another old CB, no longer in the config, this is a leftover reservation
+                    StaticNode(
+                        "queue3-st-compute-resource1-1",
+                        "ip-1",
+                        "hostname-1",
+                        "some_state",
+                        "queue3",
+                        reservation_name=f"{SLURM_RESERVATION_NAME_PREFIX}cr-987654",
+                    ),
+                ],
+                [f"{SLURM_RESERVATION_NAME_PREFIX}cr-876543", f"{SLURM_RESERVATION_NAME_PREFIX}cr-987654"],
+            )
+        ],
+    )
+    def test_cleanup_leftover_slurm_reservations(
+        self,
+        mocker,
+        capacity_block_manager,
+        capacity_block,
+        nodes,
+        expected_leftover_slurm_reservations,
+    ):
+        # only cr-123456, queue-cb, compute-resource-cb is in the list of capacity blocks from config
+        capacity_block_manager._capacity_blocks = {"cr-123456": capacity_block}
+        delete_res_mock = mocker.patch("slurm_plugin.capacity_block_manager.delete_slurm_reservation")
+        capacity_block_manager._cleanup_leftover_slurm_reservations(nodes)
+
+        # verify that only the slurm reservation associated with a CB, no longer in the config,
+        # are considered as leftover
+        expected_calls = []
+        for slurm_reservation in expected_leftover_slurm_reservations:
+            expected_calls.append(call(name=slurm_reservation))
+        delete_res_mock.assert_has_calls(expected_calls)
+
+    @pytest.mark.parametrize(
+        (
+            "state",
+            "reservation_exists",
+            "expected_create_res_call",
+            "expected_update_res_call",
+            "expected_delete_res_call",
+        ),
+        [
+            ("pending", False, True, False, False),
+            ("pending", True, False, True, False),
+            ("active", False, False, False, False),
+            ("active", True, False, False, True),
+        ],
+    )
+    def test_update_slurm_reservation(
+        self,
+        mocker,
+        capacity_block_manager,
+        capacity_block,
+        state,
+        reservation_exists,
+        expected_create_res_call,
+        expected_update_res_call,
+        expected_delete_res_call,
+        caplog,
+    ):
+        caplog.set_level(logging.INFO)
+        capacity_block_reservation_info = CapacityBlockReservationInfo({**FAKE_CAPACITY_BLOCK_INFO, "State": state})
+        capacity_block.update_ec2_info(capacity_block_reservation_info)
+        capacity_block.add_nodename("node1")
+        capacity_block.add_nodename("node2")
+        nodenames = ",".join(capacity_block.nodenames())
+        slurm_reservation_name = f"{SLURM_RESERVATION_NAME_PREFIX}{FAKE_CAPACITY_BLOCK_ID}"
+        check_res_mock = mocker.patch(
+            "slurm_plugin.capacity_block_manager.does_slurm_reservation_exist", return_value=reservation_exists
+        )
+        create_res_mock = mocker.patch("slurm_plugin.capacity_block_manager.create_slurm_reservation")
+        update_res_mock = mocker.patch("slurm_plugin.capacity_block_manager.update_slurm_reservation")
+        delete_res_mock = mocker.patch("slurm_plugin.capacity_block_manager.delete_slurm_reservation")
+        expected_start_time = datetime(2020, 1, 1, 0, 0, 0)
+        mocker.patch("slurm_plugin.capacity_block_manager.datetime").now.return_value = expected_start_time
+
+        capacity_block_manager._update_slurm_reservation(capacity_block)
+
+        # check the right commands to create/delete/update reservations are called accordingly to the state
+        check_res_mock.assert_called_with(name=slurm_reservation_name)
+        msg_prefix = f"Capacity Block reservation {FAKE_CAPACITY_BLOCK_ID} is in state {state}. "
+        msg_suffix = f" Slurm reservation {slurm_reservation_name} for nodes {nodenames}."
+
+        # when state is != active
+        if expected_create_res_call:
+            create_res_mock.assert_called_with(
+                name=slurm_reservation_name, start_time=expected_start_time, nodes=nodenames
+            )
+            assert_that(caplog.text).contains(msg_prefix + "Creating related" + msg_suffix)
+        if expected_update_res_call:
+            update_res_mock.assert_called_with(name=slurm_reservation_name, nodes=nodenames)
+            assert_that(caplog.text).contains(msg_prefix + "Updating existing related" + msg_suffix)
+
+        # when state is active
+        if expected_delete_res_call:
+            delete_res_mock.assert_called_with(name=slurm_reservation_name)
+            assert_that(caplog.text).contains(msg_prefix + "Deleting related" + msg_suffix)
+
+        if state == "active" and not reservation_exists:
+            assert_that(caplog.text).contains(msg_prefix + "Nothing to do. No existing" + msg_suffix)
+
+    @pytest.mark.parametrize(
+        (
+            "init_capacity_blocks",
+            "capacity_blocks_from_config",
+            "capacity_blocks_info_from_ec2",
+            "expected_new_capacity_blocks",
+            "expected_new_update_time",
+        ),
+        [
+            # nothing in the config, just change update time
+            ({}, {}, [], {}, True),
+            # new config without info, remove old block from the map
+            (
+                {
+                    "cr-987654": CapacityBlock("id", "queue-cb", "compute-resource-cb"),
+                },
+                {},
+                [],
+                {},
+                True,
+            ),
+            # update old values with new values
+            (
+                {
+                    "cr-987654": CapacityBlock("id", "queue-cb", "compute-resource-cb"),
+                },
+                {
+                    "cr-123456": CapacityBlock("id", "queue-cb", "compute-resource-cb"),
+                    "cr-234567": CapacityBlock("id2", "queue-cb2", "compute-resource-cb2"),
+                },
+                [
+                    CapacityBlockReservationInfo(
+                        {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-123456"}
+                    ),
+                    CapacityBlockReservationInfo(
+                        {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-234567"}
+                    ),
+                ],
+                {
+                    "cr-123456": CapacityBlock("id", "queue-cb", "compute-resource-cb"),
+                    "cr-234567": CapacityBlock("id2", "queue-cb2", "compute-resource-cb2"),
+                },
+                True,
+            ),
+        ],
+    )
+    def test_update_capacity_blocks_info_from_ec2(
+        self,
+        mocker,
+        capacity_block_manager,
+        capacity_blocks_from_config,
+        init_capacity_blocks,
+        expected_new_capacity_blocks,
+        capacity_blocks_info_from_ec2,
+        expected_new_update_time,
+    ):
+        mocker.patch.object(
+            capacity_block_manager, "_capacity_blocks_from_config", return_value=capacity_blocks_from_config
+        )
+        mocked_now = datetime(2020, 1, 1, 0, 0, 0)
+        mocker.patch("slurm_plugin.capacity_block_manager.datetime").now.return_value = mocked_now
+        capacity_block_manager._capacity_blocks = init_capacity_blocks
+
+        mocked_client = mocker.MagicMock()
+        mocked_client.return_value.describe_capacity_reservations.return_value = capacity_blocks_info_from_ec2
+        capacity_block_manager._ec2_client = mocked_client
+
+        capacity_block_manager._update_capacity_blocks_info_from_ec2()
+
+        assert_that(expected_new_capacity_blocks).is_equal_to(capacity_block_manager._capacity_blocks)
+        assert_that(capacity_block_manager._capacity_blocks_update_time).is_equal_to(mocked_now)
+        if expected_new_capacity_blocks:
+            # verify that all the blocks have the updated info from ec2
+            assert_that(
+                capacity_block_manager._capacity_blocks.get("cr-123456")._capacity_block_reservation_info
+            ).is_equal_to(
+                CapacityBlockReservationInfo(
+                    {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-123456"}
+                )
+            )
+            assert_that(
+                capacity_block_manager._capacity_blocks.get("cr-234567")._capacity_block_reservation_info
+            ).is_equal_to(
+                CapacityBlockReservationInfo(
+                    {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-234567"}
+                )
+            )
+
+    @pytest.mark.parametrize(
+        ("fleet_config", "expected_capacity_blocks", "expected_exception"),
+        [
+            ({}, {}, False),
+            (
+                {
+                    "queue-cb": {
+                        "compute-resource-cb": {
+                            "CapacityType": "capacity-block",
+                            "CapacityReservationId": "cr-123456",
+                        }
+                    },
+                    "queue1": {
+                        "compute-resource1": {"CapacityType": "on-demand", "CapacityReservationId": "cr-123456"}
+                    },
+                    "queue-cb2": {
+                        "compute-resource-cb2": {
+                            "CapacityType": "capacity-block",
+                            "CapacityReservationId": "cr-234567",
+                        }
+                    },
+                },
+                {
+                    "cr-123456": CapacityBlock("cr-123456", "queue-cb", "compute-resource-cb"),
+                    "cr-234567": CapacityBlock("cr-234567", "queue-cb2", "compute-resource-cb2"),
+                },
+                False,
+            ),
+            (
+                {"broken-queue-without-id": {"compute-resource-cb": {"CapacityType": "capacity-block"}}},
+                {},
+                True,
+            ),
+            (
+                {"queue-with-cr-id-but-no-cb": {"compute-resource-cb": {"CapacityReservationId": "cr-123456"}}},
+                {},
+                False,
+            ),
+        ],
+    )
+    def test_capacity_blocks_from_config(
+        self, capacity_block_manager, fleet_config, expected_capacity_blocks, expected_exception
+    ):
+        capacity_block_manager._fleet_config = fleet_config
+
+        if expected_exception:
+            with pytest.raises(KeyError):
+                capacity_block_manager._capacity_blocks_from_config()
+        else:
+            assert_that(expected_capacity_blocks).is_equal_to(capacity_block_manager._capacity_blocks_from_config())
+
+    @pytest.mark.parametrize(
+        ("compute_resource_config", "expected_result"),
+        [
+            ({}, False),
+            ({"CapacityType": "spot"}, False),
+            ({"CapacityType": "on-demand"}, False),
+            ({"CapacityType": "capacity-block"}, True),
+        ],
+    )
+    def test__is_compute_resource_associated_to_capacity_block(
+        self, capacity_block_manager, compute_resource_config, expected_result
+    ):
+        assert_that(
+            capacity_block_manager._is_compute_resource_associated_to_capacity_block(compute_resource_config)
+        ).is_equal_to(expected_result)
+
+    @pytest.mark.parametrize(
+        ("compute_resource_config", "expected_result", "expected_exception"),
+        [
+            ({}, False, True),
+            ({"CapacityType": "spot"}, False, True),
+            ({"CapacityType": "spot", "CapacityReservationId": "cr-123456"}, "cr-123456", False),
+            ({"CapacityType": "on-demand", "CapacityReservationId": "cr-123456"}, "cr-123456", False),
+            ({"CapacityType": "capacity-block"}, True, True),
+            ({"CapacityType": "capacity-block", "CapacityReservationId": "cr-123456"}, "cr-123456", False),
+        ],
+    )
+    def test_capacity_reservation_id_from_compute_resource_config(
+        self, capacity_block_manager, compute_resource_config, expected_result, expected_exception
+    ):
+        if expected_exception:
+            with pytest.raises(KeyError):
+                capacity_block_manager._capacity_reservation_id_from_compute_resource_config(compute_resource_config)
+        else:
+            assert_that(
+                capacity_block_manager._capacity_reservation_id_from_compute_resource_config(compute_resource_config)
+            ).is_equal_to(expected_result)

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -397,15 +397,15 @@ class TestCapacityBlockManager:
             create_res_mock.assert_called_with(
                 name=slurm_reservation_name, start_time=expected_start_time, nodes=nodenames
             )
-            assert_that(caplog.text).contains(msg_prefix + "Creating related" + msg_suffix)
+            assert_that(caplog.text).contains(msg_prefix + "Creating" + msg_suffix)
         if expected_update_res_call:
             update_res_mock.assert_called_with(name=slurm_reservation_name, nodes=nodenames)
-            assert_that(caplog.text).contains(msg_prefix + "Updating existing related" + msg_suffix)
+            assert_that(caplog.text).contains(msg_prefix + "Updating existing" + msg_suffix)
 
         # when state is active
         if expected_delete_res_call:
             delete_res_mock.assert_called_with(name=slurm_reservation_name)
-            assert_that(caplog.text).contains(msg_prefix + "Deleting related" + msg_suffix)
+            assert_that(caplog.text).contains(msg_prefix + "Deleting" + msg_suffix)
 
         if state == "active" and not reservation_exists:
             assert_that(caplog.text).contains(msg_prefix + "Nothing to do. No existing" + msg_suffix)

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -230,7 +230,7 @@ class TestCapacityBlockManager:
         )
         mocked_client = mocker.MagicMock()
         expected_exception = isinstance(capacity_blocks_info_from_ec2, Exception)
-        mocked_client.return_value.describe_capacity_reservations.side_effect = [
+        mocked_client.describe_capacity_reservations.side_effect = [
             capacity_blocks_info_from_ec2 if expected_exception else capacity_blocks_info_from_ec2
         ]
         capacity_block_manager._ec2_client = mocked_client
@@ -549,7 +549,7 @@ class TestCapacityBlockManager:
         capacity_block_manager._capacity_blocks = init_capacity_blocks
         expected_exception = isinstance(expected_error, AWSClientError)
         mocked_client = mocker.MagicMock()
-        mocked_client.return_value.describe_capacity_reservations.side_effect = [
+        mocked_client.describe_capacity_reservations.side_effect = [
             expected_error if expected_exception else capacity_blocks_info_from_ec2
         ]
         capacity_block_manager._ec2_client = mocked_client

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -456,7 +456,7 @@ class TestCapacityBlockManager:
         # when state is != active
         if expected_create_res_call:
             create_res_mock.assert_called_with(
-                name=slurm_reservation_name, start_time=expected_start_time, nodes=nodenames
+                name=slurm_reservation_name, start_time="now", nodes=nodenames, duration="infinite"
             )
             assert_that(caplog.text).contains(msg_prefix + "Creating" + msg_suffix)
         else:

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -197,7 +197,9 @@ class TestCapacityBlockManager:
             capacity_block_manager, "_is_time_to_update_capacity_blocks_info", return_value=is_time_to_update
         )
         mocker.patch.object(
-            capacity_block_manager, "_capacity_blocks_from_config", return_value=capacity_blocks_from_config
+            capacity_block_manager,
+            "_retrieve_capacity_blocks_from_fleet_config",
+            return_value=capacity_blocks_from_config,
         )
         mocked_client = mocker.MagicMock()
         mocked_client.return_value.describe_capacity_reservations.return_value = capacity_blocks_info_from_ec2
@@ -534,16 +536,18 @@ class TestCapacityBlockManager:
             ),
         ],
     )
-    def test_capacity_blocks_from_config(
+    def test_retrieve_capacity_blocks_from_fleet_config(
         self, capacity_block_manager, fleet_config, expected_capacity_blocks, expected_exception
     ):
         capacity_block_manager._fleet_config = fleet_config
 
         if expected_exception:
             with pytest.raises(KeyError):
-                capacity_block_manager._capacity_blocks_from_config()
+                capacity_block_manager._retrieve_capacity_blocks_from_fleet_config()
         else:
-            assert_that(expected_capacity_blocks).is_equal_to(capacity_block_manager._capacity_blocks_from_config())
+            assert_that(expected_capacity_blocks).is_equal_to(
+                capacity_block_manager._retrieve_capacity_blocks_from_fleet_config()
+            )
 
     @pytest.mark.parametrize(
         ("compute_resource_config", "expected_result"),

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -319,27 +319,25 @@ class TestCapacityBlockManager:
             cleanup_mock.assert_not_called()
 
     @pytest.mark.parametrize(
-        ("previous_capacity_blocks_update_time", "expected_update_time"),
+        ("is_initialized", "now", "expected_updated_time"),
         [
             # manager not initialized
-            (None, True),
+            (False, datetime(2020, 1, 1, 1, 00, 0), True),
             # delta < CAPACITY_BLOCK_RESERVATION_UPDATE_PERIOD
-            (datetime(2020, 1, 2, 1, 51, 0), False),
-            (datetime(2020, 1, 2, 1, 50, 0), False),
+            (True, datetime(2020, 1, 1, 1, 00, 10), False),
+            (True, datetime(2020, 1, 1, 1, 9, 0), False),
             # delta >= CAPACITY_BLOCK_RESERVATION_UPDATE_PERIOD
-            (datetime(2020, 1, 2, 1, 40, 0), True),
-            (datetime(2020, 1, 2, 0, 51, 0), True),
-            (datetime(2020, 1, 1, 0, 51, 0), True),
+            (True, datetime(2020, 1, 1, 1, 10, 0), True),
+            (True, datetime(2020, 1, 1, 1, 21, 0), True),
+            (True, datetime(2020, 1, 1, 2, 00, 0), True),
+            (True, datetime(2020, 1, 2, 1, 00, 0), True),
         ],
     )
     def test_is_time_to_update_capacity_blocks_info(
-        self, mocker, capacity_block_manager, previous_capacity_blocks_update_time, expected_update_time
+        self, capacity_block_manager, is_initialized, now, expected_updated_time
     ):
-        mocked_now = datetime(2020, 1, 2, 1, 51, 0)
-        mocker.patch("slurm_plugin.capacity_block_manager.datetime").now.return_value = mocked_now
-
-        capacity_block_manager._capacity_blocks_update_time = previous_capacity_blocks_update_time
-        assert_that(capacity_block_manager._is_time_to_update_capacity_blocks_info(mocked_now))
+        capacity_block_manager._capacity_blocks_update_time = datetime(2020, 1, 1, 1, 00, 0) if is_initialized else None
+        assert_that(capacity_block_manager._is_time_to_update_capacity_blocks_info(now))
 
     @pytest.mark.parametrize(
         ("capacity_blocks", "nodes", "expected_nodenames_in_capacity_block"),

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -85,8 +85,10 @@ class TestCapacityBlock:
         ("reservation_name", "expected_output"),
         [("test", ""), (f"{SLURM_RESERVATION_NAME_PREFIX}anything-else", "anything-else")],
     )
-    def test_slurm_reservation_name_to_id(self, reservation_name, expected_output):
-        assert_that(CapacityBlock.slurm_reservation_name_to_id(reservation_name)).is_equal_to(expected_output)
+    def test_capacity_block_id_from_slurm_reservation_name(self, reservation_name, expected_output):
+        assert_that(CapacityBlock.capacity_block_id_from_slurm_reservation_name(reservation_name)).is_equal_to(
+            expected_output
+        )
 
     @pytest.mark.parametrize(
         ("reservation_name", "expected_output"),

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -107,7 +107,7 @@ class TestCapacityBlockManager:
     def test_ec2_client(self, capacity_block_manager, mocker):
         ec2_mock = mocker.patch("slurm_plugin.capacity_block_manager.Ec2Client", return_value=mocker.MagicMock())
         capacity_block_manager.ec2_client()
-        ec2_mock.assert_called_with(config="fake_boto3_config")
+        ec2_mock.assert_called_with(config="fake_boto3_config", region="eu-west-2")
         capacity_block_manager.ec2_client()
         ec2_mock.assert_called_once()
 

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -218,7 +218,7 @@ class TestCapacityBlockManager:
         nodenames = ",".join(capacity_block.nodenames())
         slurm_reservation_name = f"{SLURM_RESERVATION_NAME_PREFIX}{FAKE_CAPACITY_BLOCK_ID}"
         check_res_mock = mocker.patch(
-            "slurm_plugin.capacity_block_manager.does_slurm_reservation_exist", return_value=reservation_exists
+            "slurm_plugin.capacity_block_manager.is_slurm_reservation", return_value=reservation_exists
         )
         create_res_mock = mocker.patch("slurm_plugin.capacity_block_manager.create_slurm_reservation")
         update_res_mock = mocker.patch("slurm_plugin.capacity_block_manager.update_slurm_reservation")

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -24,7 +24,7 @@ from slurm_plugin.capacity_block_manager import (
 from slurm_plugin.slurm_resources import DynamicNode, SlurmReservation, StaticNode
 
 from aws.common import AWSClientError
-from aws.ec2 import CapacityBlockReservationInfo
+from aws.ec2 import CapacityReservationInfo
 
 FAKE_CAPACITY_BLOCK_ID = "cr-a1234567"
 FAKE_CAPACITY_BLOCK_INFO = {
@@ -58,7 +58,7 @@ class TestCapacityBlock:
         [("active", True), ("anything-else", False)],
     )
     def test_is_active(self, capacity_block, state, expected_output):
-        capacity_block_reservation_info = CapacityBlockReservationInfo({**FAKE_CAPACITY_BLOCK_INFO, "State": state})
+        capacity_block_reservation_info = CapacityReservationInfo({**FAKE_CAPACITY_BLOCK_INFO, "State": state})
         capacity_block.update_capacity_block_reservation_info(capacity_block_reservation_info)
         assert_that(capacity_block.is_active()).is_equal_to(expected_output)
 
@@ -147,11 +147,11 @@ class TestCapacityBlockManager:
                     "cr-123456": CapacityBlock("cr-123456", "queue-cb", "compute-resource-cb"),
                 },
                 [
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-123456"}
                     ),
                     # add another id not in the capacity block to trigger an internal error, that does not stop the loop
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-234567"}
                     ),
                 ],
@@ -189,13 +189,13 @@ class TestCapacityBlockManager:
                     "cr-345678": CapacityBlock("cr-345678", "queue-cb3", "compute-resource-cb3"),
                 },
                 [
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-123456"}
                     ),
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-234567"}
                     ),
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-345678"}
                     ),
                 ],
@@ -431,7 +431,7 @@ class TestCapacityBlockManager:
         caplog,
     ):
         caplog.set_level(logging.INFO)
-        capacity_block_reservation_info = CapacityBlockReservationInfo({**FAKE_CAPACITY_BLOCK_INFO, "State": state})
+        capacity_block_reservation_info = CapacityReservationInfo({**FAKE_CAPACITY_BLOCK_INFO, "State": state})
         capacity_block.update_capacity_block_reservation_info(capacity_block_reservation_info)
         capacity_block.add_nodename("node1")
         capacity_block.add_nodename("node2")
@@ -494,10 +494,10 @@ class TestCapacityBlockManager:
                     "cr-123456": CapacityBlock("id", "queue-cb", "compute-resource-cb"),
                 },
                 [
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-123456"}
                     ),
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-234567"}
                     ),
                 ],
@@ -509,10 +509,10 @@ class TestCapacityBlockManager:
                     "cr-123456": CapacityBlock("id", "queue-cb", "compute-resource-cb"),
                 },
                 [
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-123456"}
                     ),
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-234567"}
                     ),
                 ],
@@ -525,10 +525,10 @@ class TestCapacityBlockManager:
                     "cr-234567": CapacityBlock("cr-234567", "queue-cb", "compute-resource-cb"),
                 },
                 [
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-123456"}
                     ),
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-234567"}
                     ),
                 ],
@@ -568,7 +568,7 @@ class TestCapacityBlockManager:
             assert_that(
                 capacity_block_manager._capacity_blocks.get("cr-123456")._capacity_block_reservation_info
             ).is_equal_to(
-                CapacityBlockReservationInfo(
+                CapacityReservationInfo(
                     {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-123456"}
                 )
             )
@@ -580,14 +580,14 @@ class TestCapacityBlockManager:
                 assert_that(
                     capacity_block_manager._capacity_blocks.get("cr-123456")._capacity_block_reservation_info
                 ).is_equal_to(
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-123456"}
                     )
                 )
                 assert_that(
                     capacity_block_manager._capacity_blocks.get("cr-234567")._capacity_block_reservation_info
                 ).is_equal_to(
-                    CapacityBlockReservationInfo(
+                    CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-234567"}
                     )
                 )

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -203,8 +203,23 @@ def test_set_config(initialize_instance_manager_mock):
         worker_pool_max_backlog=10,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
-    updated_config = SimpleNamespace(
+    updated_config_1 = SimpleNamespace(
+        some_key_1="some_value_1",
+        some_key_2="some_value_2",
+        insufficient_capacity_timeout=20,
+        worker_pool_size=5,
+        worker_pool_max_backlog=10,
+        cluster_name="cluster",
+        head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={"queue1": {"cr1": {"test": "test"}}},
+    )
+    updated_config_2 = SimpleNamespace(
         some_key_1="some_value_1",
         some_key_2="some_value_2_changed",
         insufficient_capacity_timeout=10,
@@ -212,16 +227,21 @@ def test_set_config(initialize_instance_manager_mock):
         worker_pool_max_backlog=5,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={"queue1": {"cr1": {"test": "test"}}},
     )
 
     cluster_manager = ClusterManager(initial_config)
     assert_that(cluster_manager._config).is_equal_to(initial_config)
     cluster_manager.set_config(initial_config)
     assert_that(cluster_manager._config).is_equal_to(initial_config)
-    cluster_manager.set_config(updated_config)
-    assert_that(cluster_manager._config).is_equal_to(updated_config)
+    cluster_manager.set_config(updated_config_1)
+    assert_that(cluster_manager._config).is_equal_to(updated_config_1)
+    cluster_manager.set_config(updated_config_2)
+    assert_that(cluster_manager._config).is_equal_to(updated_config_2)
 
-    assert_that(initialize_instance_manager_mock.call_count).is_equal_to(2)
+    assert_that(initialize_instance_manager_mock.call_count).is_equal_to(3)
 
 
 @pytest.mark.usefixtures(
@@ -238,6 +258,9 @@ def test_exception_from_report_console_output_from_nodes(mocker):
         compute_console_wait_time=10,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     unhealthy_nodes = [
         StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname", "some_state", "queue1"),
@@ -344,6 +367,9 @@ def test_clean_up_inactive_partition(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     part = SlurmPartition("partition4", "placeholder_nodes", "INACTIVE")
@@ -705,6 +731,9 @@ def test_handle_health_check(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
 
     cluster_manager = ClusterManager(mock_sync_config)
@@ -771,6 +800,9 @@ def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._static_nodes_in_replacement = current_replacing_nodes
@@ -880,6 +912,9 @@ def test_handle_unhealthy_dynamic_nodes(
         disable_nodes_on_insufficient_capacity=disable_nodes_on_insufficient_capacity,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     mock_instance_manager = cluster_manager._instance_manager
@@ -936,6 +971,9 @@ def test_handle_powering_down_nodes(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     mock_instance_manager = cluster_manager._instance_manager
@@ -1310,6 +1348,9 @@ def test_maintain_nodes(
         disable_nodes_on_insufficient_capacity=disable_nodes_on_insufficient_capacity,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._static_nodes_in_replacement = static_nodes_in_replacement
@@ -1558,6 +1599,7 @@ def test_manage_cluster(
         node_replacement_timeout=1800,
         terminate_max_batch_size=1,
         head_node_instance_id="i-instance-id",
+        fleet_config={},
     )
     mocker.patch("time.sleep")
     cluster_manager = ClusterManager(mock_sync_config)
@@ -2201,6 +2243,7 @@ def test_manage_cluster_boto3(
         )
     cluster_manager._instance_manager._store_assigned_hostnames = mocker.MagicMock()
     cluster_manager._instance_manager._update_dns_hostnames = mocker.MagicMock()
+    mocker.patch.object(cluster_manager._capacity_block_manager, "get_reserved_nodenames", return_value=[])
     cluster_manager.manage_cluster()
 
     assert_that(caplog.records).is_length(len(expected_error_messages))
@@ -2365,6 +2408,9 @@ def test_increase_partitions_protected_failure_count(nodes, initial_map, expecte
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._partitions_protected_failure_count_map = initial_map
@@ -2390,6 +2436,9 @@ def test_reset_partition_failure_count(mocker, partition, expected_map):
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._partitions_protected_failure_count_map = {"queue1": 2, "queue2": 1}
@@ -2461,6 +2510,9 @@ def test_handle_protected_mode_process(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     caplog.set_level(logging.INFO)
     cluster_manager = ClusterManager(mock_sync_config)
@@ -2515,6 +2567,9 @@ def test_enter_protected_mode(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     mock_update_compute_fleet_status = mocker.patch.object(cluster_manager, "_update_compute_fleet_status")
@@ -2593,6 +2648,9 @@ def test_is_node_being_replaced(current_replacing_nodes, node, instance, current
         insufficient_capacity_timeout=3,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = current_time
@@ -2652,6 +2710,9 @@ def test_is_node_replacement_timeout(node, current_node_in_replacement, is_repla
         insufficient_capacity_timeout=-2.2,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = datetime(2020, 1, 2, 0, 0, 0)
@@ -2721,6 +2782,9 @@ def test_handle_failed_health_check_nodes_in_replacement(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._static_nodes_in_replacement = current_nodes_in_replacement
@@ -2782,6 +2846,9 @@ def test_handle_bootstrap_failure_nodes(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     for node, instance in zip(active_nodes, instances):
@@ -2846,6 +2913,9 @@ def test_find_bootstrap_failure_nodes(active_nodes, instances):
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     for node, instance in zip(active_nodes, instances):
@@ -3021,6 +3091,9 @@ def test_handle_ice_nodes(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     caplog.set_level(logging.INFO)
     cluster_manager = ClusterManager(mock_sync_config)
@@ -3369,6 +3442,9 @@ def test_reset_timeout_expired_compute_resources(
         insufficient_capacity_timeout=20,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(config)
     cluster_manager._current_time = datetime(2021, 1, 2, 0, 0, 0)
@@ -3722,6 +3798,9 @@ def test_find_unhealthy_slurm_nodes(
         disable_nodes_on_insufficient_capacity=disable_nodes_on_insufficient_capacity,
         cluster_name="cluster",
         head_node_instance_id="i-instance-id",
+        region="region",
+        boto3_config=None,
+        fleet_config={},
     )
     cluster_manager = ClusterManager(mock_sync_config)
     # Run test

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -733,13 +733,32 @@ def test_handle_health_check(
     "current_replacing_nodes, slurm_nodes, expected_replacing_nodes",
     [
         (
-            {"queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2", "queue1-st-c5xlarge-4"},
+            {
+                "queue1-st-c5xlarge-1",
+                "queue1-st-c5xlarge-2",
+                "queue1-st-c5xlarge-3",
+                "queue1-st-c5xlarge-4",
+                "queue1-st-c5xlarge-5",
+                "queue1-st-c5xlarge-6",
+                "queue1-st-c5xlarge-13",
+            },
             [
+                # nodes in the current replacement list
                 StaticNode("queue1-st-c5xlarge-1", "ip", "hostname", "IDLE+CLOUD", "queue1"),
                 StaticNode("queue1-st-c5xlarge-2", "ip", "hostname", "DOWN+CLOUD", "queue1"),
-                StaticNode("queue1-st-c5xlarge-3", "ip", "hostname", "IDLE+CLOUD", "queue1"),
+                StaticNode("queue1-st-c5xlarge-4", "ip", "hostname", "IDLE+CLOUD+MAINTENANCE+RESERVED", "queue1"),
+                StaticNode("queue1-st-c5xlarge-3", "ip", "hostname", "DOWN+CLOUD+MAINTENANCE+RESERVED", "queue1"),
+                StaticNode("queue1-st-c5xlarge-5", "ip", "hostname", "IDLE+CLOUD+RESERVED", "queue1"),
+                StaticNode("queue1-st-c5xlarge-6", "ip", "hostname", "DOWN+CLOUD+RESERVED", "queue1"),
+                # nodes not in replacement list
+                StaticNode("queue1-st-c5xlarge-8", "ip", "hostname", "IDLE+CLOUD+MAINTENANCE+RESERVED", "queue1"),
+                StaticNode("queue1-st-c5xlarge-7", "ip", "hostname", "DOWN+CLOUD+MAINTENANCE+RESERVED", "queue1"),
+                StaticNode("queue1-st-c5xlarge-9", "ip", "hostname", "IDLE+CLOUD+RESERVED", "queue1"),
+                StaticNode("queue1-st-c5xlarge-10", "ip", "hostname", "DOWN+CLOUD+RESERVED", "queue1"),
+                StaticNode("queue1-st-c5xlarge-11", "ip", "hostname", "IDLE+CLOUD", "queue1"),
+                StaticNode("queue1-st-c5xlarge-12", "ip", "hostname", "DOWN+CLOUD", "queue1"),
             ],
-            {"queue1-st-c5xlarge-2"},
+            {"queue1-st-c5xlarge-2", "queue1-st-c5xlarge-6"},
         )
     ],
     ids=["mixed"],
@@ -747,7 +766,7 @@ def test_handle_health_check(
 @pytest.mark.usefixtures(
     "initialize_instance_manager_mock", "initialize_executor_mock", "initialize_console_logger_mock"
 )
-def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes, expected_replacing_nodes, mocker):
+def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes, expected_replacing_nodes):
     mock_sync_config = SimpleNamespace(
         insufficient_capacity_timeout=600,
         cluster_name="cluster",

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -735,9 +735,9 @@ def test_handle_health_check(
         (
             {"queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2", "queue1-st-c5xlarge-4"},
             [
-                DynamicNode("queue1-st-c5xlarge-1", "ip", "hostname", "IDLE+CLOUD", "queue1"),
-                DynamicNode("queue1-st-c5xlarge-2", "ip", "hostname", "DOWN+CLOUD", "queue1"),
-                DynamicNode("queue1-st-c5xlarge-3", "ip", "hostname", "IDLE+CLOUD", "queue1"),
+                StaticNode("queue1-st-c5xlarge-1", "ip", "hostname", "IDLE+CLOUD", "queue1"),
+                StaticNode("queue1-st-c5xlarge-2", "ip", "hostname", "DOWN+CLOUD", "queue1"),
+                StaticNode("queue1-st-c5xlarge-3", "ip", "hostname", "IDLE+CLOUD", "queue1"),
             ],
             {"queue1-st-c5xlarge-2"},
         )

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -330,42 +330,14 @@ class TestEc2CreateFleetManager:
     }
 
     @pytest.mark.parametrize(
-        (
-            "batch_size",
-            "queue",
-            "compute_resource",
-            "all_or_nothing",
-            "launch_overrides",
-            "log_assertions",
-        ),
+        ("batch_size", "queue", "compute_resource", "all_or_nothing", "launch_overrides", "log_assertions"),
         [
             # normal - spot
-            (
-                5,
-                "queue1",
-                "fleet-spot",
-                False,
-                {},
-                None,
-            ),
+            (5, "queue1", "fleet-spot", False, {}, None),
             # normal - on-demand
-            (
-                5,
-                "queue2",
-                "fleet-ondemand",
-                False,
-                {},
-                None,
-            ),
+            (5, "queue2", "fleet-ondemand", False, {}, None),
             # all or nothing
-            (
-                5,
-                "queue1",
-                "fleet-spot",
-                True,
-                {},
-                None,
-            ),
+            (5, "queue1", "fleet-spot", True, {}, None),
             # launch_overrides
             (
                 5,
@@ -384,32 +356,11 @@ class TestEc2CreateFleetManager:
                 None,
             ),
             # Fleet with (Single-Subnet, Multi-InstanceType) AND all_or_nothing is True --> MinTargetCapacity is set
-            (
-                5,
-                "queue4",
-                "fleet1",
-                True,
-                {},
-                None,
-            ),
+            (5, "queue4", "fleet1", True, {}, None),
             # Fleet with (Multi-Subnet, Single-InstanceType) AND all_or_nothing is True --> MinTargetCapacity is set
-            (
-                5,
-                "queue5",
-                "fleet1",
-                True,
-                {},
-                None,
-            ),
+            (5, "queue5", "fleet1", True, {}, None),
             # Fleet with (Multi-Subnet, Multi-InstanceType) AND all_or_nothing is False --> NOT set MinTargetCapacity
-            (
-                5,
-                "queue6",
-                "fleet1",
-                False,
-                {},
-                None,
-            ),
+            (5, "queue6", "fleet1", False, {}, None),
             # Fleet with (Multi-Subnet, Multi-InstanceType) AND all_or_nothing is True --> Log a warning
             (
                 5,

--- a/tests/slurm_plugin/test_fleet_manager/TestEc2CreateFleetManager/test_evaluate_launch_params/fleet_capacity_block/expected_launch_params.json
+++ b/tests/slurm_plugin/test_fleet_manager/TestEc2CreateFleetManager/test_evaluate_launch_params/fleet_capacity_block/expected_launch_params.json
@@ -1,0 +1,33 @@
+{
+  "LaunchTemplateConfigs":[
+    {
+      "LaunchTemplateSpecification":{
+        "LaunchTemplateName":"hit-queue-cb-fleet-capacity-block",
+        "Version":"$Latest"
+      },
+      "Overrides":[
+        {
+          "InstanceType":"t2.medium",
+          "SubnetId":"1234567"
+        },
+        {
+          "InstanceType":"t2.large",
+          "SubnetId":"1234567"
+        }
+      ]
+    }
+  ],
+  "OnDemandOptions":{
+    "SingleInstanceType":false,
+    "SingleAvailabilityZone":true,
+    "MinTargetCapacity":1,
+    "CapacityReservationOptions":{
+      "UsageStrategy":"use-capacity-reservations-first"
+    }
+  },
+  "TargetCapacitySpecification":{
+    "TotalTargetCapacity":5,
+    "DefaultTargetCapacityType":"capacity-block"
+  },
+  "Type":"instant"
+}


### PR DESCRIPTION
### Capacity Block for ML

Capacity Block reservation for Machine Learning (CB) allow AWS users to reserve blocks of GPU capacity for a future start date and for a time duration of their choice. They are capacity reservations of type `capacity-block`, with additional attributes like: `StartDate`, `EndDate` and additional states.

Capacity Block instances are managed by ParallelCluster as a static nodes but in a peculiar way. ParallelCluster permits to create a cluster even if the CB reservation is not yet active and automatically launch the instances when it will become active.

The Slurm nodes corresponding to compute resources associated to CB reservations are kept in maintenance until the CB start time is reached. When CB is not active, the slurm nodes will stay in a Slurm reservation/maintenance state, associated to the slurm admin user, it means that the nodes can accept jobs but they will stay in pending, until the reservation will be removed.

Clustermgtd will automatically create/delete slurm reservations, putting the related CB nodes in maintenance or not, accordingly to the CB state. The Slurm reservation will be removed when CB is active, nodes will start and become available for the pending jobs or for new jobs submissions.

When the CB end time is reached nodes will be re-inserted in a reservation/maintenance state. It’s up to the user to resubmit/requeue the jobs to a new queue/compute-resource when CB time is ended.

### CapacityBlockManager

`CapacityBlockManager` is a new class that will perform the following actions:
* when CB is not active or expired, a new Slurm reservation will be created/updated
* when CB is active, Slurm reservation will be removed and nodes will become standard static instances

Slurm reservation name will be `pcluster-{capacity_block_reservation_id}`

CapacityBlockManager will be initialized by clustermgtd with region, boto3_config and fleet_config info.
Fleet config is the existing `fleet-config.json` file, that has been extended to include capacity reservation ids and capacity type (ondemand vs spot vs capacity-block).
The manager will reload fleet-config info and capacity reservation info every time the daemon is restarted
or when the config is modified.
Current logic updates CB reservation info every 10 minutes.

The manager will remove the nodes associated with CB reservations that are not active
from the list of unhealthy static nodenames.

### CapacityBlock

`CapacityBlock` is a new class to store internal info about the capacity block,
merging them from ec2 (e.g. capacity block state) and from the config (i.e. list of nodes associated to it).

### Managing slurm reservations
Created a new set of commands (using scontrol) to manage the Slurm reservations:
* create a reservation
  * Use `slurm` as default user rather than root, given that "slurm" is the admin in ParallelCluster setup.
* update an existing reservation
  * I put in common steps to populate create and update commands since they are very similar.
* check if reservation exists
* delete_reservation
* added the reservation_name attribute to the `SlurmNode` class.

#### Leftover slurm reservations

When a CB is removed from a cluster config during a cluster update, we need to remove related slurm reservations.
We're retrieving all the slurm reservations from slurm and deleting them if they are no longer associated with existing CBs in the config.

### Nodes in maintenance state

After this patch the nodes in `MAINTENANCE+RESERVED` state will be excluded by the static nodes in replacement list.
Will see in the "replacement list" only nodes that are not yet up (as before) and nodes that are not in maintenance.

This mechanism permits the daemons (or the user) to avoid replacement of turned down static nodes (`DOWN`) by putting them in maintenance as preliminary step.
This works only for nodes in both `MAINTENANCE` and `RESERVED` state, nodes only in `RESERVED` state will be replaced as before.

In the future, we can extend this mechanism to have an additional field to check (e.g. skip them only if the maintenance is set by the `root` user).

### boto3 layer

Added boto3 layer, this code is taken from the CLI, removing the caching mechanism.
This permits to decouple node daemons code from boto3 calls, adding exceptions catching mechanism.

### Managing exceptions

Defined a new `SlurmCommandError` to identify errors coming from scontrol commands.
Defined a new `SlurmCommandErrorHandler` to permit to handle `SlurmCommandError` and log messages.

Added `retry (max-attempt:2, wait=1s)` and `SlurmCommandErrorHandler` decorator to all the reservations commands.

The main method of the `CapacityBlockManager` (`get_reserved_nodenames`), called by clustermgtd cannot raise any exception.
If the error in the `update_slurm_reservation` happens when updating a single capacity block/slurm reservation,
this is catched and the loop will continue, updating the others.

If there is a generic error like `AWSClientError` (wrapped to `CapacityBlockManagerError`) the entire list of `capacity_blocks` and `reserved_nodes` won't be changed, logging an error.

If `cleanup_leftover_slurm_reservation` fails this will be logged, but the process will continue.

### FleetManager changes

The main difference between on-demand, spot and capacity-block instances, is that capacity-block requires `Market-Type=capacity-block` but this is added to the Launch Template at generation time from the CLI/CDK.
Capacity reservation id and capacity type info for the compute resources are saved in the `config-fleet.json` file, that is generated by the cookbook according to Cluster configuration.

According to this file the node is able to understand if the compute-resource is associated to a CB reservation and add the following additional info:
```
        "OnDemandOptions": {
            ...
            "CapacityReservationOptions": {"UsageStrategy": "use-capacity-reservations-first"},
        },
        "TargetCapacitySpecification": {...."DefaultTargetCapacityType": "capacity-block"},
    }
```

The FleetManager has been modified to support empty `AllocationStrategy` because CB does not support any of the existing options.

### Tests
* The new and modified code is verified by unit tests.

### References
* Slurm reservations: https://slurm.schedmd.com/reservations.html
* Capacity Blocks: https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html
* CLI patch: https://github.com/aws/aws-parallelcluster/pull/5817
* Cookbook patch: https://github.com/aws/aws-parallelcluster-cookbook/pull/2526

### Logging

Slurm reservation creation
```
2023-11-07 12:43:55,361 - [slurm_plugin.capacity_block_manager:_retrieve_capacity_blocks_from_fleet_config] - INFO - Retrieving Capacity Blocks from fleet configuration.
2023-11-07 12:43:55,361 - [slurm_plugin.capacity_block_manager:_update_capacity_blocks_info_from_ec2] - INFO - Retrieving Capacity Blocks information from EC2 for cr-0296d8df657e57a7b
2023-11-07 12:43:55,384 - [aws.common:_log_boto3_calls] - INFO - Executing boto3 call: region=us-east-2, service=ec2, operation=DescribeCapacityReservations, params={'CapacityReservationIds': ['cr-0296d8df657e57a7b']}
2023-11-07 12:43:55,512 - [common.schedulers.slurm_reservation_commands:is_slurm_reservation] - INFO - Slurm reservation pcluster-cr-0296d8df657e57a7b not found.
2023-11-07 12:43:55,513 - [slurm_plugin.capacity_block_manager:_log_cb_info] - INFO - Capacity Block reservation cr-0296d8df657e57a7b is in state scheduled. Creating Slurm reservation pcluster-cr-0296d8df657e57a7b for nodes queue1-st-p5-1.
2023-11-07 12:43:55,513 - [common.schedulers.slurm_reservation_commands:create_slurm_reservation] - INFO - Creating Slurm reservation with command: sudo /opt/slurm/bin/scontrol create reservation
Reservation created: pcluster-cr-0296d8df657e57a7b
2023-11-07 12:43:55,573 - [slurm_plugin.clustermgtd:_find_unhealthy_slurm_nodes] - INFO - The nodes queue1-st-p5-1 are associated with unactive Capacity Blocks, they will not be considered as unhealthy nodes.
2023-11-07 12:43:55,574 - [slurm_plugin.slurm_resources:_is_static_node_ip_configuration_valid] - WARNING - Node state check: static node without nodeaddr set, node queue1-st-p5-1(queue1-st-p5-1), node state DOWN+CLOUD+NOT_RESPONDING+POWERING_UP:
2023-11-07 12:43:55,574 - [slurm_plugin.clustermgtd:_terminate_orphaned_instances] - INFO - Checking for orphaned instance
```

No time to update, `capacity_block_manager` does anything.
```
2023-11-07 17:30:51,134 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Following nodes are currently in replacement: (x0) []
2023-11-07 17:30:51,135 - [slurm_plugin.clustermgtd:_find_unhealthy_slurm_nodes] - INFO - The nodes associated with inactive Capacity Blocks and not considered as unhealthy nodes are: queue1-st-p5-1
2023-11-07 17:30:51,135 - [slurm_plugin.slurm_resources:_is_static_node_ip_configuration_valid] - WARNING - Node state check: static node without nodeaddr set, node queue1-st-p5-1(queue1-st-p5-1), node state IDLE+CLOUD+MAINTENANCE+POWERED_DOWN+RESERVED:
2023-11-07 17:30:51,135 - [slurm_plugin.clustermgtd:_terminate_orphaned_instances] - INFO - Checking for orphaned instance
```

Time to update, because update period passed (I set it to 2 minutes for testing the behaviour)
```
2023-11-07 17:31:51,163 - [slurm_plugin.clustermgtd:_maintain_nodes] - INFO - Following nodes are currently in replacement: (x0) []
2023-11-07 17:31:51,163 - [slurm_plugin.capacity_block_manager:_retrieve_capacity_blocks_from_fleet_config] - INFO - Retrieving Capacity Blocks from fleet configuration.
2023-11-07 17:31:51,163 - [slurm_plugin.capacity_block_manager:_update_capacity_blocks_info_from_ec2] - INFO - Retrieving Capacity Blocks information from EC2 for cr-0296d8df657e57a7b
2023-11-07 17:31:51,177 - [aws.common:_log_boto3_calls] - INFO - Executing boto3 call: region=us-east-2, service=ec2, operation=DescribeCapacityReservations, params={'CapacityReservationIds': ['cr-0296d8df657e57a7b']}
2023-11-07 17:31:51,310 - [slurm_plugin.capacity_block_manager:_log_cb_info] - INFO - Capacity Block reservation cr-0296d8df657e57a7b is in state scheduled. Nothing to do. Already existing Slurm reservation pcluster-cr-0296d8df657e57a7b for nodes queue1-st-p5-1.
2023-11-07 17:31:51,337 - [slurm_plugin.clustermgtd:_find_unhealthy_slurm_nodes] - INFO - The nodes associated with inactive Capacity Blocks and not considered as unhealthy nodes are: queue1-st-p5-1
2023-11-07 17:31:51,338 - [slurm_plugin.slurm_resources:_is_static_node_ip_configuration_valid] - WARNING - Node state check: static node without nodeaddr set, node queue1-st-p5-1(queue1-st-p5-1), node state IDLE+CLOUD+MAINTENANCE+POWERED_DOWN+RESERVED:
2023-11-07 17:31:51,338 - [slurm_plugin.clustermgtd:_terminate_orphaned_instances] - INFO - Checking for orphaned instance
```