### PR TITLE
Change shellcheck severity level to warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
-          severity: error
+          severity: warning

--- a/util/upload-node.sh
+++ b/util/upload-node.sh
@@ -10,7 +10,8 @@ _info() {
 }
 
 _help() {
-    local -- _cmd=$(basename "$0")
+    local -- _cmd
+    _cmd=$(basename "$0")
 
     cat <<EOF
 
@@ -84,11 +85,11 @@ main() {
 
     # Create archive
     _cwd=$(pwd)
-    pushd "${_srcdir}" > /dev/null
+    pushd "${_srcdir}" > /dev/null || exit
     _stashName=$(git stash create)
     git archive --format tar --prefix="aws-parallelcluster-node-${_version}/" "${_stashName:-HEAD}" | gzip > "${_cwd}/aws-parallelcluster-node-${_version}.tgz"
     #tar zcvf "${_cwd}/aws-parallelcluster-node-${_version}.tgz" --transform "s,^aws-parallelcluster-node/,aws-parallelcluster-node-${_version}/," ../aws-parallelcluster-node
-    popd > /dev/null
+    popd > /dev/null || exit
     md5sum aws-parallelcluster-node-${_version}.tgz > aws-parallelcluster-node-${_version}.md5
 
     # upload package


### PR DESCRIPTION
### Description of changes
* Change the shellcheck severity level to warning to discover potential problems earlier
* Fixed the warnings, the warnings are in my fork [here](https://github.com/judysng/aws-parallelcluster-node/actions/runs/7414119739/job/20174519697)
  * [SC2155](https://www.shellcheck.net/wiki/SC2155) - Declare and assign separately to avoid masking return values.
  * [SC2164](https://www.shellcheck.net/wiki/SC2164) - Use 'pushd ... || exit' or 'pushd ... || return' in case pushd fails.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
