### PR TITLE
[release-3.8] Resume log fix/refactoring and method renaming

### DIFF
--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -194,8 +194,6 @@ class InstanceManager(ABC):
                         }
                     )
 
-        logger.info("Database update: COMPLETED")
-
     @log_exception(logger, "updating DNS records", raise_on_error=True, exception_to_raise=HostnameDnsStoreError)
     def _update_dns_hostnames(self, nodes, update_dns_batch_size=500):
         logger.info(
@@ -205,7 +203,7 @@ class InstanceManager(ABC):
         )
         if not self._hosted_zone or not self._dns_domain:
             logger.info(
-                "Empty DNS domain name or hosted zone configuration parameter.",
+                "Empty DNS domain name or hosted zone configuration parameter",
             )
             return
 
@@ -239,7 +237,6 @@ class InstanceManager(ABC):
                 route53_client.change_resource_record_sets(
                     HostedZoneId=self._hosted_zone, ChangeBatch={"Changes": list(changes_batch)}
                 )
-        logger.info("DNS records update: COMPLETED")
 
     def _parse_nodes_resume_list(self, node_list: List[str]) -> defaultdict[str, defaultdict[str, List[str]]]:
         """
@@ -897,9 +894,8 @@ class JobLevelScalingInstanceManager(InstanceManager):
                 assign_node_batch_size=assign_node_batch_size,
                 raise_on_error=False,
             )
-
             logger.info(
-                "Successful launched %s instances for nodes %s",
+                "Successful launched and assigned %s instances for nodes %s",
                 "all" if len(successful_launched_nodes) == len(nodes_resume_list) else "partial",
                 print_with_count(successful_launched_nodes),
             )
@@ -945,7 +941,7 @@ class JobLevelScalingInstanceManager(InstanceManager):
                     raise_on_error=True,
                 )
                 logger.info(
-                    "Successful launched all instances for nodes %s",
+                    "Successful launched and assigned all instances for nodes %s",
                     print_with_count(nodes_resume_list),
                 )
                 self._update_dict(self.nodes_assigned_to_instances, nodes_resume_mapping)
@@ -1092,7 +1088,7 @@ class JobLevelScalingInstanceManager(InstanceManager):
             # Reuse already launched capacity
             # fmt: off
             logger.info(
-                "Booking already launched instances for nodes %s:",
+                "Booking already launched instances for nodes %s",
                 print_with_count(slurm_node_list[:len(reusable_instances)]),
             )
             instances_launched[queue][compute_resource].extend(reusable_instances[:len(slurm_node_list)])

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -847,7 +847,7 @@ class JobLevelScalingInstanceManager(InstanceManager):
 
         if scaling_strategy in [ScalingStrategy.ALL_OR_NOTHING, ScalingStrategy.GREEDY_ALL_OR_NOTHING]:
             logger.info("Assigning nodes with all-or-nothing strategy")
-            self.all_or_nothing_node_assignment(
+            self._all_or_nothing_node_assignment(
                 assign_node_batch_size=assign_node_batch_size,
                 instances_launched=instances_launched,
                 nodes_resume_list=nodes_resume_list,
@@ -857,7 +857,7 @@ class JobLevelScalingInstanceManager(InstanceManager):
             )
         else:
             logger.info("Assigning nodes with best-effort strategy")
-            self.best_effort_node_assignment(
+            self._best_effort_node_assignment(
                 assign_node_batch_size=assign_node_batch_size,
                 failed_launch_nodes=failed_launch_nodes,
                 instances_launched=instances_launched,
@@ -873,7 +873,7 @@ class JobLevelScalingInstanceManager(InstanceManager):
             for error_code in self.failed_nodes:
                 self.failed_nodes[error_code] = self.failed_nodes.get(error_code, set()).difference(nodeset)
 
-    def best_effort_node_assignment(
+    def _best_effort_node_assignment(
         self,
         assign_node_batch_size,
         failed_launch_nodes,
@@ -919,7 +919,7 @@ class JobLevelScalingInstanceManager(InstanceManager):
             logger.info("No launched instances found for nodes %s", print_with_count(nodes_resume_list))
             self._update_failed_nodes(set(nodes_resume_list), "InsufficientInstanceCapacity", override=False)
 
-    def all_or_nothing_node_assignment(
+    def _all_or_nothing_node_assignment(
         self,
         assign_node_batch_size,
         instances_launched,

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -3262,8 +3262,8 @@ class TestJobLevelScalingInstanceManager:
         expect_all_or_nothing_node_assignment,
         expect_best_effort_node_assignment,
     ):
-        instance_manager.all_or_nothing_node_assignment = mocker.MagicMock()
-        instance_manager.best_effort_node_assignment = mocker.MagicMock()
+        instance_manager._all_or_nothing_node_assignment = mocker.MagicMock()
+        instance_manager._best_effort_node_assignment = mocker.MagicMock()
         instance_manager._add_instances_for_nodes(
             node_list=[],
             launch_batch_size=1,
@@ -3271,11 +3271,11 @@ class TestJobLevelScalingInstanceManager:
             scaling_strategy=scaling_strategy,
         )
         if expect_all_or_nothing_node_assignment:
-            instance_manager.all_or_nothing_node_assignment.assert_called_once()
-            instance_manager.best_effort_node_assignment.assert_not_called()
+            instance_manager._all_or_nothing_node_assignment.assert_called_once()
+            instance_manager._best_effort_node_assignment.assert_not_called()
         if expect_best_effort_node_assignment:
-            instance_manager.best_effort_node_assignment.assert_called_once()
-            instance_manager.all_or_nothing_node_assignment.assert_not_called()
+            instance_manager._best_effort_node_assignment.assert_called_once()
+            instance_manager._all_or_nothing_node_assignment.assert_not_called()
 
     @pytest.mark.parametrize(
         "job, nodes_to_launch, launch_batch_size, unused_launched_instances, launched_instances, "
@@ -4249,7 +4249,7 @@ class TestJobLevelScalingInstanceManager:
         # patch internal functions
         instance_manager._assign_instances_to_nodes = mocker.MagicMock()
 
-        instance_manager.best_effort_node_assignment(
+        instance_manager._best_effort_node_assignment(
             assign_node_batch_size=assign_node_batch_size,
             failed_launch_nodes=failed_launch_nodes,
             instances_launched=instances_launched,
@@ -4441,7 +4441,7 @@ class TestJobLevelScalingInstanceManager:
         )
         instance_manager.unused_launched_instances = unused_launched_instances
 
-        instance_manager.all_or_nothing_node_assignment(
+        instance_manager._all_or_nothing_node_assignment(
             assign_node_batch_size=assign_node_batch_size,
             instances_launched=instances_launched,
             nodes_resume_list=nodes_resume_list,


### PR DESCRIPTION
### Description of changes
* Fix mapping of node assigned to instances for best-effort

  In the best effort node assignment, not all the nodes to be resumed have an assigned instances.
  The fix cover the case when len(successful_launched_nodes) < len(nodes_resume_list).
  This was causing misunderstanding in the flow log, see example later, but functionality wasn't impacted. 

* Reformat log for resume program execution

* Rename instance manager methods

### Tests
Manually tested on running cluster.
Resume log changed
from
```
2023-11-14 11:36:29,164 - 48010 - [slurm_plugin.resume:main] - INFO - ResumeProgram startup.
2023-11-14 11:36:29,165 - 48010 - [slurm_plugin.resume:_get_config] - INFO - Reading /etc/parallelcluster/slurm_plugin/parallelcluster_slurm_resume.conf
2023-11-14 11:36:29,166 - 48010 - [slurm_plugin.resume:main] - INFO - ResumeProgram config: SlurmResumeConfig(region='us-east-1', cluster_name='jls-4', dynamodb_table='parallelcluster-slurm-jls-4', hosted_zone='Z07134712BL7RRXVW2BHD', dns_domain='jls-4.pcluster.', use_private_hostname=False, head_node_private_ip='192.168.24.235', head_node_hostname='ip-192-168-24-235.ec2.internal', launch_max_batch_size=500, assign_node_max_batch_size=500, terminate_max_batch_size=1000, update_node_address=True, scaling_strategy='best-effort', job_level_scaling=True, fleet_config={'q1': {'c1': {'CapacityType': 'on-demand', 'Api': 'create-fleet', 'Instances': [{'InstanceType': 'c5.4xlarge'}], 'Networking': {'SubnetIds': ['subnet-01bbe94d5ff9fe2c5']}, 'AllocationStrategy': 'lowest-price'}}, 'q2': {'c2': {'CapacityType': 'on-demand', 'Api': 'run-instances', 'Instances': [{'InstanceType': 'c5.4xlarge'}]}}, 'q5': {'c5-1': {'CapacityType': 'on-demand', 'Api': 'create-fleet', 'Instances': [{'InstanceType': 'c5.4xlarge'}], 'Networking': {'SubnetIds': ['subnet-01bbe94d5ff9fe2c5']}, 'AllocationStrategy': 'lowest-price'}, 'c5-2': {'CapacityType': 'on-demand', 'Api': 'create-fleet', 'Instances': [{'InstanceType': 'p4d.24xlarge'}], 'Networking': {'SubnetIds': ['subnet-01bbe94d5ff9fe2c5']}, 'AllocationStrategy': 'lowest-price'}}}, run_instances_overrides={}, create_fleet_overrides={}, clustermgtd_timeout=300, clustermgtd_heartbeat_file_path='/opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat', _boto3_retry=1, _boto3_config={'retries': {'max_attempts': 1, 'mode': 'standard'}}, boto3_config=<botocore.config.Config object at 0x7feff44a0c70>, logging_config='/opt/parallelcluster/pyenv/versions/3.9.17/envs/node_virtualenv/lib/python3.9/site-packages/slurm_plugin/logging/parallelcluster_resume_logging.conf', head_node_instance_id='i-0d107cf004c0f59de')
2023-11-14 11:36:29,166 - 48010 - [slurm_plugin.resume:_get_slurm_resume] - INFO - Slurm Resume File content: {'jobs': [{'extra': None, 'job_id': 11022, 'features': '[(c5.4xlarge)*1&(p4d.24xlarge)*1]', 'nodes_alloc': 'q5-dy-c5-1-3,q5-dy-c5-2-1', 'nodes_resume': 'q5-dy-c5-1-3,q5-dy-c5-2-1', 'oversubscribe': 'OK', 'partition': 'q5', 'reservation': None}, {'extra': None, 'job_id': 11023, 'features': '[(c5.4xlarge)*1&(p4d.24xlarge)*1]', 'nodes_alloc': 'q5-dy-c5-1-4,q5-dy-c5-2-1', 'nodes_resume': 'q5-dy-c5-1-4,q5-dy-c5-2-1', 'oversubscribe': 'OK', 'partition': 'q5', 'reservation': None}], 'all_nodes_resume': 'q5-dy-c5-1-[3-4],q5-dy-c5-2-1'}
2023-11-14 11:36:29,171 - 48010 - [slurm_plugin.common:is_clustermgtd_heartbeat_valid] - INFO - Latest heartbeat from clustermgtd: 2023-11-14 11:36:20.043501+00:00
2023-11-14 11:36:29,171 - 48010 - [slurm_plugin.resume:_resume] - INFO - Launching EC2 instances for the following Slurm nodes: q5-dy-c5-1-[3-4],q5-dy-c5-2-1
2023-11-14 11:36:29,281 - 48010 - [slurm_plugin.resume:_resume] - INFO - Current state of Slurm nodes to resume: [('q5-dy-c5-1-3', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('q5-dy-c5-1-4', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('q5-dy-c5-2-1', 'MIXED+CLOUD+NOT_RESPONDING+POWERING_UP')]
2023-11-14 11:36:29,308 - 48010 - [botocore.credentials:load] - INFO - Found credentials from IAM Role: jls-4-RoleHeadNode-669yRydojc2m
2023-11-14 11:36:29,349 - 48010 - [slurm_plugin.instance_manager:_parse_nodes_resume_list] - INFO - Nodes already assigned to running instances: {}
2023-11-14 11:36:29,349 - 48010 - [slurm_plugin.instance_manager:_launch_instances] - INFO - Launching best-effort instances for nodes (x2) ['q5-dy-c5-1-3', 'q5-dy-c5-1-4']
2023-11-14 11:36:29,349 - 48010 - [slurm_plugin.fleet_manager:create_fleet] - INFO - Launching instances with create_fleet API. Parameters: {'LaunchTemplateConfigs': [{'LaunchTemplateSpecification': {'LaunchTemplateName': 'jls-4-q5-c5-1', 'Version': '$Latest'}, 'Overrides': [{'InstanceType': 'c5.4xlarge', 'SubnetId': 'subnet-01bbe94d5ff9fe2c5'}]}], 'TargetCapacitySpecification': {'TotalTargetCapacity': 2, 'DefaultTargetCapacityType': 'on-demand'}, 'Type': 'instant', 'OnDemandOptions': {'SingleInstanceType': True, 'SingleAvailabilityZone': True, 'AllocationStrategy': 'lowest-price', 'MinTargetCapacity': 1, 'CapacityReservationOptions': {'UsageStrategy': 'use-capacity-reservations-first'}}}
2023-11-14 11:36:32,331 - 48010 - [slurm_plugin.fleet_manager:launch_ec2_instances] - INFO - Launched the following instances (x2) ['i-0f4ec32817cde62fb', 'i-030c09006acb3b2ce']
2023-11-14 11:36:32,332 - 48010 - [slurm_plugin.instance_manager:_launch_instances] - INFO - Launching best-effort instances for nodes (x1) ['q5-dy-c5-2-1']
2023-11-14 11:36:32,332 - 48010 - [slurm_plugin.fleet_manager:create_fleet] - INFO - Launching instances with create_fleet API. Parameters: {'LaunchTemplateConfigs': [{'LaunchTemplateSpecification': {'LaunchTemplateName': 'jls-4-q5-c5-2', 'Version': '$Latest'}, 'Overrides': [{'InstanceType': 'p4d.24xlarge', 'SubnetId': 'subnet-01bbe94d5ff9fe2c5'}]}], 'TargetCapacitySpecification': {'TotalTargetCapacity': 1, 'DefaultTargetCapacityType': 'on-demand'}, 'Type': 'instant', 'OnDemandOptions': {'SingleInstanceType': True, 'SingleAvailabilityZone': True, 'AllocationStrategy': 'lowest-price', 'MinTargetCapacity': 1, 'CapacityReservationOptions': {'UsageStrategy': 'use-capacity-reservations-first'}}}
2023-11-14 11:36:33,660 - 48010 - [slurm_plugin.fleet_manager:_launch_instances] - ERROR - Error in CreateFleet request (9b17efda-3bff-46b7-b9ae-86bcad2f1b68): InsufficientInstanceCapacity - We currently do not have sufficient p4d.24xlarge capacity in the Availability Zone you requested (us-east-1d). Our system will be working on provisioning additional capacity. You can currently get p4d.24xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1a, us-east-1b.
2023-11-14 11:36:33,761 - 48010 - [slurm_plugin.instance_manager:_launch_instances] - ERROR - Encountered exception when launching instances for nodes (x1) ['q5-dy-c5-2-1']: We currently do not have sufficient p4d.24xlarge capacity in the Availability Zone you requested (us-east-1d). Our system will be working on provisioning additional capacity. You can currently get p4d.24xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1a, us-east-1b.
2023-11-14 11:36:33,761 - 48010 - [slurm_plugin.instance_manager:_scaling_for_jobs] - INFO - JobID 11022 - The nodes_resume list from Slurm Resume File is (x2) ['q5-dy-c5-1-3', 'q5-dy-c5-2-1']
2023-11-14 11:36:33,761 - 48010 - [slurm_plugin.instance_manager:_parse_nodes_resume_list] - INFO - JobID 11022 - Nodes already assigned to running instances: {}
2023-11-14 11:36:33,761 - 48010 - [slurm_plugin.instance_manager:_resize_slurm_node_list] - INFO - JobID 11022 - Booking already launched instances for nodes (x1) ['q5-dy-c5-1-3']
2023-11-14 11:36:33,761 - 48010 - [slurm_plugin.instance_manager:_add_instances_for_nodes] - INFO - JobID 11022 - Assigning nodes with best-effort strategy
2023-11-14 11:36:33,761 - 48010 - [slurm_plugin.instance_manager:_store_assigned_hostnames] - INFO - JobID 11022 - Saving assigned hostnames in DynamoDB
2023-11-14 11:36:33,794 - 48010 - [slurm_plugin.instance_manager:_update_dns_hostnames] - INFO - JobID 11022 - Updating DNS records for Z07134712BL7RRXVW2BHD - jls-4.pcluster.
2023-11-14 11:36:34,040 - 48010 - [slurm_plugin.instance_manager:_update_slurm_node_addrs] - INFO - JobID 11022 - Nodes are now configured with instances (x1) ["('q5-dy-c5-1-3', EC2Instance(id='i-0f4ec32817cde62fb', private_ip='192.168.139.166', hostname='ip-192-168-139-166', launch_time=datetime.datetime(2023, 11, 14, 11, 36, 30, tzinfo=tzlocal()), slurm_node=None))"]
2023-11-14 11:36:34,040 - 48010 - [slurm_plugin.instance_manager:best_effort_node_assignment] - INFO - JobID 11022 - Successful launched and assigned partial instances for nodes (x1) ['q5-dy-c5-1-3']
2023-11-14 11:36:34,040 - 48010 - [slurm_plugin.instance_manager:_scaling_for_jobs] - INFO - JobID 11023 - The nodes_resume list from Slurm Resume File is (x2) ['q5-dy-c5-1-4', 'q5-dy-c5-2-1']
2023-11-14 11:36:34,040 - 48010 - [slurm_plugin.instance_manager:_parse_nodes_resume_list] - INFO - JobID 11023 - Nodes already assigned to running instances: {'q5': {'c5-1': ['q5-dy-c5-1-3'], 'c5-2': ['q5-dy-c5-2-1']}}
2023-11-14 11:36:34,040 - 48010 - [slurm_plugin.instance_manager:_parse_nodes_resume_list] - INFO - JobID 11023 - Discarding NodeName already assigned to running instance: q5-dy-c5-2-1
2023-11-14 11:36:34,040 - 48010 - [slurm_plugin.instance_manager:_resize_slurm_node_list] - INFO - JobID 11023 - Booking already launched instances for nodes (x1) ['q5-dy-c5-1-4']
2023-11-14 11:36:34,041 - 48010 - [slurm_plugin.instance_manager:_add_instances_for_nodes] - INFO - JobID 11023 - Assigning nodes with best-effort strategy
2023-11-14 11:36:34,041 - 48010 - [slurm_plugin.instance_manager:_store_assigned_hostnames] - INFO - JobID 11023 - Saving assigned hostnames in DynamoDB
2023-11-14 11:36:34,046 - 48010 - [slurm_plugin.instance_manager:_update_dns_hostnames] - INFO - JobID 11023 - Updating DNS records for Z07134712BL7RRXVW2BHD - jls-4.pcluster.
2023-11-14 11:36:34,327 - 48010 - [slurm_plugin.instance_manager:_update_slurm_node_addrs] - INFO - JobID 11023 - Nodes are now configured with instances (x1) ["('q5-dy-c5-1-4', EC2Instance(id='i-030c09006acb3b2ce', private_ip='192.168.128.238', hostname='ip-192-168-128-238', launch_time=datetime.datetime(2023, 11, 14, 11, 36, 30, tzinfo=tzlocal()), slurm_node=None))"]
2023-11-14 11:36:34,328 - 48010 - [slurm_plugin.instance_manager:best_effort_node_assignment] - INFO - JobID 11023 - Successful launched and assigned all instances for nodes (x1) ['q5-dy-c5-1-4']
2023-11-14 11:36:34,328 - 48010 - [slurm_plugin.resume:_resume] - INFO - Successfully launched nodes (x2) ['q5-dy-c5-1-3', 'q5-dy-c5-1-4']
2023-11-14 11:36:34,328 - 48010 - [slurm_plugin.resume:_resume] - ERROR - Failed to launch following nodes, setting nodes to DOWN: (x1) ['q5-dy-c5-2-1']
2023-11-14 11:36:34,328 - 48010 - [slurm_plugin.resume:_handle_failed_nodes] - INFO - Setting following failed nodes into DOWN state (x1) ['q5-dy-c5-2-1'] with reason: (Code:InsufficientInstanceCapacity)Failure when resuming nodes
2023-11-14 11:36:34,348 - 48010 - [slurm_plugin.resume:main] - INFO - ResumeProgram finished.
```

to
```
2023-11-14 14:15:29,526 - 13114 - [slurm_plugin.resume:main] - INFO - ResumeProgram startup.
2023-11-14 14:15:29,527 - 13114 - [slurm_plugin.resume:_get_config] - INFO - Reading /etc/parallelcluster/slurm_plugin/parallelcluster_slurm_resume.conf
2023-11-14 14:15:29,528 - 13114 - [slurm_plugin.resume:main] - INFO - ResumeProgram config: SlurmResumeConfig(region='us-east-1', cluster_name='jls-4', dynamodb_table='parallelcluster-slurm-jls-4', hosted_zone='Z07134712BL7RRXVW2BHD', dns_domain='jls-4.pcluster.', use_private_hostname=False, head_node_private_ip='192.168.24.235', head_node_hostname='ip-192-168-24-235.ec2.internal', launch_max_batch_size=500, assign_node_max_batch_size=500, terminate_max_batch_size=1000, update_node_address=True, scaling_strategy='best-effort', job_level_scaling=True, fleet_config={'q1': {'c1': {'CapacityType': 'on-demand', 'Api': 'create-fleet', 'Instances': [{'InstanceType': 'c5.4xlarge'}], 'Networking': {'SubnetIds': ['subnet-01bbe94d5ff9fe2c5']}, 'AllocationStrategy': 'lowest-price'}}, 'q2': {'c2': {'CapacityType': 'on-demand', 'Api': 'run-instances', 'Instances': [{'InstanceType': 'c5.4xlarge'}]}}, 'q5': {'c5-1': {'CapacityType': 'on-demand', 'Api': 'create-fleet', 'Instances': [{'InstanceType': 'c5.4xlarge'}], 'Networking': {'SubnetIds': ['subnet-01bbe94d5ff9fe2c5']}, 'AllocationStrategy': 'lowest-price'}, 'c5-2': {'CapacityType': 'on-demand', 'Api': 'create-fleet', 'Instances': [{'InstanceType': 'p4d.24xlarge'}], 'Networking': {'SubnetIds': ['subnet-01bbe94d5ff9fe2c5']}, 'AllocationStrategy': 'lowest-price'}}}, run_instances_overrides={}, create_fleet_overrides={}, clustermgtd_timeout=300, clustermgtd_heartbeat_file_path='/opt/slurm/etc/pcluster/.slurm_plugin/clustermgtd_heartbeat', _boto3_retry=1, _boto3_config={'retries': {'max_attempts': 1, 'mode': 'standard'}}, boto3_config=<botocore.config.Config object at 0x7f89dfe50ca0>, logging_config='/opt/parallelcluster/pyenv/versions/3.9.17/envs/node_virtualenv/lib/python3.9/site-packages/slurm_plugin/logging/parallelcluster_resume_logging.conf', head_node_instance_id='i-0d107cf004c0f59de')
2023-11-14 14:15:29,528 - 13114 - [slurm_plugin.resume:_get_slurm_resume] - INFO - Slurm Resume File content: {'jobs': [{'extra': None, 'job_id': 11042, 'features': '[(c5.4xlarge)*1&(p4d.24xlarge)*1]', 'nodes_alloc': 'q5-dy-c5-1-1,q5-dy-c5-2-1', 'nodes_resume': 'q5-dy-c5-1-1,q5-dy-c5-2-1', 'oversubscribe': 'OK', 'partition': 'q5', 'reservation': None}, {'extra': None, 'job_id': 11043, 'features': '[(c5.4xlarge)*1&(p4d.24xlarge)*1]', 'nodes_alloc': 'q5-dy-c5-1-2,q5-dy-c5-2-1', 'nodes_resume': 'q5-dy-c5-1-2,q5-dy-c5-2-1', 'oversubscribe': 'OK', 'partition': 'q5', 'reservation': None}], 'all_nodes_resume': 'q5-dy-c5-1-[1-2],q5-dy-c5-2-1'}
2023-11-14 14:15:29,533 - 13114 - [slurm_plugin.common:is_clustermgtd_heartbeat_valid] - INFO - Latest heartbeat from clustermgtd: 2023-11-14 14:15:27.431830+00:00
2023-11-14 14:15:29,533 - 13114 - [slurm_plugin.resume:_resume] - INFO - Launching EC2 instances for the following Slurm nodes: q5-dy-c5-1-[1-2],q5-dy-c5-2-1
2023-11-14 14:15:29,635 - 13114 - [slurm_plugin.resume:_resume] - INFO - Current state of Slurm nodes to resume: [('q5-dy-c5-1-1', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('q5-dy-c5-1-2', 'ALLOCATED+CLOUD+NOT_RESPONDING+POWERING_UP'), ('q5-dy-c5-2-1', 'MIXED+CLOUD+NOT_RESPONDING+POWERING_UP')]
2023-11-14 14:15:29,661 - 13114 - [botocore.credentials:load] - INFO - Found credentials from IAM Role: jls-4-RoleHeadNode-669yRydojc2m
2023-11-14 14:15:29,702 - 13114 - [slurm_plugin.instance_manager:_launch_instances] - INFO - Launching best-effort instances for nodes (x2) ['q5-dy-c5-1-1', 'q5-dy-c5-1-2']
2023-11-14 14:15:29,702 - 13114 - [slurm_plugin.fleet_manager:create_fleet] - INFO - Launching instances with create_fleet API. Parameters: {'LaunchTemplateConfigs': [{'LaunchTemplateSpecification': {'LaunchTemplateName': 'jls-4-q5-c5-1', 'Version': '$Latest'}, 'Overrides': [{'InstanceType': 'c5.4xlarge', 'SubnetId': 'subnet-01bbe94d5ff9fe2c5'}]}], 'TargetCapacitySpecification': {'TotalTargetCapacity': 2, 'DefaultTargetCapacityType': 'on-demand'}, 'Type': 'instant', 'OnDemandOptions': {'SingleInstanceType': True, 'SingleAvailabilityZone': True, 'AllocationStrategy': 'lowest-price', 'MinTargetCapacity': 1, 'CapacityReservationOptions': {'UsageStrategy': 'use-capacity-reservations-first'}}}
2023-11-14 14:15:32,782 - 13114 - [slurm_plugin.fleet_manager:launch_ec2_instances] - INFO - Launched the following instances (x2) ['i-0bbdfabfa93ec7ab6', 'i-0416d9ca3d3074213']
2023-11-14 14:15:32,782 - 13114 - [slurm_plugin.instance_manager:_launch_instances] - INFO - Launching best-effort instances for nodes (x1) ['q5-dy-c5-2-1']
2023-11-14 14:15:32,783 - 13114 - [slurm_plugin.fleet_manager:create_fleet] - INFO - Launching instances with create_fleet API. Parameters: {'LaunchTemplateConfigs': [{'LaunchTemplateSpecification': {'LaunchTemplateName': 'jls-4-q5-c5-2', 'Version': '$Latest'}, 'Overrides': [{'InstanceType': 'p4d.24xlarge', 'SubnetId': 'subnet-01bbe94d5ff9fe2c5'}]}], 'TargetCapacitySpecification': {'TotalTargetCapacity': 1, 'DefaultTargetCapacityType': 'on-demand'}, 'Type': 'instant', 'OnDemandOptions': {'SingleInstanceType': True, 'SingleAvailabilityZone': True, 'AllocationStrategy': 'lowest-price', 'MinTargetCapacity': 1, 'CapacityReservationOptions': {'UsageStrategy': 'use-capacity-reservations-first'}}}
2023-11-14 14:15:33,991 - 13114 - [slurm_plugin.fleet_manager:_launch_instances] - ERROR - Error in CreateFleet request (0ba56b9a-7e43-43e5-ad11-ba5a6f2d2bb1): InsufficientInstanceCapacity - We currently do not have sufficient p4d.24xlarge capacity in the Availability Zone you requested (us-east-1d). Our system will be working on provisioning additional capacity. You can currently get p4d.24xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1a, us-east-1b.
2023-11-14 14:15:34,091 - 13114 - [slurm_plugin.instance_manager:_launch_instances] - ERROR - Encountered exception when launching instances for nodes (x1) ['q5-dy-c5-2-1']: We currently do not have sufficient p4d.24xlarge capacity in the Availability Zone you requested (us-east-1d). Our system will be working on provisioning additional capacity. You can currently get p4d.24xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1a, us-east-1b.
2023-11-14 14:15:34,091 - 13114 - [slurm_plugin.instance_manager:_scaling_for_jobs] - INFO - JobID 11042 - The nodes_resume list from Slurm Resume File is (x2) ['q5-dy-c5-1-1', 'q5-dy-c5-2-1']
2023-11-14 14:15:34,091 - 13114 - [slurm_plugin.instance_manager:_resize_slurm_node_list] - INFO - JobID 11042 - Booking already launched instances for nodes (x1) ['q5-dy-c5-1-1']
2023-11-14 14:15:34,091 - 13114 - [slurm_plugin.instance_manager:_add_instances_for_nodes] - INFO - JobID 11042 - Assigning nodes with best-effort strategy
2023-11-14 14:15:34,091 - 13114 - [slurm_plugin.instance_manager:_store_assigned_hostnames] - INFO - JobID 11042 - Saving assigned hostnames in DynamoDB
2023-11-14 14:15:34,120 - 13114 - [slurm_plugin.instance_manager:_update_dns_hostnames] - INFO - JobID 11042 - Updating DNS records for Z07134712BL7RRXVW2BHD - jls-4.pcluster.
2023-11-14 14:15:34,269 - 13114 - [slurm_plugin.instance_manager:_update_slurm_node_addrs] - INFO - JobID 11042 - Nodes are now configured with instances (x1) ["('q5-dy-c5-1-1', EC2Instance(id='i-0bbdfabfa93ec7ab6', private_ip='192.168.129.62', hostname='ip-192-168-129-62', launch_time=datetime.datetime(2023, 11, 14, 14, 15, 31, tzinfo=tzlocal()), slurm_node=None))"]
2023-11-14 14:15:34,269 - 13114 - [slurm_plugin.instance_manager:best_effort_node_assignment] - INFO - JobID 11042 - Successful launched and assigned partial instances for nodes (x1) ['q5-dy-c5-1-1']
2023-11-14 14:15:34,269 - 13114 - [slurm_plugin.instance_manager:_scaling_for_jobs] - INFO - JobID 11043 - The nodes_resume list from Slurm Resume File is (x2) ['q5-dy-c5-1-2', 'q5-dy-c5-2-1']
2023-11-14 14:15:34,269 - 13114 - [slurm_plugin.instance_manager:_resize_slurm_node_list] - INFO - JobID 11043 - Booking already launched instances for nodes (x1) ['q5-dy-c5-1-2']
2023-11-14 14:15:34,269 - 13114 - [slurm_plugin.instance_manager:_add_instances_for_nodes] - INFO - JobID 11043 - Assigning nodes with best-effort strategy
2023-11-14 14:15:34,269 - 13114 - [slurm_plugin.instance_manager:_store_assigned_hostnames] - INFO - JobID 11043 - Saving assigned hostnames in DynamoDB
2023-11-14 14:15:34,277 - 13114 - [slurm_plugin.instance_manager:_update_dns_hostnames] - INFO - JobID 11043 - Updating DNS records for Z07134712BL7RRXVW2BHD - jls-4.pcluster.
2023-11-14 14:15:34,518 - 13114 - [slurm_plugin.instance_manager:_update_slurm_node_addrs] - INFO - JobID 11043 - Nodes are now configured with instances (x1) ["('q5-dy-c5-1-2', EC2Instance(id='i-0416d9ca3d3074213', private_ip='192.168.134.187', hostname='ip-192-168-134-187', launch_time=datetime.datetime(2023, 11, 14, 14, 15, 31, tzinfo=tzlocal()), slurm_node=None))"]
2023-11-14 14:15:34,518 - 13114 - [slurm_plugin.instance_manager:best_effort_node_assignment] - INFO - JobID 11043 - Successful launched and assigned partial instances for nodes (x1) ['q5-dy-c5-1-2']
2023-11-14 14:15:34,518 - 13114 - [slurm_plugin.resume:_resume] - INFO - Successfully launched nodes (x2) ['q5-dy-c5-1-1', 'q5-dy-c5-1-2']
2023-11-14 14:15:34,518 - 13114 - [slurm_plugin.resume:_resume] - ERROR - Failed to launch following nodes, setting nodes to DOWN: (x1) ['q5-dy-c5-2-1']
2023-11-14 14:15:34,518 - 13114 - [slurm_plugin.resume:_handle_failed_nodes] - INFO - Setting following failed nodes into DOWN state (x1) ['q5-dy-c5-2-1'] with reason: (Code:InsufficientInstanceCapacity)Failure when resuming nodes
2023-11-14 14:15:34,538 - 13114 - [slurm_plugin.resume:main] - INFO - ResumeProgram finished.
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
