### PR TITLE
[develop] Fix Slurm reservation deletion command

### DIFF
--- a/src/common/schedulers/slurm_reservation_commands.py
+++ b/src/common/schedulers/slurm_reservation_commands.py
@@ -161,7 +161,7 @@ def delete_slurm_reservation(
 
     Official documentation is https://slurm.schedmd.com/reservations.html
     """
-    cmd = f"{SCONTROL} delete reservation"
+    cmd = f"{SCONTROL} delete"
     cmd = _add_param(cmd, "ReservationName", name)
 
     logger.debug("Deleting Slurm reservation with command: %s", cmd)

--- a/tests/common/schedulers/test_slurm_reservation_commands.py
+++ b/tests/common/schedulers/test_slurm_reservation_commands.py
@@ -392,7 +392,7 @@ def test_delete_reservation(name, cmd_call_kwargs, mocker, run_command_output, e
     else:
         delete_slurm_reservation(name)
 
-    cmd = f"{SCONTROL} delete reservation ReservationName={name}"
+    cmd = f"{SCONTROL} delete ReservationName={name}"
     run_cmd_mock.assert_called_with(cmd, raise_on_error=True, timeout=DEFAULT_SCONTROL_COMMAND_TIMEOUT, shell=True)
 
 


### PR DESCRIPTION
The right command is `scontrol delete ReservationName=xxx` and not `scontrol delete reservation ReservationName=xxx`.

### Tests
* Manually tested in a running cluster.
* I found this issue by simulating a transition from `scheduled` to `active` Capacity Block

### References
* Follow-up of #591 

