### PR TITLE
Add UnfulfillableCapacity and InsufficientCapacity in the list of EC2…

### DIFF
--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -223,6 +223,8 @@ class SlurmNode(metaclass=ABCMeta):
         "MaxSpotInstanceCountExceeded",
         "Unsupported",
         "SpotMaxPriceTooLow",
+        "UnfulfillableCapacity",
+        "InsufficientCapacity",
     }
 
     def __init__(


### PR DESCRIPTION
… error codes used for fast fail-over

According to https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html

UnfulfillableCapacity: At this time there isn't enough spare capacity to fulfill your request for Spot Instances. You can wait a few minutes to see whether capacity becomes available for your request. Alternatively, create a more flexible request. For example, include additional instance types, include additional Availability Zones, or use the capacity-optimized allocation strategy.

InsufficientCapacity: There is not enough capacity to fulfill your import instance request. You can wait for additional capacity to become available.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
