### PR TITLE
[GH] Add validation for input of pcluster-version

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -21,6 +21,13 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - name: Validate pcluster version format
+      run: |
+        if ! echo "${{ inputs.pcluster-version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "Error: Invalid version format '${{ inputs.pcluster-version }}'. Expected format: X.Y.Z (e.g., 3.14.0)"
+          exit 1
+        fi
+        echo "Version format validated: ${{ inputs.pcluster-version }}"
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0


### PR DESCRIPTION
### Description of changes
* Add validation for input of pcluster-version

Cookbook https://github.com/aws/aws-parallelcluster-cookbook/pull/3084
CLI https://github.com/aws/aws-parallelcluster/pull/7178

### Tests
* Failure https://github.com/himani2411/aws-parallelcluster-node/actions/runs/20579154226/job/59102743619
* Success https://github.com/himani2411/aws-parallelcluster-node/actions/runs/20579167593 with PR https://github.com/himani2411/aws-parallelcluster-node/pull/1

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
