### PR TITLE
[Release] Add logic to is_backing_instance_valid to check the IP to make sure t…

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1200,14 +1200,21 @@ class ClusterManager:
                 active_nodes += partition.slurm_nodes
         return list(dict.fromkeys(active_nodes))
 
-    def _is_node_in_replacement_valid(self, node, check_node_is_valid):
+    def _is_node_in_replacement_valid(self, node: SlurmNode, check_node_is_valid):
         """
         Check node is replacement timeout or in replacement.
 
         If check_node_is_valid=True, check whether a node is in replacement,
         If check_node_is_valid=False, check whether a node is replacement timeout.
         """
-        if node.instance and node.name in self._static_nodes_in_replacement:
+        if (
+            node.is_backing_instance_valid(
+                self._config.ec2_instance_missing_max_count,
+                self._nodes_without_backing_instance_count_map,
+                log_warn_if_unhealthy=True,
+            )
+            and node.name in self._static_nodes_in_replacement
+        ):
             time_is_expired = time_is_up(
                 node.instance.launch_time, self._current_time, grace_time=self._config.node_replacement_timeout
             )

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -180,6 +180,17 @@ class SlurmReservation:
     users: str
 
 
+class MissingInstance:
+    name: str
+    ip: str
+    count: int
+
+    def __init__(self, name, ip, count):
+        self.name = name
+        self.ip = ip
+        self.count = count
+
+
 class SlurmNode(metaclass=ABCMeta):
     SLURM_SCONTROL_COMPLETING_STATE = "COMPLETING"
     SLURM_SCONTROL_BUSY_STATES = {"MIXED", "ALLOCATED", SLURM_SCONTROL_COMPLETING_STATE}
@@ -427,7 +438,7 @@ class SlurmNode(metaclass=ABCMeta):
     def is_backing_instance_valid(
         self,
         ec2_instance_missing_max_count,
-        nodes_without_backing_instance_count_map: dict,
+        nodes_without_backing_instance_count_map: dict[str, MissingInstance],
         log_warn_if_unhealthy=True,
     ):
         """Check if a slurm node's addr is set, it points to a valid instance in EC2."""
@@ -445,7 +456,11 @@ class SlurmNode(metaclass=ABCMeta):
                 )
             # Allow a few iterations for the eventual consistency of EC2 data
             logger.debug(f"Map of slurm nodes without backing instances {nodes_without_backing_instance_count_map}")
-            missing_instance_loop_count = nodes_without_backing_instance_count_map.get(self.name, 0)
+            missing_instance = nodes_without_backing_instance_count_map.get(self.name, None)
+            missing_instance_loop_count = missing_instance.count if missing_instance else 0
+            if missing_instance and self.nodeaddr != missing_instance.ip:
+                # Reset the loop count since the nodeaddr has changed
+                missing_instance_loop_count = 0
             # If the loop count has been reached, the instance is unhealthy and will be terminated
             if missing_instance_loop_count >= ec2_instance_missing_max_count:
                 if log_warn_if_unhealthy:
@@ -454,7 +469,8 @@ class SlurmNode(metaclass=ABCMeta):
                 nodes_without_backing_instance_count_map.pop(self.name, None)
                 self.ec2_backing_instance_valid = False
             else:
-                nodes_without_backing_instance_count_map[self.name] = missing_instance_loop_count + 1
+                instance_to_add = MissingInstance(self.name, self.nodeaddr, missing_instance_loop_count + 1)
+                nodes_without_backing_instance_count_map[self.name] = instance_to_add
                 if log_warn_if_unhealthy:
                     logger.warning(
                         f"Incrementing missing EC2 instance count for node {self.name} to "

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -767,6 +767,7 @@ def test_handle_health_check(
         region="region",
         boto3_config=None,
         fleet_config={},
+        ec2_instance_missing_max_count=0,
     )
 
     cluster_manager = ClusterManager(mock_sync_config)
@@ -831,6 +832,7 @@ def test_update_static_nodes_in_replacement(current_replacing_nodes, slurm_nodes
         region="region",
         boto3_config=None,
         fleet_config={},
+        ec2_instance_missing_max_count=0,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._static_nodes_in_replacement = current_replacing_nodes
@@ -2691,6 +2693,7 @@ def test_is_node_being_replaced(current_replacing_nodes, node, instance, current
         region="region",
         boto3_config=None,
         fleet_config={},
+        ec2_instance_missing_max_count=0,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = current_time
@@ -2753,6 +2756,7 @@ def test_is_node_replacement_timeout(node, current_node_in_replacement, is_repla
         region="region",
         boto3_config=None,
         fleet_config={},
+        ec2_instance_missing_max_count=0,
     )
     cluster_manager = ClusterManager(mock_sync_config)
     cluster_manager._current_time = datetime(2020, 1, 2, 0, 0, 0)


### PR DESCRIPTION
…he instance matches what is being tracked

The missing instance map did not track what the IP address was that was associated with the slurm node.
Because of this if a new instance is launched before an instance becomes healthy, the increment is not reset
for the instance count map.  This change uses a class object to track the data and links the node name to the ip.

Also use the `is_backing_instance_valid()` function in `is_state_healthy()` instead of the plain `node.instance`
object check to allow for the delay in EC2 consistency.

### Tests
* Ran local unit tests

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
