### PR TITLE
[develop] Update Capacity Blocks at every clustermgtd loop if there were errors updating Slurm reservations

### DIFF
--- a/src/slurm_plugin/capacity_block_manager.py
+++ b/src/slurm_plugin/capacity_block_manager.py
@@ -148,7 +148,7 @@ class CapacityBlockManager:
         try:
             # evaluate if it's the moment to update info
             now = datetime.now(tz=timezone.utc)
-            if self._is_time_to_update_capacity_blocks_info(now):
+            if self._is_time_to_update(now):
                 reserved_nodenames = []
                 slurm_reservation_update_errors = 0
 
@@ -199,9 +199,9 @@ class CapacityBlockManager:
 
         return self._reserved_nodenames
 
-    def _is_time_to_update_capacity_blocks_info(self, current_time: datetime):
+    def _is_time_to_update(self, current_time: datetime):
         """
-        Return true if it's the moment to update capacity blocks info, from ec2 and from config.
+        Return true if it's the time to update capacity blocks info, from ec2 and config, and manage slurm reservations.
 
         This is true when the CapacityBlockManager is not yet initialized (self._capacity_blocks_update_time == None)
         and every 10 minutes.

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -173,7 +173,7 @@ class TestCapacityBlockManager:
             ),
             (
                 # return first nodename because there is an internal error
-                # in the second capacity block when updating info from EC2
+                # when associating info from EC2 (2 CBs) and the capacity block in the config (1 CB)
                 True,
                 ["node1"],
                 {
@@ -192,7 +192,7 @@ class TestCapacityBlockManager:
                     ),
                 ],
                 [StaticNode("queue-cb-st-compute-resource-cb-1", "ip-1", "hostname-1", "some_state", "queue-cb")],
-                [True, True],
+                [True],
                 ["queue-cb-st-compute-resource-cb-1"],
             ),
             (
@@ -203,12 +203,18 @@ class TestCapacityBlockManager:
                 {
                     "cr-123456": SimpleNamespace(
                         capacity_block_id="cr-123456", compute_resources_map={"queue-cb": {"compute-resource-cb"}}
-                    )
+                    ),
+                    "cr-234567": SimpleNamespace(
+                        capacity_block_id="cr-234567", compute_resources_map={"queue-cb2": {"compute-resource-cb2"}}
+                    ),
                 },
                 [
                     CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-123456"}
-                    )
+                    ),
+                    CapacityReservationInfo(
+                        {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-234567"}
+                    ),
                 ],
                 [StaticNode("queue-cb-st-compute-resource-cb-1", "ip-1", "hostname-1", "some_state", "queue-cb")],
                 [True, False],  # reservation creation failed for the second CB
@@ -222,11 +228,17 @@ class TestCapacityBlockManager:
                 {
                     "cr-123456": SimpleNamespace(
                         capacity_block_id="cr-123456", compute_resources_map={"queue-cb": {"compute-resource-cb"}}
-                    )
+                    ),
+                    "cr-234567": SimpleNamespace(
+                        capacity_block_id="cr-234567", compute_resources_map={"queue-cb2": {"compute-resource-cb2"}}
+                    ),
                 },
                 [
                     CapacityReservationInfo(
                         {**FAKE_CAPACITY_BLOCK_INFO, "State": "pending", "CapacityReservationId": "cr-123456"}
+                    ),
+                    CapacityReservationInfo(
+                        {**FAKE_CAPACITY_BLOCK_INFO, "State": "active", "CapacityReservationId": "cr-234567"}
                     ),
                 ],
                 [StaticNode("queue-cb-st-compute-resource-cb-1", "ip-1", "hostname-1", "some_state", "queue-cb")],

--- a/tests/slurm_plugin/test_capacity_block_manager.py
+++ b/tests/slurm_plugin/test_capacity_block_manager.py
@@ -310,9 +310,7 @@ class TestCapacityBlockManager:
         expected_reserved_nodenames,
         caplog,
     ):
-        mocker.patch.object(
-            capacity_block_manager, "_is_time_to_update_capacity_blocks_info", return_value=is_time_to_update
-        )
+        mocker.patch.object(capacity_block_manager, "_is_time_to_update", return_value=is_time_to_update)
         mocked_capacity_blocks_from_config = self._build_capacity_blocks(capacity_blocks_from_config)
         mocker.patch.object(
             capacity_block_manager,
@@ -381,11 +379,11 @@ class TestCapacityBlockManager:
             (True, datetime(2020, 1, 2, 1, 00, 0), True),
         ],
     )
-    def test_is_time_to_update_capacity_blocks_info(
+    def test_is_time_to_update(
         self, capacity_block_manager, is_initialized, now, expected_updated_time
     ):
         capacity_block_manager._capacity_blocks_update_time = datetime(2020, 1, 1, 1, 00, 0) if is_initialized else None
-        assert_that(capacity_block_manager._is_time_to_update_capacity_blocks_info(now))
+        assert_that(capacity_block_manager._is_time_to_update(now))
 
     @pytest.mark.parametrize(
         ("capacity_blocks", "nodes", "expected_nodenames_in_capacity_block"),


### PR DESCRIPTION
### Description of changes
Previously, in case of internal error during the creation/update/deletion of slurm reservations, the code was trying to do the same action only after 10 minutes.

Now we're monitoring the `_slurm_reservation_update_errors` attribute and if it has a value `> 0` we're saying that it's time to update.

This improves the responsiveness of the system.

1. When CB passes from inactive to active --> we need to remove the slurm reservation ASAP, retrying many times in case of issues. Have the reservation removed is really important.

2. When CB passes from active to inactive --> if there are jobs associated to the nodes and the nodes are not yet terminated it's not possible to create the reservation, so we need to retry ASAP and not after 10 minutes.


### Minor change

Renamed to `is_time_to_update` since when it's true, it's not only the moment to updating info from ec2 and config but also
to update slurm reservations accordingly.


### Tests
* [Make unit tests parameters more coherent](https://github.com/aws/aws-parallelcluster-node/commit/975bc86a9ff7b9dedac6d4db17725d19d053e9b2) 

Some values were not really needed for the tests
because we are simulating internal errors and particular conditions.
Some values were missing even if not impacting the test logic.

### References
* Followup of #591 
