### PR TITLE
[Bugfix] Fix a bug that was causing `clustermgtd` to fail when a field returned by the command `scontrol show nodes` has a value that contains the character `=`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+3.11.0
+------
+
+**BUG FIXES**
+- Fix a bug that was causing `clustermgtd` to fail when a field returned by the command `scontrol show nodes`
+  has a value that contains the character `=`.
+
 3.10.1
 ------
 

--- a/src/common/schedulers/slurm_commands.py
+++ b/src/common/schedulers/slurm_commands.py
@@ -443,7 +443,7 @@ def _parse_nodes_info(slurm_node_info: str) -> List[SlurmNode]:
         lines = node.splitlines()
         kwargs = {}
         for line in lines:
-            key, value = line.split("=")
+            key, value = line.split("=", 1)
             if key in date_fields:
                 if value not in ["None", "Unknown"]:
                     value = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S").astimezone(tz=timezone.utc)

--- a/tests/common/schedulers/test_slurm_commands.py
+++ b/tests/common/schedulers/test_slurm_commands.py
@@ -194,23 +194,23 @@ def test_is_static_node(nodename, expected_is_static):
             False,
         ),
         (
-            "NodeName=multiple-dy-c5xlarge-4\n"
-            "NodeAddr=multiple-dy-c5xlarge-4\n"
-            "NodeHostName=multiple-dy-c5xlarge-4\n"
+            "NodeName=multiple-dy-c5xlarge-3\n"
+            "NodeAddr=multiple-dy-c5xlarge-3\n"
+            "NodeHostName=multiple-dy-c5xlarge-3\n"
             "State=IDLE+CLOUD+POWER\n"
-            "Partitions=multiple,multiple2\n"
-            "Reason=(Code:InsufficientInstanceCapacity)Failure when resuming nodes [root@2023-01-31T21:24:55]\n"
-            "SlurmdStartTime=2023-01-23T17:57:07\n"
+            "Partitions=multiple\n"
+            "Reason=some reason containing key=value entries \n"
+            "SlurmdStartTime=None\n"
             "######\n",
             [
                 DynamicNode(
-                    "multiple-dy-c5xlarge-4",
-                    "multiple-dy-c5xlarge-4",
-                    "multiple-dy-c5xlarge-4",
+                    "multiple-dy-c5xlarge-3",
+                    "multiple-dy-c5xlarge-3",
+                    "multiple-dy-c5xlarge-3",
                     "IDLE+CLOUD+POWER",
-                    "multiple,multiple2",
-                    "(Code:InsufficientInstanceCapacity)Failure when resuming nodes [root@2023-01-31T21:24:55]",
-                    slurmdstarttime=datetime(2023, 1, 23, 17, 57, 7).astimezone(tz=timezone.utc),
+                    "multiple",
+                    "some reason containing key=value entries ",
+                    slurmdstarttime=None,
                 ),
             ],
             False,


### PR DESCRIPTION
### Description of changes
Fix a bug that was causing `clustermgtd` to fail when a field returned by the command `scontrol show nodes` has a value that contains the character `=`.

In particular, before this change when the field `Reason` is set to a string containing `=`, then clustermgtd would fail with the below error casuing the nodes management loop to be interrupted.

```
Unable to get partition/node info from slurm, no other action can be performed. Sleeping... Exception: too many values to unpack (expected 2)
```

### Tests
* Unit Test

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
