### PR TITLE
Add tests for Python versions 3.11, 3.12, 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
         name:
           - Python 3.9 Tests
           - Python 3.10 Tests
-          - Python 3.9 Tests Coverage
+          - Python 3.11 Tests
+          - Python 3.12 Tests
+          - Python 3.13 Tests
+          - Python 3.12 Tests Coverage
           - Code Checks
         include:
           - name: Python 3.9 Tests
@@ -39,12 +42,24 @@ jobs:
             python: '3.10'
             toxdir: cli
             toxenv: py310-nocov
-          - name: Python 3.9 Tests Coverage
-            python: 3.9
+          - name: Python 3.11 Tests
+            python: '3.11'
             toxdir: cli
-            toxenv: py39-cov
+            toxenv: py311-nocov
+          - name: Python 3.12 Tests
+            python: '3.12'
+            toxdir: cli
+            toxenv: py312-nocov
+          - name: Python 3.13 Tests
+            python: '3.13'
+            toxdir: cli
+            toxenv: py313-nocov
+          - name: Python 3.12 Tests Coverage
+            python: 3.12
+            toxdir: cli
+            toxenv: py312-cov
           - name: Code Checks
-            python: 3.9
+            python: 3.12
             toxdir: cli
             toxenv: code-linters
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310}-cov
+    py{39,310,311,312,313}-cov
     code-linters
 
 # Default testenv. Used to run tests on all python versions.
@@ -14,6 +14,7 @@ usedevelop =
 allowlist_externals =
     bash
 deps =
+    setuptools
     -r tests/requirements.txt
 commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/


### PR DESCRIPTION
### Description of changes
* Modified tox and GitHub CI configuration to support Python 3.11, 3.12, 3.13.
* Set default coverage version to 3.12 being that the version we have in cookbook 
* Updated branch settings so that new tests are required

### Tests
* Confirmed that tests are running successfully in GitHub as part of CI workflow

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
