### PR TITLE
[DEX] Add possibility in 'upload-node.sh' to specify an optional scope

### DIFF
--- a/util/upload-node.sh
+++ b/util/upload-node.sh
@@ -24,6 +24,7 @@ _help() {
   --profile <aws-profile>       AWS profile name to use for the upload
                                 (optional, default is AWS_PROFILE env variable or "default")
   --region <aws-region>         Region to use for AWSCli commands (optional, default is "us-east-1")
+  --scope <string>              Disambiguation string used in the S3 path to avoid collisions (default is empty)
   -h, --help                    Print this help message
 EOF
 }
@@ -40,6 +41,8 @@ main() {
             --profile=*)        _profile="${1#*=}";;
             --region)           _region="$2"; shift;;
             --region=*)         _region="${1#*=}";;
+            --scope)            _scope="$2"; shift;;
+            --scope=*)          _scope="${1#*=}";;
             -h|--help|help)     _help; exit 0;;
             *)                  _help; echo "[error] Unrecognized option '$1'"; exit 1;;
         esac
@@ -65,6 +68,10 @@ main() {
     if [ -z "${_region}" ]; then
         _info "--region parameter not specified, using 'us-east-1'"
         _region="us-east-1"
+    fi
+    if [ -z "${_scope}" ]; then
+        _info "--scope parameter not specified, no scope will be used"
+        _scope=""
     fi
 
     # check bucket or create it
@@ -94,6 +101,9 @@ main() {
 
     # upload package
     _key_path="parallelcluster/${_version}/node"
+    if [ -n "${_scope}" ]; then
+        _key_path="${_key_path}/${_scope}"
+    fi
     aws ${_profile} --region "${_region}" s3 cp aws-parallelcluster-node-${_version}.tgz s3://${_bucket}/${_key_path}/aws-parallelcluster-node-${_version}.tgz || _error_exit 'Failed to push node to S3'
     aws ${_profile} --region "${_region}" s3 cp aws-parallelcluster-node-${_version}.md5 s3://${_bucket}/${_key_path}/aws-parallelcluster-node-${_version}.md5 || _error_exit 'Failed to push node md5 to S3'
     aws ${_profile} --region "${_region}" s3api head-object --bucket ${_bucket} --key ${_key_path}/aws-parallelcluster-node-${_version}.tgz --output text --query LastModified > aws-parallelcluster-node-${_version}.tgz.date || _error_exit 'Failed to fetch LastModified date'


### PR DESCRIPTION
### Description of changes
Add possibility in 'upload-node.sh' to specify an optional scope to disambiguate different node packages for the same version.

Example:

```
bash util/upload-node.sh --bucket mgiacomo-workspace --srcdir /Users/mgiacomo/workplace/aws-parallelcluster-dev/aws-parallelcluster-node --scope dfsm
```

### Tests
1. Tested upload without scope (current behaviour): node is uploaded to `s3://BUCKET_NAME/parallelcluster/3.9.0/node/aws-parallelcluster-node-3.9.0.tgz`

2. Tested upload with a custom scope: node is uploaded to `s3://BUCKET_NAME/parallelcluster/3.9.0/node/SCOPE/aws-parallelcluster-node-3.9.0.tgz`

### References
* Equivalent PR for cookbook: 

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
