### PR TITLE
[develop] Add exp backoff in launch ec2 instances call on throttling 

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -147,7 +147,7 @@ class ClustermgtdConfig:
         "node_replacement_timeout": 1800,
         "terminate_drain_nodes": True,
         "terminate_down_nodes": True,
-        "orphaned_instance_timeout": 120,
+        "orphaned_instance_timeout": 300,
         # Health check configs
         "disable_ec2_health_check": False,
         "disable_scheduled_event_health_check": False,

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -186,7 +186,7 @@ class FleetManager(ABC):
                     "Launched the following instances %s",
                     print_with_count([instance.get("InstanceId", "") for instance in assigned_nodes.get("Instances")]),
                 )
-                logger.debug("Full launched instances information: %s", assigned_nodes.get("Instances"))
+                logger.debug("Launched instances information: %s", assigned_nodes.get("Instances"))
 
         return [EC2Instance.from_describe_instance_data(instance_info) for instance_info in assigned_nodes["Instances"]]
 

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -239,7 +239,12 @@ class Ec2RunInstancesManager(FleetManager):
         try:
             return run_instances(self._region, self._boto3_config, launch_params)
         except ClientError as e:
-            logger.error("Failed RunInstances request: %s", e.response.get("ResponseMetadata").get("RequestId"))
+            logger.error(
+                "Failed RunInstances request (%s): %s - %s",
+                e.response.get("ResponseMetadata", {}).get("RequestId"),
+                e.response.get("Error", {}).get("Code"),
+                e.response.get("Error", {}).get("Message"),
+            )
             raise e
 
 
@@ -388,7 +393,12 @@ class Ec2CreateFleetManager(FleetManager):
                 raise LaunchInstancesError(err_list[0].get("ErrorCode"), err_list[0].get("ErrorMessage"))
             return {"Instances": instances}
         except ClientError as e:
-            logger.error("Failed CreateFleet request: %s", e.response.get("ResponseMetadata", {}).get("RequestId"))
+            logger.error(
+                "Failed CreateFleet request (%s): %s - %s",
+                e.response.get("ResponseMetadata", {}).get("RequestId"),
+                e.response.get("Error", {}).get("Code"),
+                e.response.get("Error", {}).get("Message"),
+            )
             raise e
 
     def _get_instances_info(self, instance_ids: list):

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -71,7 +71,7 @@ class TestClustermgtdConfig:
                     "node_replacement_timeout": 1800,
                     "terminate_drain_nodes": True,
                     "terminate_down_nodes": True,
-                    "orphaned_instance_timeout": 120,
+                    "orphaned_instance_timeout": 300,
                     # health check configs
                     "disable_ec2_health_check": False,
                     "disable_scheduled_event_health_check": False,


### PR DESCRIPTION
### Description of changes
* Add exp backoff in launch ec2 instances call on throttling.
  This is specially useful during all-or-nothing scaling, during all-in optimization call, to avoid quiting the all-in call and enter the job loop.
  The longer retry time requires to increases the orphaned_instance_timeout by 3 min, from 120 to 300 secs
* Add error code and message on ClientError when launching instances, for RunInstances and CreateFleet API calls
* Reword debug log message

### Tests
* manually tested on running cluster

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
