### PR TITLE
[develop] Improve Clustermgtd logic to consider all IP(s) on an instance

### DIFF
--- a/src/common/ec2_utils.py
+++ b/src/common/ec2_utils.py
@@ -22,10 +22,11 @@ def get_private_ip_address_and_dns_name(instance_info):
     """
     private_ip = instance_info["PrivateIpAddress"]
     private_dns_name = instance_info["PrivateDnsName"]
+    all_private_ips = [private_ip]
     for network_interface in instance_info["NetworkInterfaces"]:
+        all_private_ips.append(network_interface.get("PrivateIpAddress", private_ip))
         attachment = network_interface["Attachment"]
         if attachment.get("DeviceIndex", -1) == 0 and attachment.get("NetworkCardIndex", -1) == 0:
             private_ip = network_interface.get("PrivateIpAddress", private_ip)
             private_dns_name = network_interface.get("PrivateDnsName", private_dns_name)
-            break
-    return private_ip, private_dns_name
+    return private_ip, private_dns_name, set(all_private_ips)

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1129,10 +1129,12 @@ class ClusterManager:
         if cluster_instances:
             ip_to_slurm_node_map = {node.nodeaddr: node for node in nodes}
             for instance in cluster_instances:
-                if instance.private_ip in ip_to_slurm_node_map:
-                    slurm_node = ip_to_slurm_node_map.get(instance.private_ip)
-                    slurm_node.instance = instance
-                    instance.slurm_node = slurm_node
+                for private_ip in instance.all_private_ips:
+                    if private_ip in ip_to_slurm_node_map:
+                        slurm_node = ip_to_slurm_node_map.get(private_ip)
+                        slurm_node.instance = instance
+                        instance.slurm_node = slurm_node
+                        break
 
     @staticmethod
     def get_instance_id_to_active_node_map(partitions: List[SlurmPartition]) -> Dict:

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -26,11 +26,12 @@ logger = logging.getLogger(__name__)
 
 
 class EC2Instance:
-    def __init__(self, id, private_ip, hostname, launch_time):
+    def __init__(self, id, private_ip, hostname, all_private_ips, launch_time):
         """Initialize slurm node with attributes."""
         self.id = id
         self.private_ip = private_ip
         self.hostname = hostname
+        self.all_private_ips = all_private_ips
         self.launch_time = launch_time
         self.slurm_node = None
 
@@ -53,11 +54,12 @@ class EC2Instance:
     @staticmethod
     def from_describe_instance_data(instance_info):
         try:
-            private_ip, private_dns_name = get_private_ip_address_and_dns_name(instance_info)
+            private_ip, private_dns_name, all_private_ips = get_private_ip_address_and_dns_name(instance_info)
             return EC2Instance(
                 instance_info["InstanceId"],
                 private_ip,
                 private_dns_name.split(".")[0],
+                all_private_ips,
                 instance_info["LaunchTime"],
             )
         except KeyError as e:

--- a/src/slurm_plugin/instance_manager.py
+++ b/src/slurm_plugin/instance_manager.py
@@ -279,12 +279,13 @@ class InstanceManager:
         instances = []
         for instance_info in filtered_iterator:
             try:
-                private_ip, private_dns_name = get_private_ip_address_and_dns_name(instance_info)
+                private_ip, private_dns_name, all_private_ips = get_private_ip_address_and_dns_name(instance_info)
                 instances.append(
                     EC2Instance(
                         instance_info["InstanceId"],
                         private_ip,
                         private_dns_name.split(".")[0],
+                        all_private_ips,
                         instance_info["LaunchTime"],
                     )
                 )

--- a/tests/common/test_ec2_utils.py
+++ b/tests/common/test_ec2_utils.py
@@ -15,7 +15,7 @@ from common.ec2_utils import get_private_ip_address_and_dns_name
 
 
 @pytest.mark.parametrize(
-    "instance_info, expected_private_ip, expected_private_dns_name",
+    "instance_info, expected_private_ip, expected_private_dns_name, expected_all_private_ips",
     [
         (
             {
@@ -36,6 +36,7 @@ from common.ec2_utils import get_private_ip_address_and_dns_name
             },
             "ip.1.0.0.1",
             "ip-1-0-0-1",
+            {"ip.1.0.0.1"},
         ),
         (
             {
@@ -54,6 +55,7 @@ from common.ec2_utils import get_private_ip_address_and_dns_name
             },
             "ip.1.0.0.1",
             "ip-1-0-0-1",
+            {"ip.1.0.0.1"},
         ),
         (
             {
@@ -69,6 +71,7 @@ from common.ec2_utils import get_private_ip_address_and_dns_name
             },
             "ip.1.0.0.1",
             "ip-1-0-0-1",
+            {"ip.1.0.0.1"},
         ),
         (
             {
@@ -97,6 +100,7 @@ from common.ec2_utils import get_private_ip_address_and_dns_name
             },
             "ip.1.0.0.2",
             "ip-1-0-0-2",
+            {"ip.1.0.0.1", "ip.1.0.0.2"},
         ),
         (
             {
@@ -125,10 +129,16 @@ from common.ec2_utils import get_private_ip_address_and_dns_name
             },
             "ip.1.0.0.1",
             "ip-1-0-0-1",
+            {"ip.1.0.0.1", "ip.1.0.0.2"},
         ),
     ],
 )
-def test_get_private_ip_address_and_dns_name(mocker, instance_info, expected_private_ip, expected_private_dns_name):
-    actual_private_ip, actual_private_dns_name = get_private_ip_address_and_dns_name(instance_info)
+def test_get_private_ip_address_and_dns_name(
+    mocker, instance_info, expected_private_ip, expected_private_dns_name, expected_all_private_ips
+):
+    actual_private_ip, actual_private_dns_name, actual_all_private_ips = get_private_ip_address_and_dns_name(
+        instance_info
+    )
     assert_that(actual_private_ip).is_equal_to(expected_private_ip)
     assert_that(actual_private_dns_name).is_equal_to(expected_private_dns_name)
+    assert_that(actual_all_private_ips).is_equal_to(expected_all_private_ips)

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -732,7 +732,7 @@ def test_slurm_node_is_state_healthy(
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             True,
             True,
             "Node bootstrap error: Replacement timeout expires for node queue1-st-c5xlarge-1(ip-1) in replacement",
@@ -750,7 +750,7 @@ def test_slurm_node_is_state_healthy(
         ),
         (
             DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             False,
             False,
             "Node bootstrap error: Resume timeout expires",
@@ -779,7 +779,7 @@ def test_slurm_node_is_state_healthy(
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             False,
             False,
             None,
@@ -790,7 +790,7 @@ def test_slurm_node_is_state_healthy(
             DynamicNode(
                 "queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-1", "hostname", "DOWN+CLOUD+POWERED_DOWN", "queue1"
             ),
-            EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             False,
             False,
             None,
@@ -799,7 +799,7 @@ def test_slurm_node_is_state_healthy(
         ),
         (
             DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DRAIN+CLOUD", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             False,
             False,
             None,
@@ -808,7 +808,7 @@ def test_slurm_node_is_state_healthy(
         ),
         (
             DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWERING_DOWN", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             False,
             False,
             None,
@@ -817,7 +817,7 @@ def test_slurm_node_is_state_healthy(
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWERING_DOWN", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             True,
             False,
             "failed during bootstrap when performing health check",
@@ -826,7 +826,7 @@ def test_slurm_node_is_state_healthy(
         ),
         (
             DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             False,
             False,
             "failed during bootstrap when performing health check",
@@ -841,7 +841,7 @@ def test_slurm_node_is_state_healthy(
                 "DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING",
                 "queue1",
             ),
-            EC2Instance("id-1", "ip-1", "hostname", "launch_time"),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             False,
             False,
             None,
@@ -937,12 +937,12 @@ def test_slurm_node_is_bootstrap_failure(
     [
         (
             DynamicNode("queue-dy-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD", "queue"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             True,
         ),
         (
             StaticNode("queue-st-c5xlarge-1", "queue-st-c5xlarge-1", "hostname", "IDLE+CLOUD", "queue"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             False,
         ),
         (
@@ -963,7 +963,7 @@ def test_slurm_node_is_bootstrap_failure(
         # Powering_down nodes with backing instance is considered as healthy
         (
             DynamicNode("queue-dy-c5xlarge-1", "ip-2", "hostname", "DOWN+CLOUD+POWERING_DOWN", "queue"),
-            EC2Instance("id-2", "ip-2", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-2", "ip-2", "hostname", {"ip-2"}, datetime(2020, 1, 1, 0, 0, 0)),
             True,
         ),
         # Powering_down nodes without backing instance is considered as unhealthy
@@ -1105,7 +1105,7 @@ def test_slurm_node_is_powering_down_with_nodeaddr(node, expected_result):
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD+POWER", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             True,
         ),
     ],

--- a/tests/slurm_plugin/test_cluster_event_publisher.py
+++ b/tests/slurm_plugin/test_cluster_event_publisher.py
@@ -939,7 +939,9 @@ def test_publish_unhealthy_static_node_events(test_nodes, expected_details, leve
         event_publisher = ClusterEventPublisher(event_handler(received_events, level_filter=level_filter))
 
     instances = [
-        EC2Instance(f"i-id-{instance_id}", f"1.2.3.{instance_id}", f"host-{instance_id}", "sometime")
+        EC2Instance(
+            f"i-id-{instance_id}", f"1.2.3.{instance_id}", f"host-{instance_id}", {f"1.2.3.{instance_id}"}, "sometime"
+        )
         for instance_id in range(len(test_nodes))
     ]
 
@@ -1663,7 +1665,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue1",
                     "(Code:InsufficientReservedInstanceCapacity)Failure when resuming nodes",
                     instance=EC2Instance(
-                        id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                        id="id-1",
+                        private_ip="ip-1",
+                        hostname="hostname",
+                        launch_time="some_launch_time",
+                        all_private_ips={"ip-1"},
                     ),
                 ),
                 DynamicNode(
@@ -1693,7 +1699,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:UnauthorizedOperation)Error",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1756,7 +1766,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "IDLE+CLOUD+POWERING_DOWN",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                        id="id-1",
+                        private_ip="ip-1",
+                        hostname="hostname",
+                        all_private_ips={"ip-1"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1766,7 +1780,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "IDLE+CLOUD",
                     "queue",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -1776,7 +1794,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1786,7 +1808,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "DOWN",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-3", private_ip="ip-3", hostname="hostname", launch_time="some_launch_time"
+                        id="id-3",
+                        private_ip="ip-3",
+                        hostname="hostname",
+                        all_private_ips={"ip-3"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -1800,7 +1826,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=24, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-4", private_ip="ip-4", hostname="hostname", launch_time="some_launch_time"
+                        id="id-4",
+                        private_ip="ip-4",
+                        hostname="hostname",
+                        all_private_ips={"ip-4"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -1811,7 +1841,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:InsufficientHostCapacity)Failure when resuming nodes",
                     instance=EC2Instance(
-                        id="id-5", private_ip="ip-5", hostname="hostname", launch_time="some_launch_time"
+                        id="id-5",
+                        private_ip="ip-5",
+                        hostname="hostname",
+                        all_private_ips={"ip-5"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -1825,7 +1859,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=12, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-6", private_ip="ip-6", hostname="hostname", launch_time="some_launch_time"
+                        id="id-6",
+                        private_ip="ip-6",
+                        hostname="hostname",
+                        all_private_ips={"ip-6"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1839,7 +1877,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=23, second=10, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-7", private_ip="ip-7", hostname="hostname", launch_time="some_launch_time"
+                        id="id-7",
+                        private_ip="ip-7",
+                        hostname="hostname",
+                        all_private_ips={"ip-7"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1853,7 +1895,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=21, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-8", private_ip="ip-8", hostname="hostname", launch_time="some_launch_time"
+                        id="id-8",
+                        private_ip="ip-8",
+                        hostname="hostname",
+                        all_private_ips={"ip-8"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -1864,7 +1910,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:AccessDeniedException)Error",
                     instance=EC2Instance(
-                        id="id-9", private_ip="ip-9", hostname="hostname", launch_time="some_launch_time"
+                        id="id-9",
+                        private_ip="ip-9",
+                        hostname="hostname",
+                        all_private_ips={"ip-9"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1878,7 +1928,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=25, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-10", private_ip="ip-10", hostname="hostname", launch_time="some_launch_time"
+                        id="id-10",
+                        private_ip="ip-10",
+                        hostname="hostname",
+                        all_private_ips={"ip-10"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1889,7 +1943,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:VolumeLimitExceeded)Error",
                     instance=EC2Instance(
-                        id="id-11", private_ip="ip-11", hostname="hostname", launch_time="some_launch_time"
+                        id="id-11",
+                        private_ip="ip-11",
+                        hostname="hostname",
+                        all_private_ips={"ip-11"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -1903,7 +1961,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=11, hour=11, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-12", private_ip="ip-12", hostname="hostname", launch_time="some_launch_time"
+                        id="id-12",
+                        private_ip="ip-12",
+                        hostname="hostname",
+                        all_private_ips={"ip-12"},
+                        launch_time="some_launch_time",
                     ),
                 ),
             ],
@@ -1977,7 +2039,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "IDLE+CLOUD+POWERING_DOWN",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                        id="id-1",
+                        private_ip="ip-1",
+                        hostname="hostname",
+                        all_private_ips={"ip-1"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -1987,7 +2053,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "IDLE+CLOUD",
                     "queue",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -1997,7 +2067,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2007,7 +2081,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "DOWN",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-3", private_ip="ip-3", hostname="hostname", launch_time="some_launch_time"
+                        id="id-3",
+                        private_ip="ip-3",
+                        hostname="hostname",
+                        all_private_ips={"ip-3"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2021,7 +2099,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=24, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-4", private_ip="ip-4", hostname="hostname", launch_time="some_launch_time"
+                        id="id-4",
+                        private_ip="ip-4",
+                        hostname="hostname",
+                        all_private_ips={"ip-4"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2032,7 +2114,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:InsufficientHostCapacity)Failure when resuming nodes",
                     instance=EC2Instance(
-                        id="id-5", private_ip="ip-5", hostname="hostname", launch_time="some_launch_time"
+                        id="id-5",
+                        private_ip="ip-5",
+                        hostname="hostname",
+                        all_private_ips={"ip-5"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2046,7 +2132,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=12, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-6", private_ip="ip-6", hostname="hostname", launch_time="some_launch_time"
+                        id="id-6",
+                        private_ip="ip-6",
+                        hostname="hostname",
+                        all_private_ips={"ip-6"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2060,7 +2150,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=23, second=10, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-7", private_ip="ip-7", hostname="hostname", launch_time="some_launch_time"
+                        id="id-7",
+                        private_ip="ip-7",
+                        hostname="hostname",
+                        all_private_ips={"ip-7"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2074,7 +2168,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=21, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-8", private_ip="ip-8", hostname="hostname", launch_time="some_launch_time"
+                        id="id-8",
+                        private_ip="ip-8",
+                        hostname="hostname",
+                        all_private_ips={"ip-8"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2085,7 +2183,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:AccessDeniedException)Error",
                     instance=EC2Instance(
-                        id="id-9", private_ip="ip-9", hostname="hostname", launch_time="some_launch_time"
+                        id="id-9",
+                        private_ip="ip-9",
+                        hostname="hostname",
+                        all_private_ips={"ip-9"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2099,7 +2201,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=25, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-10", private_ip="ip-10", hostname="hostname", launch_time="some_launch_time"
+                        id="id-10",
+                        private_ip="ip-10",
+                        hostname="hostname",
+                        all_private_ips={"ip-10"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2110,7 +2216,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:VolumeLimitExceeded)Error",
                     instance=EC2Instance(
-                        id="id-11", private_ip="ip-11", hostname="hostname", launch_time="some_launch_time"
+                        id="id-11",
+                        private_ip="ip-11",
+                        hostname="hostname",
+                        all_private_ips={"ip-11"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2124,7 +2234,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=11, hour=11, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-12", private_ip="ip-12", hostname="hostname", launch_time="some_launch_time"
+                        id="id-12",
+                        private_ip="ip-12",
+                        hostname="hostname",
+                        all_private_ips={"ip-12"},
+                        launch_time="some_launch_time",
                     ),
                 ),
             ],
@@ -2506,7 +2620,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2516,7 +2634,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "DOWN",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-3", private_ip="ip-3", hostname="hostname", launch_time="some_launch_time"
+                        id="id-3",
+                        private_ip="ip-3",
+                        hostname="hostname",
+                        all_private_ips={"ip-3"},
+                        launch_time="some_launch_time",
                     ),
                 ),
             ],
@@ -2599,7 +2721,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "IDLE+CLOUD+POWERING_DOWN",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                        id="id-1",
+                        private_ip="ip-1",
+                        hostname="hostname",
+                        all_private_ips={"ip-1"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2609,7 +2735,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "IDLE+CLOUD",
                     "queue",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2619,7 +2749,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "MIXED+CLOUD+NOT_RESPONDING+POWERING_UP",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                        id="id-2",
+                        private_ip="ip-2",
+                        hostname="hostname",
+                        all_private_ips={"ip-2"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2629,7 +2763,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "DOWN",
                     "queue1",
                     instance=EC2Instance(
-                        id="id-3", private_ip="ip-3", hostname="hostname", launch_time="some_launch_time"
+                        id="id-3",
+                        private_ip="ip-3",
+                        hostname="hostname",
+                        all_private_ips={"ip-3"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2643,7 +2781,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=24, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-4", private_ip="ip-4", hostname="hostname", launch_time="some_launch_time"
+                        id="id-4",
+                        private_ip="ip-4",
+                        hostname="hostname",
+                        all_private_ips={"ip-4"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2654,7 +2796,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:InsufficientHostCapacity)Failure when resuming nodes",
                     instance=EC2Instance(
-                        id="id-5", private_ip="ip-5", hostname="hostname", launch_time="some_launch_time"
+                        id="id-5",
+                        private_ip="ip-5",
+                        hostname="hostname",
+                        all_private_ips={"ip-5"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2668,7 +2814,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=12, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-6", private_ip="ip-6", hostname="hostname", launch_time="some_launch_time"
+                        id="id-6",
+                        private_ip="ip-6",
+                        hostname="hostname",
+                        all_private_ips={"ip-6"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2682,7 +2832,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=23, second=10, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-7", private_ip="ip-7", hostname="hostname", launch_time="some_launch_time"
+                        id="id-7",
+                        private_ip="ip-7",
+                        hostname="hostname",
+                        all_private_ips={"ip-7"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2696,7 +2850,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=21, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-8", private_ip="ip-8", hostname="hostname", launch_time="some_launch_time"
+                        id="id-8",
+                        private_ip="ip-8",
+                        hostname="hostname",
+                        all_private_ips={"ip-8"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2707,7 +2865,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:AccessDeniedException)Error",
                     instance=EC2Instance(
-                        id="id-9", private_ip="ip-9", hostname="hostname", launch_time="some_launch_time"
+                        id="id-9",
+                        private_ip="ip-9",
+                        hostname="hostname",
+                        all_private_ips={"ip-9"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2721,7 +2883,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=10, hour=11, minute=25, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-10", private_ip="ip-10", hostname="hostname", launch_time="some_launch_time"
+                        id="id-10",
+                        private_ip="ip-10",
+                        hostname="hostname",
+                        all_private_ips={"ip-10"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 StaticNode(
@@ -2732,7 +2898,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                     "queue2",
                     "(Code:VolumeLimitExceeded)Error",
                     instance=EC2Instance(
-                        id="id-11", private_ip="ip-11", hostname="hostname", launch_time="some_launch_time"
+                        id="id-11",
+                        private_ip="ip-11",
+                        hostname="hostname",
+                        all_private_ips={"ip-11"},
+                        launch_time="some_launch_time",
                     ),
                 ),
                 DynamicNode(
@@ -2746,7 +2916,11 @@ def test_publish_node_launch_events(failed_nodes, expected_details, level_filter
                         year=2023, month=3, day=11, hour=11, minute=23, second=14, tzinfo=timezone.utc
                     ),
                     instance=EC2Instance(
-                        id="id-12", private_ip="ip-12", hostname="hostname", launch_time="some_launch_time"
+                        id="id-12",
+                        private_ip="ip-12",
+                        hostname="hostname",
+                        all_private_ips={"ip-12"},
+                        launch_time="some_launch_time",
                     ),
                 ),
             ],

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -295,10 +295,10 @@ def test_exception_from_report_console_output_from_nodes(mocker):
     [
         (
             [
-                EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "some_launch_time"),
                 None,
                 None,
-                EC2Instance("id-3", "ip-3", "hostname", "some_launch_time"),
+                EC2Instance("id-3", "ip-3", "hostname", {"ip-3"}, "some_launch_time"),
                 None,
                 None,
                 None,
@@ -335,14 +335,14 @@ def test_exception_from_report_console_output_from_nodes(mocker):
             None,
         ),
         (
-            [EC2Instance("id-3", "ip-3", "hostname", "some_launch_time")],
+            [EC2Instance("id-3", "ip-3", "hostname", {"ip-3"}, "some_launch_time")],
             [StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname", "some_state", "queue1")],
             None,
             Exception,
             None,
         ),
         (
-            [EC2Instance("id-3", "ip-3", "hostname", "some_launch_time")],
+            [EC2Instance("id-3", "ip-3", "hostname", {"ip-3"}, "some_launch_time")],
             [StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname", "some_state", "queue1")],
             {"queue1-st-c5xlarge-3"},
             None,
@@ -450,7 +450,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                                id="id-1",
+                                private_ip="ip-1",
+                                hostname="hostname",
+                                all_private_ips={"ip-1"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                         "id-2": StaticNode(
@@ -460,7 +464,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                                id="id-2",
+                                private_ip="ip-2",
+                                hostname="hostname",
+                                all_private_ips={"ip-2"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                     },
@@ -476,7 +484,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                                id="id-1",
+                                private_ip="ip-1",
+                                hostname="hostname",
+                                all_private_ips={"ip-1"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                         "id-2": StaticNode(
@@ -486,7 +498,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                                id="id-2",
+                                private_ip="ip-2",
+                                hostname="hostname",
+                                all_private_ips={"ip-2"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                     },
@@ -509,7 +525,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                                id="id-1",
+                                private_ip="ip-1",
+                                hostname="hostname",
+                                all_private_ips={"ip-1"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                         "id-2": StaticNode(
@@ -519,7 +539,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                                id="id-2",
+                                private_ip="ip-2",
+                                hostname="hostname",
+                                all_private_ips={"ip-2"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                     },
@@ -543,7 +567,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-1", private_ip="ip-1", hostname="hostname", launch_time="some_launch_time"
+                                id="id-1",
+                                private_ip="ip-1",
+                                hostname="hostname",
+                                all_private_ips={"ip-1"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                         "id-2": StaticNode(
@@ -553,7 +581,11 @@ def test_get_ec2_instances(mocker):
                             state="some_state",
                             partitions="queue1",
                             instance=EC2Instance(
-                                id="id-2", private_ip="ip-2", hostname="hostname", launch_time="some_launch_time"
+                                id="id-2",
+                                private_ip="ip-2",
+                                hostname="hostname",
+                                all_private_ips={"ip-2"},
+                                launch_time="some_launch_time",
                             ),
                         ),
                     },
@@ -584,8 +616,8 @@ def test_perform_health_check_actions(
         StaticNode("queue1-st-c5xlarge-5", "ip-2", "queue1-st-c5xlarge-5", "some_state", "queue1"),
     ]
     instances = [
-        EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"),
-        EC2Instance("id-2", "ip-2", "hostname", "some_launch_time"),
+        EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "some_launch_time"),
+        EC2Instance("id-2", "ip-2", "hostname", {"ip-2"}, "some_launch_time"),
     ]
     for node, instance in zip(slurm_nodes, instances):
         node.instance = instance
@@ -828,7 +860,7 @@ def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes
                     "queue1",
                 ),
             ],
-            [EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"), None],
+            [EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "some_launch_time"), None],
             ["id-1"],
             ["queue1-dy-c5xlarge-1", "queue1-dy-c5xlarge-2"],
             True,
@@ -876,7 +908,7 @@ def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes
                     "(Code:MaxSpotInstanceCountExceeded)Failure when resuming nodes [root@2023-01-31T21:24:55]",
                 ),
             ],
-            [EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"), None, None, None, None],
+            [EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "some_launch_time"), None, None, None, None],
             ["id-1"],
             [
                 "queue1-dy-c5xlarge-1",
@@ -938,15 +970,15 @@ def test_handle_unhealthy_dynamic_nodes(
                 StaticNode("queue1-st-c5xlarge-9", "ip-9", "hostname", "IDLE+CLOUD+POWERING_DOWN", "queue1"),
             ],
             [
-                EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "some_launch_time"),
                 None,
-                EC2Instance("id-3", "ip-3", "hostname", "some_launch_time"),
+                EC2Instance("id-3", "ip-3", "hostname", {"ip-3"}, "some_launch_time"),
                 None,
                 None,
-                EC2Instance("id-7", "ip-7", "hostname", "some_launch_time"),
-                EC2Instance("id-6", "ip-6", "hostname", "some_launch_time"),
-                EC2Instance("id-8", "ip-8", "hostname", "some_launch_time"),
-                EC2Instance("id-9", "ip-9", "hostname", "some_launch_time"),
+                EC2Instance("id-7", "ip-7", "hostname", {"ip-7"}, "some_launch_time"),
+                EC2Instance("id-6", "ip-6", "hostname", {"ip-6"}, "some_launch_time"),
+                EC2Instance("id-8", "ip-8", "hostname", {"ip-8"}, "some_launch_time"),
+                EC2Instance("id-9", "ip-9", "hostname", {"ip-9"}, "some_launch_time"),
             ],
             ["id-3", "id-6", "id-9"],
             ["queue1-dy-c5xlarge-2", "queue1-dy-c5xlarge-3", "queue1-st-c5xlarge-6", "queue1-st-c5xlarge-9"],
@@ -1002,14 +1034,14 @@ def test_handle_powering_down_nodes(
                 StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname", "IDLE+CLOUD", "queue1"),
             ],
             [
-                EC2Instance("id-1", "ip-1", "hostname", "some_launch_time"),
-                EC2Instance("id-2", "ip-2", "hostname", "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "some_launch_time"),
+                EC2Instance("id-2", "ip-2", "hostname", {"ip-2"}, "some_launch_time"),
                 None,
             ],
             [
-                EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
-                EC2Instance("id-3", "ip-3", "hostname-3", "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time"),
+                EC2Instance("id-2", "ip-2", "hostname-2", {"ip-2"}, "some_launch_time"),
+                EC2Instance("id-3", "ip-3", "hostname-3", {"ip-3"}, "some_launch_time"),
             ],
             {
                 "current-queue1-st-c5xlarge-6",
@@ -1033,9 +1065,9 @@ def test_handle_powering_down_nodes(
             ],
             [None, None, None],
             [
-                EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
-                EC2Instance("id-3", "ip-3", "hostname-3", "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time"),
+                EC2Instance("id-2", "ip-2", "hostname-2", {"ip-2"}, "some_launch_time"),
+                EC2Instance("id-3", "ip-3", "hostname-3", {"ip-3"}, "some_launch_time"),
             ],
             {
                 "current-queue1-st-c5xlarge-6",
@@ -1059,8 +1091,8 @@ def test_handle_powering_down_nodes(
             ],
             [None, None],
             [
-                EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time"),
+                EC2Instance("id-2", "ip-2", "hostname-2", {"ip-2"}, "some_launch_time"),
             ],
             {"current-queue1-st-c5xlarge-6", "queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"},
             [],
@@ -1086,8 +1118,8 @@ def test_handle_powering_down_nodes(
             ],
             [None, None],
             [
-                EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time"),
+                EC2Instance("id-2", "ip-2", "hostname-2", {"ip-2"}, "some_launch_time"),
             ],
             {"current-queue1-st-c5xlarge-6", "queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"},
             [],
@@ -1254,14 +1286,14 @@ def test_handle_unhealthy_static_nodes(
                 ),  # ice dynamic node does not belong to unhealthy node when enable fast capacity failover
             ],
             [
-                EC2Instance("id-2", "ip-2", "hostname", "some_launch_time"),
+                EC2Instance("id-2", "ip-2", {"ip-2"}, "hostname", "some_launch_time"),
                 # Setting launch time here for instance for static node to trigger replacement timeout
-                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-1", "ip-1", {"ip-1"}, "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-2", "ip-4", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-4", {"ip-4"}, "hostname", datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-5", "ip-5", "hostname", "some_launch_time"),
-                EC2Instance("id-6", "ip-6", "hostname", "some_launch_time"),
+                EC2Instance("id-5", "ip-5", {"ip-5"}, "hostname", "some_launch_time"),
+                EC2Instance("id-6", "ip-6", {"ip-6"}, "hostname", "some_launch_time"),
                 None,
             ],
             True,
@@ -1307,14 +1339,14 @@ def test_handle_unhealthy_static_nodes(
                 DynamicNode("queue3-dy-c5xlarge-1", "ip-6", "hostname", "IDLE+CLOUD", "queue1"),  # healthy dynamic
             ],
             [
-                EC2Instance("id-2", "ip-2", "hostname", "some_launch_time"),
+                EC2Instance("id-2", "ip-2", "hostname", {"ip-2"}, "some_launch_time"),
                 # Setting launch time here for instance for static node to trigger replacement timeout
-                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-2", "ip-4", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-4", "hostname", {"ip-4"}, datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-5", "ip-5", "hostname", "some_launch_time"),
-                EC2Instance("id-6", "ip-6", "hostname", "some_launch_time"),
+                EC2Instance("id-5", "ip-5", "hostname", {"ip-5"}, "some_launch_time"),
+                EC2Instance("id-6", "ip-6", "hostname", {"ip-6"}, "some_launch_time"),
             ],
             True,
             False,
@@ -1401,8 +1433,8 @@ def test_maintain_nodes(
     [
         (
             [
-                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-                EC2Instance("id-2", "ip-2", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-2", "hostname", {"ip-2"}, datetime(2020, 1, 1, 0, 0, 0)),
             ],
             [
                 DynamicNode("queue1-st-c5xlarge-1", "ip", "hostname", "some_state", "queue1"),
@@ -1413,8 +1445,8 @@ def test_maintain_nodes(
         ),
         (
             [
-                EC2Instance("id-3", "ip-3", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-                EC2Instance("id-2", "ip-2", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-3", "ip-3", "hostname", {"ip-3"}, datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-2", "hostname", {"ip-2"}, datetime(2020, 1, 1, 0, 0, 0)),
             ],
             [None, None],
             datetime(2020, 1, 1, 0, 0, 30),
@@ -1422,8 +1454,8 @@ def test_maintain_nodes(
         ),
         (
             [
-                EC2Instance("id-3", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
-                EC2Instance("id-2", "ip-2", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-3", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-2", "ip-2", "hostname", {"ip-2"}, datetime(2020, 1, 1, 0, 0, 0)),
             ],
             [None, None],
             datetime(2020, 1, 1, 0, 0, 29),
@@ -1481,8 +1513,8 @@ def test_terminate_orphaned_instances(
             False,
             False,
             [
-                EC2Instance("id-1", "ip", "hostname", "launch_time"),
-                EC2Instance("id-2", "ip", "hostname", "launch_time"),
+                EC2Instance("id-1", "ip", "hostname", {"ip"}, "launch_time"),
+                EC2Instance("id-2", "ip", "hostname", {"ip"}, "launch_time"),
             ],
             [
                 StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "some_state", "queue1"),
@@ -1504,7 +1536,7 @@ def test_terminate_orphaned_instances(
         (
             True,
             False,
-            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time")],
             [
                 StaticNode("queue1-st-c5xlarge-1", "ip", "hostname", "some_state", "queue1"),
                 DynamicNode("queue1-dy-c5xlarge-2", "ip", "hostname", "some_state", "queue1"),
@@ -1518,7 +1550,7 @@ def test_terminate_orphaned_instances(
         (
             False,
             True,
-            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time")],
             [
                 StaticNode("queue1-st-c5xlarge-1", "ip", "hostname", "some_state", "queue1"),
                 DynamicNode("queue1-dy-c5xlarge-2", "ip", "hostname", "some_state", "queue1"),
@@ -1539,7 +1571,7 @@ def test_terminate_orphaned_instances(
         (
             False,
             True,
-            [EC2Instance("id-1", "ip-1", "hostname", "launch_time")],
+            [EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time")],
             [],
             {"queue1": SlurmPartition("queue1", "placeholder_nodes", "UP")},
             ComputeFleetStatus.RUNNING,
@@ -2616,7 +2648,7 @@ def initialize_console_logger_mock(mocker):
         (
             set(),
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             datetime(2020, 1, 1, 0, 0, 29),
             False,
         ),
@@ -2630,14 +2662,14 @@ def initialize_console_logger_mock(mocker):
         (
             {"queue1-st-c5xlarge-1"},
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             datetime(2020, 1, 1, 0, 0, 29),
             True,
         ),
         (
             {"queue1-st-c5xlarge-1"},
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "IDLE+CLOUD", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             datetime(2020, 1, 1, 0, 0, 30),
             False,
         ),
@@ -2675,7 +2707,7 @@ def test_is_node_being_replaced(current_replacing_nodes, node, instance, current
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             {"queue1-st-c5xlarge-1"},
             True,
         ),
@@ -2693,13 +2725,13 @@ def test_is_node_being_replaced(current_replacing_nodes, node, instance, current
                 "DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING",
                 "queue1",
             ),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             {"some_node_in_replacement"},
             False,
         ),
         (
             StaticNode("queue1-st-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+NOT_RESPONDING", "queue1"),
-            EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+            EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
             {"some_node_in_replacement"},
             False,
         ),
@@ -2825,13 +2857,13 @@ def test_handle_failed_health_check_nodes_in_replacement(
                 ),  # fail health check
             ],
             [
-                EC2Instance("id-3", "ip-3", "hostname", "some_launch_time"),
-                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-3", "ip-3", "hostname", {"ip-3"}, "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-5", "ip-5", "hostname", "some_launch_time"),
-                EC2Instance("id-6", "ip-6", "hostname", "some_launch_time"),
+                EC2Instance("id-5", "ip-5", "hostname", {"ip-5"}, "some_launch_time"),
+                EC2Instance("id-6", "ip-6", "hostname", {"ip-6"}, "some_launch_time"),
             ],
         ),
     ],
@@ -2895,13 +2927,13 @@ def test_handle_bootstrap_failure_nodes(
                 DynamicNode("queue3-dy-c5xlarge-1", "ip-6", "hostname", "IDLE+CLOUD", "queue1"),  # healthy dynamic
             ],
             [
-                EC2Instance("id-3", "ip-3", "hostname", "some_launch_time"),
-                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-3", "ip-3", "hostname", {"ip-3"}, "some_launch_time"),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-1", "ip-1", "hostname", datetime(2020, 1, 1, 0, 0, 0)),
+                EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, 0, 0, 0)),
                 None,
-                EC2Instance("id-5", "ip-5", "hostname", "some_launch_time"),
-                EC2Instance("id-6", "ip-6", "hostname", "some_launch_time"),
+                EC2Instance("id-5", "ip-5", "hostname", {"ip-5"}, "some_launch_time"),
+                EC2Instance("id-6", "ip-6", "hostname", {"ip-6"}, "some_launch_time"),
             ],
         ),
     ],
@@ -3595,7 +3627,7 @@ def test_set_ice_compute_resources_to_down(
                     "hostname",
                     "IDLE",
                     "queue2",
-                    instance=EC2Instance("id-5", "ip-5", "hostname", "some_launch_time"),
+                    instance=EC2Instance("id-5", "ip-5", "hostname", {"ip-5"}, "some_launch_time"),
                 ),  # healthy static
                 DynamicNode(
                     "queue3-dy-c5xlarge-1",
@@ -3603,7 +3635,7 @@ def test_set_ice_compute_resources_to_down(
                     "hostname",
                     "IDLE+CLOUD",
                     "queue1",
-                    instance=EC2Instance("id-6", "ip-6", "hostname", "some_launch_time"),
+                    instance=EC2Instance("id-6", "ip-6", "hostname", {"ip-6"}, "some_launch_time"),
                 ),  # healthy dynamic
                 DynamicNode("queue1-dy-c4xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
                 DynamicNode(
@@ -3709,7 +3741,7 @@ def test_set_ice_compute_resources_to_down(
                     "hostname",
                     "IDLE",
                     "queue2",
-                    instance=EC2Instance("id-5", "ip-5", "hostname", "some_launch_time"),
+                    instance=EC2Instance("id-5", "ip-5", "hostname", {"ip-5"}, "some_launch_time"),
                 ),  # healthy static
                 DynamicNode(
                     "queue3-dy-c5xlarge-1",
@@ -3717,7 +3749,7 @@ def test_set_ice_compute_resources_to_down(
                     "hostname",
                     "IDLE+CLOUD",
                     "queue1",
-                    instance=EC2Instance("id-6", "ip-6", "hostname", "some_launch_time"),
+                    instance=EC2Instance("id-6", "ip-6", "hostname", {"ip-6"}, "some_launch_time"),
                 ),  # healthy dynamic
                 DynamicNode("queue1-dy-c4xlarge-1", "ip-1", "hostname", "DOWN", "queue1"),
                 DynamicNode(

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -95,7 +95,7 @@ class TestInstanceManager:
             (
                 [
                     [
-                        EC2Instance("i-2", "ip-2", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                        EC2Instance("i-2", "ip-2", "hostname", {"ip-2"}, datetime(2020, 1, 1, tzinfo=timezone.utc)),
                     ],
                 ],
                 10,
@@ -181,7 +181,7 @@ class TestInstanceManager:
             (
                 None,
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 None,
                 "Empty table name configuration parameter",
                 False,
@@ -197,7 +197,7 @@ class TestInstanceManager:
             (
                 "table_name",
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 [
                     call(
                         Item={
@@ -215,8 +215,8 @@ class TestInstanceManager:
                 "table_name",
                 ["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"],
                 [
-                    EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                    EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                    EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time"),
+                    EC2Instance("id-2", "ip-2", "hostname-2", {"ip-2"}, "some_launch_time"),
                 ],
                 [
                     call(
@@ -286,7 +286,7 @@ class TestInstanceManager:
                 None,
                 "dns.domain",
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 None,
                 "Empty table name configuration parameter",
                 False,
@@ -307,7 +307,7 @@ class TestInstanceManager:
                 "hosted_zone",
                 "dns.domain",
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 MockedBoto3Request(
                     method="change_resource_record_sets",
                     response={
@@ -343,8 +343,8 @@ class TestInstanceManager:
                 "dns.domain",
                 ["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"],
                 [
-                    EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                    EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                    EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time"),
+                    EC2Instance("id-2", "ip-2", "hostname-2", {"ip-2"}, "some_launch_time"),
                 ],
                 [
                     MockedBoto3Request(
@@ -391,7 +391,7 @@ class TestInstanceManager:
                 "hosted_zone",
                 "dns.domain",
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 MockedBoto3Request(
                     method="change_resource_record_sets",
                     response={},
@@ -803,8 +803,8 @@ class TestInstanceManager:
                     generate_error=False,
                 ),
                 [
-                    EC2Instance("i-1", "ip-1", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
-                    EC2Instance("i-2", "ip-2", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                    EC2Instance("i-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                    EC2Instance("i-2", "ip-2", "hostname", {"ip-2"}, datetime(2020, 1, 1, tzinfo=timezone.utc)),
                 ],
                 False,
                 id="default",
@@ -861,7 +861,7 @@ class TestInstanceManager:
                     },
                     generate_error=False,
                 ),
-                [EC2Instance("i-1", "ip-1", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc))],
+                [EC2Instance("i-1", "ip-1", "hostname", {"ip-1"}, datetime(2020, 1, 1, tzinfo=timezone.utc))],
                 False,
                 id="custom_args",
             ),
@@ -907,7 +907,7 @@ class TestInstanceManager:
                     generate_error=False,
                 ),
                 [
-                    EC2Instance("i-2", "ip-2", "hostname", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                    EC2Instance("i-2", "ip-2", "hostname", {"ip-2"}, datetime(2020, 1, 1, tzinfo=timezone.utc)),
                 ],
                 False,
                 id="no_ec2_info",
@@ -967,7 +967,7 @@ class TestInstanceManager:
                         "hostname-1",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", "12:45am"),
+                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", {"1.2.3.1"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-2",
@@ -975,7 +975,7 @@ class TestInstanceManager:
                         "hostname-2",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", "12:45am"),
+                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", {"1.2.3.2"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname-3", "some_state", "queue1"),
                     StaticNode("queue1-st-c5xlarge-4", "ip-4", "hostname-4", "some_state", "queue1"),
@@ -985,7 +985,7 @@ class TestInstanceManager:
                         "hostname-5",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", "12:45am"),
+                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", {"1.2.3.5"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-6", "ip-6", "hostname-6", "some_state", "queue1"),
                 ],
@@ -1001,7 +1001,7 @@ class TestInstanceManager:
                         "hostname-1",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", "12:45am"),
+                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", {"1.2.3.1"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-2",
@@ -1009,7 +1009,7 @@ class TestInstanceManager:
                         "hostname-2",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", "12:45am"),
+                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", {"1.2.3.2"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname-3", "some_state", "queue1"),
                     StaticNode("queue1-st-c5xlarge-4", "ip-4", "hostname-4", "some_state", "queue1"),
@@ -1019,7 +1019,7 @@ class TestInstanceManager:
                         "hostname-5",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", "12:45am"),
+                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", {"1.2.3.5"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-6", "ip-6", "hostname-6", "some_state", "queue1"),
                 ],
@@ -1035,7 +1035,7 @@ class TestInstanceManager:
                         "hostname-1",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", "12:45am"),
+                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", {"1.2.3.1"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-2",
@@ -1043,7 +1043,7 @@ class TestInstanceManager:
                         "hostname-2",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", "12:45am"),
+                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", {"1.2.3.2"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname-3", "some_state", "queue1"),
                     StaticNode("queue1-st-c5xlarge-4", "ip-4", "hostname-4", "some_state", "queue1"),
@@ -1053,7 +1053,7 @@ class TestInstanceManager:
                         "hostname-5",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", "12:45am"),
+                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", {"1.2.3.5"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-6", "ip-6", "hostname-6", "some_state", "queue1"),
                 ],
@@ -1069,7 +1069,7 @@ class TestInstanceManager:
                         "hostname-1",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", "12:45am"),
+                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", {"1.2.3.1"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-2",
@@ -1077,7 +1077,7 @@ class TestInstanceManager:
                         "hostname-2",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", "12:45am"),
+                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", {"1.2.3.2"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname-3", "some_state", "queue1"),
                     StaticNode("queue1-st-c5xlarge-4", "ip-4", "hostname-4", "some_state", "queue1"),
@@ -1087,7 +1087,7 @@ class TestInstanceManager:
                         "hostname-5",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", "12:45am"),
+                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", {"1.2.3.5"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-6", "ip-6", "hostname-6", "some_state", "queue1"),
                 ],
@@ -1103,7 +1103,7 @@ class TestInstanceManager:
                         "hostname-1",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", "12:45am"),
+                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", {"1.2.3.1"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-2",
@@ -1111,7 +1111,7 @@ class TestInstanceManager:
                         "hostname-2",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", "12:45am"),
+                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", {"1.2.3.2"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-3", "ip-3", "hostname-3", "some_state", "queue1"),
                     StaticNode("queue1-st-c5xlarge-4", "ip-4", "hostname-4", "some_state", "queue1"),
@@ -1121,7 +1121,7 @@ class TestInstanceManager:
                         "hostname-5",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", "12:45am"),
+                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", {"1.2.3.5"}, "12:45am"),
                     ),
                     StaticNode("queue1-st-c5xlarge-6", "ip-6", "hostname-6", "some_state", "queue1"),
                 ],
@@ -1137,7 +1137,7 @@ class TestInstanceManager:
                         "hostname-1",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", "12:45am"),
+                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", {"1.2.3.1"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-2",
@@ -1145,7 +1145,7 @@ class TestInstanceManager:
                         "hostname-2",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", "12:45am"),
+                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", {"1.2.3.2"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-5",
@@ -1153,7 +1153,7 @@ class TestInstanceManager:
                         "hostname-5",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", "12:45am"),
+                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", {"1.2.3.5"}, "12:45am"),
                     ),
                 ],
                 0,
@@ -1168,7 +1168,7 @@ class TestInstanceManager:
                         "hostname-1",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", "12:45am"),
+                        instance=EC2Instance("instance-1", "1.2.3.1", "instance-1-host", {"1.2.3.1"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-2",
@@ -1176,7 +1176,7 @@ class TestInstanceManager:
                         "hostname-2",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", "12:45am"),
+                        instance=EC2Instance("instance-2", "1.2.3.2", "instance-2-host", {"1.2.3.2"}, "12:45am"),
                     ),
                     StaticNode(
                         "queue1-st-c5xlarge-5",
@@ -1184,7 +1184,7 @@ class TestInstanceManager:
                         "hostname-5",
                         "some_state",
                         "queue1",
-                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", "12:45am"),
+                        instance=EC2Instance("instance-5", "1.2.3.5", "instance-5-host", {"1.2.3.5"}, "12:45am"),
                     ),
                 ],
                 2,
@@ -2128,7 +2128,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2139,7 +2143,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     )
@@ -2148,7 +2156,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2159,7 +2171,11 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q1-q1c1-st-large-1"],
                         launched_instances=(
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2184,28 +2200,52 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-54321", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-54321",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                         "q1c2": [
                             EC2Instance(
-                                "i-123456", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-123456",
+                                "ip.1.0.0.3",
+                                "ip-1-0-0-3",
+                                {"ip.1.0.0.3"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                     },
                     "q2": {
                         "q2c1": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12348", "ip.1.0.0.5", "ip-1-0-0-5", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12348",
+                                "ip.1.0.0.5",
+                                "ip-1-0-0-5",
+                                {"ip.1.0.0.5"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12349", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12349",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2216,30 +2256,54 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-54321", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-54321",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
                     call(
                         nodes={
                             "q1-q1c2-st-small-1": EC2Instance(
-                                "i-123456", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-123456",
+                                "ip.1.0.0.3",
+                                "ip-1-0-0-3",
+                                {"ip.1.0.0.3"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
                     call(
                         nodes={
                             "q2-q2c1-st-large-1": EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             "q2-q2c1-st-large-2": EC2Instance(
-                                "i-12348", "ip.1.0.0.5", "ip-1-0-0-5", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12348",
+                                "ip.1.0.0.5",
+                                "ip-1-0-0-5",
+                                {"ip.1.0.0.5"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             "q2-q2c1-st-large-3": EC2Instance(
-                                "i-12349", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12349",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2248,10 +2312,18 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-54321", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-54321",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=10,
@@ -2259,7 +2331,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c2-st-small-1": EC2Instance(
-                                "i-123456", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-123456",
+                                "ip.1.0.0.3",
+                                "ip-1-0-0-3",
+                                {"ip.1.0.0.3"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=10,
@@ -2267,13 +2343,25 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q2-q2c1-st-large-1": EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             "q2-q2c1-st-large-2": EC2Instance(
-                                "i-12348", "ip.1.0.0.5", "ip-1-0-0-5", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12348",
+                                "ip.1.0.0.5",
+                                "ip-1-0-0-5",
+                                {"ip.1.0.0.5"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             "q2-q2c1-st-large-3": EC2Instance(
-                                "i-12349", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12349",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=10,
@@ -2284,10 +2372,18 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q1-q1c1-st-large-1", "q1-q1c1-st-large-2"],
                         launched_instances=(
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-54321", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-54321",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2295,7 +2391,11 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q1-q1c2-st-small-1"],
                         launched_instances=(
                             EC2Instance(
-                                "i-123456", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-123456",
+                                "ip.1.0.0.3",
+                                "ip-1-0-0-3",
+                                {"ip.1.0.0.3"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2303,13 +2403,25 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q2-q2c1-st-large-1", "q2-q2c1-st-large-2", "q2-q2c1-st-large-3"],
                         launched_instances=(
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12348", "ip.1.0.0.5", "ip-1-0-0-5", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12348",
+                                "ip.1.0.0.5",
+                                "ip-1-0-0-5",
+                                {"ip.1.0.0.5"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12349", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12349",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2330,7 +2442,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2341,7 +2457,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2350,7 +2470,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2373,10 +2497,18 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2387,14 +2519,22 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2403,7 +2543,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2411,7 +2555,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2422,7 +2570,11 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q1-q1c1-st-large-1"],
                         launched_instances=(
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2443,10 +2595,18 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2457,14 +2617,22 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2473,7 +2641,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2481,7 +2653,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2492,7 +2668,11 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q1-q1c1-st-large-2"],
                         launched_instances=(
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2513,7 +2693,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2524,7 +2708,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2533,7 +2721,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2556,10 +2748,18 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2570,14 +2770,22 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2586,7 +2794,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2594,7 +2806,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2605,7 +2821,11 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q1-q1c1-st-large-1"],
                         launched_instances=(
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2626,10 +2846,18 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2640,7 +2868,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2649,7 +2881,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2672,10 +2908,18 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2686,14 +2930,22 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2702,7 +2954,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-2": EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         },
                         update_dns_batch_size=1,
@@ -2713,7 +2969,11 @@ class TestJobLevelScalingInstanceManager:
                         slurm_nodes=["q1-q1c1-st-large-2"],
                         launched_instances=(
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ),
                     ),
@@ -2734,10 +2994,18 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -2748,7 +3016,11 @@ class TestJobLevelScalingInstanceManager:
                     call(
                         nodes={
                             "q1-q1c1-st-large-1": EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         }
                     ),
@@ -2839,7 +3111,7 @@ class TestJobLevelScalingInstanceManager:
             ),
             (
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 False,
                 None,
                 call(["queue1-st-c5xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=None),
@@ -2847,7 +3119,7 @@ class TestJobLevelScalingInstanceManager:
             ),
             (
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 True,
                 None,
                 call(["queue1-st-c5xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=["hostname-1"]),
@@ -2855,7 +3127,7 @@ class TestJobLevelScalingInstanceManager:
             ),
             (
                 ["queue1-st-c5xlarge-1"],
-                [EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time")],
+                [EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time")],
                 True,
                 subprocess.CalledProcessError(1, "command"),
                 call(["queue1-st-c5xlarge-1"], nodeaddrs=["ip-1"], nodehostnames=["hostname-1"]),
@@ -2864,8 +3136,8 @@ class TestJobLevelScalingInstanceManager:
             (
                 ["queue1-st-c5xlarge-1", "queue1-st-c5xlarge-2"],
                 [
-                    EC2Instance("id-1", "ip-1", "hostname-1", "some_launch_time"),
-                    EC2Instance("id-2", "ip-2", "hostname-2", "some_launch_time"),
+                    EC2Instance("id-1", "ip-1", "hostname-1", {"ip-1"}, "some_launch_time"),
+                    EC2Instance("id-2", "ip-2", "hostname-2", {"ip-2"}, "some_launch_time"),
                 ],
                 False,
                 None,
@@ -2952,7 +3224,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -2975,7 +3251,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3003,7 +3283,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3013,7 +3297,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3079,7 +3367,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue1": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3107,7 +3399,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3116,7 +3412,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue10": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3125,14 +3425,22 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     },
                     "queue10": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     },
@@ -3158,7 +3466,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3167,7 +3479,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3176,10 +3492,18 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3310,7 +3634,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3325,7 +3653,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3335,7 +3667,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3350,10 +3686,18 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-654321", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-654321",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -3363,7 +3707,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3401,7 +3749,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue4": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3467,7 +3819,11 @@ class TestJobLevelScalingInstanceManager:
                     "queue1": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3530,14 +3886,22 @@ class TestJobLevelScalingInstanceManager:
                     "queue1": {
                         "c52xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     },
                     "queue3": {
                         "p4d24xlarge": [
                             EC2Instance(
-                                "i-123456", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-123456",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     },
@@ -3609,14 +3973,22 @@ class TestJobLevelScalingInstanceManager:
                     "queue1": {
                         "c52xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     },
                     "queue3": {
                         "p4d24xlarge": [
                             EC2Instance(
-                                "i-123456", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-123456",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     },
@@ -3850,7 +4222,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -3863,28 +4239,52 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "q1c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-54321", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-54321",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                         "q1c2": [
                             EC2Instance(
-                                "i-123456", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-123456",
+                                "ip.1.0.0.3",
+                                "ip-1-0-0-3",
+                                {"ip.1.0.0.3"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                     },
                     "q2": {
                         "q2c1": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12348", "ip.1.0.0.5", "ip-1-0-0-5", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12348",
+                                "ip.1.0.0.5",
+                                "ip-1-0-0-5",
+                                {"ip.1.0.0.5"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12349", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12349",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
@@ -3935,7 +4335,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3945,7 +4349,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3960,7 +4368,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c2": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3976,7 +4388,11 @@ class TestJobLevelScalingInstanceManager:
                     "q2": {
                         "c2": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3985,7 +4401,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c2": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.4", "ip-1-0-0-4", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.4",
+                                "ip-1-0-0-4",
+                                {"ip.1.0.0.4"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -3995,7 +4415,11 @@ class TestJobLevelScalingInstanceManager:
                     "q2": {
                         "c2": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4105,10 +4529,22 @@ class TestJobLevelScalingInstanceManager:
                 {
                     "q1": {
                         "c1": [
-                            EC2Instance("q1c1-1", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c1-1",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ],
                         "c2": [
-                            EC2Instance("q1c2-1", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c2-1",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ],
                     }
                 },
@@ -4116,10 +4552,22 @@ class TestJobLevelScalingInstanceManager:
                 {
                     "q1": {
                         "c1": [
-                            EC2Instance("q1c1-1", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c1-1",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ],
                         "c2": [
-                            EC2Instance("q1c2-1", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c2-1",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ],
                     }
                 },
@@ -4128,31 +4576,63 @@ class TestJobLevelScalingInstanceManager:
                 {
                     "q1": {
                         "c1": [
-                            EC2Instance("q1c1-1", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c1-1",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ],
                         "c2": [
-                            EC2Instance("q1c2-1", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c2-1",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ],
                     }
                 },
                 {
                     "q1": {
                         "c2": [
-                            EC2Instance("q1c2-2", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c2-2",
+                                "ip.1.0.0.3",
+                                "ip-1-0-0-3",
+                                {"ip.1.0.0.3"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ]
                     }
                 },
                 {
                     "q1": {
                         "c1": [
-                            EC2Instance("q1c1-1", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc))
+                            EC2Instance(
+                                "q1c1-1",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                            )
                         ],
                         "c2": [
                             EC2Instance(
-                                "q1c2-1", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "q1c2-1",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "q1c2-2", "ip.1.0.0.3", "ip-1-0-0-3", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "q1c2-2",
+                                "ip.1.0.0.3",
+                                "ip-1-0-0-3",
+                                {"ip.1.0.0.3"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     }
@@ -4185,12 +4665,20 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                         "c2": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                     }
@@ -4208,7 +4696,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                     }
@@ -4288,7 +4780,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4297,7 +4793,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4309,12 +4809,20 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                         "c2": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                     }
@@ -4334,7 +4842,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                     }
@@ -4349,7 +4861,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4358,10 +4874,18 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -4397,12 +4921,20 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                         "c2": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ],
                     }
@@ -4525,7 +5057,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4535,7 +5071,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4567,7 +5107,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4576,7 +5120,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4585,7 +5133,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     }
@@ -4611,7 +5163,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4621,7 +5177,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     },
@@ -4653,7 +5213,11 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4662,7 +5226,11 @@ class TestJobLevelScalingInstanceManager:
                     "q2": {
                         "c2": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             )
                         ]
                     }
@@ -4671,14 +5239,22 @@ class TestJobLevelScalingInstanceManager:
                     "q1": {
                         "c1": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     },
                     "q2": {
                         "c2": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.2", "ip-1-0-0-2", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.2",
+                                "ip-1-0-0-2",
+                                {"ip.1.0.0.2"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     },
@@ -4885,22 +5461,38 @@ class TestNodeListScalingInstanceManager:
                     "queue1": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                         "c52xlarge": [
                             EC2Instance(
-                                "i-12346", "ip.1.0.0.6", "ip-1-0-0-6", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12346",
+                                "ip.1.0.0.6",
+                                "ip-1-0-0-6",
+                                {"ip.1.0.0.6"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
                     "queue2": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.7", "ip-1-0-0-7", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.7",
+                                "ip-1-0-0-7",
+                                {"ip.1.0.0.7"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12348", "ip.1.0.0.8", "ip-1-0-0-8", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12348",
+                                "ip.1.0.0.8",
+                                "ip-1-0-0-8",
+                                {"ip.1.0.0.8"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     },
@@ -4925,17 +5517,29 @@ class TestNodeListScalingInstanceManager:
                     "queue1": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },
                     "queue2": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12347", "ip.1.0.0.7", "ip-1-0-0-7", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12347",
+                                "ip.1.0.0.7",
+                                "ip-1-0-0-7",
+                                {"ip.1.0.0.7"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                             EC2Instance(
-                                "i-12348", "ip.1.0.0.8", "ip-1-0-0-8", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12348",
+                                "ip.1.0.0.8",
+                                "ip-1-0-0-8",
+                                {"ip.1.0.0.8"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ]
                     },
@@ -4958,7 +5562,11 @@ class TestNodeListScalingInstanceManager:
                     "queue1": {
                         "c5xlarge": [
                             EC2Instance(
-                                "i-12345", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)
+                                "i-12345",
+                                "ip.1.0.0.1",
+                                "ip-1-0-0-1",
+                                {"ip.1.0.0.1"},
+                                datetime(2020, 1, 1, tzinfo=timezone.utc),
                             ),
                         ],
                     },

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -285,7 +285,13 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 zip(
                     ["queue1-dy-c5xlarge-1"],
                     [
-                        EC2Instance("i-11111", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                        EC2Instance(
+                            "i-11111",
+                            "ip.1.0.0.1",
+                            "ip-1-0-0-1",
+                            {"ip.1.0.0.1"},
+                            datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        ),
                     ],
                 )
             ),
@@ -331,7 +337,13 @@ def test_resume_config(config_file, expected_attributes, test_datadir, mocker):
                 zip(
                     ["queue1-dy-c5xlarge-1"],
                     [
-                        EC2Instance("i-11111", "ip.1.0.0.1", "ip-1-0-0-1", datetime(2020, 1, 1, tzinfo=timezone.utc)),
+                        EC2Instance(
+                            "i-11111",
+                            "ip.1.0.0.1",
+                            "ip-1-0-0-1",
+                            {"ip.1.0.0.1"},
+                            datetime(2020, 1, 1, tzinfo=timezone.utc),
+                        ),
                     ],
                 )
             ),


### PR DESCRIPTION
### Description of changes
* Currently, Clustermgtd uses the primary IP coming from EC2 API to try to map the EC2 instance to a Slurm node. With this commit, clustermgtd will associate a set of all IPs of all network interfaces coming from EC2 API. Instead of matching the single IP from Slurm and the single IP from clustermgtd, this proposal will verify the single IP from Slurm is contained in the set of IPs from clustermgtd.

### Tests
The following integration tests have been passed
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  scaling:
    test_mpi.py::test_mpi:  # TODO: move outside of the scaling dir
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["rhel8"]
          schedulers: ["slurm"]
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
    test_mpi.py::test_mpi_ssh:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
        - regions: ["cn-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
        - regions: ["us-gov-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.NOT_RELEASED_OSES }}
          schedulers: ["slurm"]
    test_scaling.py::test_job_level_scaling:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: ["slurm"]
  schedulers:
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2204"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
      dimensions:
        - regions: ["ap-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["rhel8"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_scaling:
      dimensions:
        - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
          instances: [{{ common.instance("instance_type_1") }}]
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_error_handling:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.NOT_RELEASED_OSES }}
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_protected_mode:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["rhel8"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_protected_mode_on_cluster_create:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_slurm.py::test_fast_capacity_failover:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_config_update:
      dimensions:
        - regions: [ "ap-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.NOT_RELEASED_OSES }}
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_memory_based_scheduling:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2204"]
          schedulers: ["slurm"]
    test_slurm.py::test_scontrol_reboot:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
    test_slurm.py::test_scontrol_reboot_ec2_health_checks:
      dimensions:
        - regions: ["us-east-2"]
          instances: ["t2.medium"]
          oss: ["ubuntu2204"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_overrides:
      dimensions:
        - regions: ["me-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
    test_slurm_accounting.py::test_slurm_accounting:
      dimensions:
        - regions: ["ap-south-1"]
          instances:  {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2204"]
          schedulers: ["slurm"]
    test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
      dimensions:
        - regions: ["us-west-2"]
          instances:  {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_custom_partitions:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
    test_custom_munge_key.py::test_custom_munge_key:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
