### PR TITLE
[develop] Reorder instance to Slurm node assignation steps

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -1111,12 +1111,14 @@ class JobLevelScalingInstanceManager(InstanceManager):
                         batch_nodes = []
                         try:
                             batch_nodes, batch_launched_ec2_instances = zip(*batch)
-                            assigned_nodes = self._update_slurm_node_addrs(
-                                slurm_nodes=list(batch_nodes), launched_instances=batch_launched_ec2_instances
-                            )
+                            assigned_nodes = dict(batch)
+
                             self._store_assigned_hostnames(nodes=assigned_nodes)
                             self._update_dns_hostnames(
                                 nodes=assigned_nodes, update_dns_batch_size=assign_node_batch_size
+                            )
+                            self._update_slurm_node_addrs(
+                                slurm_nodes=list(batch_nodes), launched_instances=batch_launched_ec2_instances
                             )
                         except (NodeAddrUpdateError, HostnameTableStoreError, HostnameDnsStoreError):
                             if raise_on_error:
@@ -1144,9 +1146,6 @@ class JobLevelScalingInstanceManager(InstanceManager):
                 "Nodes are now configured with instances %s",
                 print_with_count(zip(slurm_nodes, launched_instances)),
             )
-
-            return dict(zip(slurm_nodes, launched_instances))
-
         except subprocess.CalledProcessError:
             logger.error(
                 "Encountered error when updating nodes %s with instances %s",


### PR DESCRIPTION
### Description of changes
Reorder instance to Slurm node assignation steps
* from scontrol update node / write on dynamoDB / write on Route53
* to write on dynamoDB / write on Route53 /scontrol update node

so that the assignation of the instance to Slurm node is done as last step, when all the data needed is set


### Tests
* unit tests added
* manually tested on running cluster

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
