### PR TITLE
[develop] Change log level to warning when temporarily partial EC2 info

### DIFF
--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -61,7 +61,7 @@ class EC2Instance:
                 instance_info["LaunchTime"],
             )
         except KeyError as e:
-            logger.error("Unable to retrieve EC2 instance info: %s", e)
+            logger.warning("Unable to retrieve EC2 instance info: %s", e)
             raise e
 
 


### PR DESCRIPTION
### Description of changes
* Change log level to warning when temporarily unable to retrieve EC2 instance info from DescribeInstances call.

The `from_describe_instance_data` logs a warning and throws an exception. The `from_describe_instance_data` is called by
1. `fleet_manager.launch_ec2_instances`, but here the instances info are already populated in the `_launch_instances`, which calls the `_get_instances_info` that does have the retries, by calling `_retrieve_instances_info_from_ec2`
2. `fleet_manager._retrieve_instances_info_from_ec2` that catch the exception

If at the end of the retries there are still instances info with partial data, in the `_launch_instances` these instances are finally logged as error.

### Tests
* n/a

### References
* n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
