### PR TITLE
[develop] Add mechanism to permit to mock generic methods/functions of the python package

### DIFF
--- a/src/aws/ec2.py
+++ b/src/aws/ec2.py
@@ -10,6 +10,8 @@
 # limitations under the License.
 from typing import List
 
+from common.utils import ApiMocker
+
 from aws.common import AWSExceptionHandler, Boto3Client
 
 
@@ -73,6 +75,7 @@ class Ec2Client(Boto3Client):
         super().__init__("ec2", region=region, config=config)
 
     @AWSExceptionHandler.handle_client_exception
+    @ApiMocker.mockable
     def describe_capacity_reservations(self, capacity_reservation_ids: List[str]) -> List[CapacityReservationInfo]:
         """Accept a space separated list of reservation ids. Return a list of CapacityReservationInfo."""
         result = []


### PR DESCRIPTION
### Description of changes

The new `ApiMocker.mockable` is a decorator that can be applied to mock any method.

The decorator will automatically search in the `<function-name-path>.overrides.py` file (if it exists) a function with the same name of the function.
If the function exists, the decorator will execute it in place of the original one.

The same `slurm_plugin.overrides.py` file is already used by `run_instances` and `create_fleet` methods,
but without the generic decorator mechanism. We can use this new mechanism for them in the future.

I'm using it for `describe_capacity_reservations` to permit to mock it when running e2e tests.
An example of bash script to create overrides file is:
```
node_virtualenv_path=$(sudo find / -iname "site-packages" | grep "node_virtualenv")
# the overrides.py file must be in the same folder of the module of the function to be mocked
cat << EOF | sudo tee -a "${node_virtualenv_path}/aws/overrides.py"
from aws.ec2 import CapacityReservationInfo

def describe_capacity_reservations(_, capacity_reservations_ids):
    return [
        CapacityReservationInfo({
            "CapacityReservationId": "cr-123456",
            "OwnerId": "123456789",
            "CapacityReservationArn": "arn:aws:ec2:us-east-2:123456789:capacity-reservation/cr-123456",
            ...
        })
    ]
EOF
```

### Tests

Tested with:
* not existing overrides.py (`ImportError`)
* empty overrides.py (`AttributeError`)
* overrides.py with other functions defined on it (`AttributeError`)
* overrides.py with the mocked `describe_capacity_reservations` (mocked output)

