### PR TITLE
[release-3.8] Increase DNS write retries of 1 unit

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -227,11 +227,11 @@ class InstanceManager(ABC):
             # Submit calls to change_resource_record_sets in batches of max 500 elements each.
             # change_resource_record_sets API call has limit of 1000 changes,
             # but the UPSERT action counts for 2 calls
-            # Also pick the number of retries to be the max between the globally configured one and 3.
+            # Also pick the number of retries to be the max between the globally configured one and 4.
             # This is done to address Route53 API throttling without changing the configured retries for all API calls.
             configured_retry = self._boto3_config.retries.get("max_attempts", 0) if self._boto3_config.retries else 0
             boto3_config = self._boto3_config.merge(
-                Config(retries={"max_attempts": max([configured_retry, 3]), "mode": "standard"})
+                Config(retries={"max_attempts": max([configured_retry, 4]), "mode": "standard"})
             )
             route53_client = boto3.client("route53", region_name=self._region, config=boto3_config)
             changes_batch_size = min(update_dns_batch_size, 500)


### PR DESCRIPTION
### Description of changes
Increase DNS write retries of 1 unit, so to account for RequestLimitExceeded when scaling more than 2000 nodes in all-or-nothing.

### Tests
manually tested on running cluster

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
