### PR TITLE
Add error to point user to slurm resume log

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,6 +18,9 @@ ignore =
     W503,
     # N818: exception name should be named with an Error suffix
     N818
+    # B042: Exception class with `__init__` should pass all args to `super().__init__()` in order to work with `copy.copy()`.
+    # Affected by false positive, https://github.com/PyCQA/flake8-bugbear/issues/525
+    B042
 exclude =
     .tox,
     .git,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+3.15.0
+------
+
+**CHANGES**
+- Direct users to slurm_resume log to see EC2 error codes if no instances are launched.
+
 3.14.0
 ------
 

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1262,7 +1262,8 @@ class ClusterManager:
             return
         log.info(
             "The following compute resources are in down state due to insufficient capacity: %s, "
-            "compute resources will be reset after insufficient capacity timeout (%s seconds) expired",
+            "compute resources will be reset after insufficient capacity timeout (%s seconds) expired."
+            "Check the slurm_resume log for ec2 error codes.",
             self._insufficient_capacity_compute_resources,
             self._config.insufficient_capacity_timeout,
         )

--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -1262,8 +1262,8 @@ class ClusterManager:
             return
         log.info(
             "The following compute resources are in down state due to insufficient capacity: %s, "
-            "compute resources will be reset after insufficient capacity timeout (%s seconds) expired."
-            "Check the slurm_resume log for ec2 error codes.",
+            "compute resources will be reset after insufficient capacity timeout (%s seconds) expired. "
+            "Check the slurm_resume log for EC2 error codes.",
             self._insufficient_capacity_compute_resources,
             self._config.insufficient_capacity_timeout,
         )

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -229,7 +229,8 @@ def _resume(arg_nodes, resume_config, slurm_resume):
         for error_code, node_list in instance_manager.failed_nodes.items():
             _handle_failed_nodes(
                 node_list,
-                reason=f"(Code:{error_code})Failure when resuming nodes - Check the slurm_resume log for ec2 error codes",
+                reason=f"(Code:{error_code})Failure when resuming nodes - "
+                       f"Check the slurm_resume log for EC2 error codes",
             )
 
         event_publisher = ClusterEventPublisher.create_with_default_publisher(

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -230,7 +230,7 @@ def _resume(arg_nodes, resume_config, slurm_resume):
             _handle_failed_nodes(
                 node_list,
                 reason=f"(Code:{error_code})Failure when resuming nodes - "
-                       f"Check the slurm_resume log for EC2 error codes",
+                f"Check the slurm_resume log for EC2 error codes",
             )
 
         event_publisher = ClusterEventPublisher.create_with_default_publisher(

--- a/src/slurm_plugin/resume.py
+++ b/src/slurm_plugin/resume.py
@@ -227,7 +227,10 @@ def _resume(arg_nodes, resume_config, slurm_resume):
             print_with_count(failed_nodes),
         )
         for error_code, node_list in instance_manager.failed_nodes.items():
-            _handle_failed_nodes(node_list, reason=f"(Code:{error_code})Failure when resuming nodes")
+            _handle_failed_nodes(
+                node_list,
+                reason=f"(Code:{error_code})Failure when resuming nodes - Check the slurm_resume log for ec2 error codes",
+            )
 
         event_publisher = ClusterEventPublisher.create_with_default_publisher(
             event_logger,

--- a/tests/slurm_plugin/test_clustermgtd.py
+++ b/tests/slurm_plugin/test_clustermgtd.py
@@ -3533,6 +3533,13 @@ def test_reset_timeout_expired_compute_resources(
     assert_that(cluster_manager._insufficient_capacity_compute_resources).is_equal_to(
         expected_insufficient_capacity_compute_resources
     )
+
+    if expected_insufficient_capacity_compute_resources:
+        assert (
+            "compute resources will be reset after insufficient capacity timeout (20 seconds) expired. "
+            "Check the slurm_resume log for EC2 error codes."
+        ) in caplog.text
+
     if expected_power_save_node_list:
         power_save_mock.assert_called_with(
             expected_power_save_node_list, reason="Enabling node since insufficient capacity timeout expired"

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -448,7 +448,10 @@ def test_resume_launch(
         if expected_failed_nodes:
             for error_code, nodeset in expected_failed_nodes.items():
                 mock_handle_failed_nodes_calls.append(
-                    call(nodeset, reason=f"(Code:{error_code})Failure when resuming nodes")
+                    call(
+                        nodeset,
+                        reason=f"(Code:{error_code})Failure when resuming nodes - Check the slurm_resume log for ec2 error codes",
+                    )
                 )
             mock_handle_failed_nodes.assert_has_calls(mock_handle_failed_nodes_calls)
             mock_terminate_instances.assert_called_with(ANY, mock_resume_config.terminate_max_batch_size)

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -451,7 +451,7 @@ def test_resume_launch(
                     call(
                         nodeset,
                         reason=f"(Code:{error_code})Failure when resuming nodes - "
-                               f"Check the slurm_resume log for EC2 error codes",
+                        f"Check the slurm_resume log for EC2 error codes",
                     )
                 )
             mock_handle_failed_nodes.assert_has_calls(mock_handle_failed_nodes_calls)

--- a/tests/slurm_plugin/test_resume.py
+++ b/tests/slurm_plugin/test_resume.py
@@ -450,7 +450,8 @@ def test_resume_launch(
                 mock_handle_failed_nodes_calls.append(
                     call(
                         nodeset,
-                        reason=f"(Code:{error_code})Failure when resuming nodes - Check the slurm_resume log for ec2 error codes",
+                        reason=f"(Code:{error_code})Failure when resuming nodes - "
+                               f"Check the slurm_resume log for EC2 error codes",
                     )
                 )
             mock_handle_failed_nodes.assert_has_calls(mock_handle_failed_nodes_calls)


### PR DESCRIPTION
### Description of changes
* Add error to point user to slurm resume log
* ignore Flake8   rule B042 as it is a minor, and it is also affected by false positiveness https://github.com/PyCQA/flake8-bugbear/issues/525.

### Tests
* Ran test_slurm_accounting with change to cause the InvalidParameter error

In slurmctld:
`[2025-10-30T12:16:05.106] update_node: node compute-dy-cit-10 reason set to: (Code:InsufficientInstanceCapacity)Failure when resuming nodes - Check the slurm_resume log for EC2 error codes`

In clustermgtd:
`2025-10-30 12:26:48,861 - [slurm_plugin.clustermgtd:_reset_timeout_expired_compute_resources] - INFO - The following compute resources are in down state due to insufficient capacity: {'compute': {'cit': ComputeResourceFailureEvent(timestamp=datetime.datetime(2025, 10, 30, 12, 16, 42, 904354, tzinfo=datetime.timezone.utc), error_code='InsufficientInstanceCapacity')}}, compute resources will be reset after insufficient capacity timeout (600.0 seconds) expired. Check the slurm_resume log for EC2 error codes.`

In slurm_resume:
`2025-10-29 13:39:59,768 - 8667 - [slurm_plugin.fleet_manager:_launch_instances] - ERROR - JobID 2 - Error in CreateFleet request (aa9a6ad3-7ac3-4745-a4d1-b8c178907b8b): InvalidParameter - Security group sg-0f2789bcd3e49cdf3 and subnet subnet-0c766771e11dab28c belong to different networks.`


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
