### PR TITLE
Update node package requirements to specify setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto3>=1.7.55
 retrying~=1.3
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ console_scripts = [
     "computemgtd = slurm_plugin.computemgtd:main",
 ]
 version = "3.15.0"
-requires = ["boto3>=1.7.55", "retrying>=1.3.3"]
+requires = ["boto3>=1.7.55", "retrying>=1.3.3", "setuptools"]
 
 setup(
     name="aws-parallelcluster-node",


### PR DESCRIPTION
### Description of changes
* Update node package requirements to specify setuptools
* Without setuptools the installation of node package fails with below error in Build image

```
ERROR: Exception:
2026-01-20 20:55:58.710000	Stdout:     Traceback (most recent call last):
2026-01-20 20:55:58.710000	Stdout:       File "/opt/parallelcluster/pyenv/versions/3.14.2/envs/node_virtualenv/lib/python3.14/site-packages/pip/_internal/cli/base_command.py", line 107, in _run_wrapper
...............................................
2026-01-20 20:55:58.711000	Stdout:         )
2026-01-20 20:55:58.711000	Stdout:     pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'
2026-01-20 20:55:58.711000	Stdout:     ---- End output of "bash"  ----
2026-01-20 20:55:58.711000	Stdout:     Ran "bash"  returned 2

```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
