### PR TITLE
[Logs] Add log lines to clustermgtd to signal that heartbeat file has been update and heartbeat metric has been published.

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -586,9 +586,11 @@ class ClusterManager:
                 self._maintain_nodes_down()
 
         # Write clustermgtd heartbeat to file
+        log.info("Writing heartbeat file")
         self._write_timestamp_to_file()
 
         # Publish heartbeat metric to CloudWatch
+        log.info("Publishing heartbeat metric")
         self._metrics_publisher.put_metric(metric_name=CW_METRICS_HEARTBEAT, value=1)
 
     def _write_timestamp_to_file(self):


### PR DESCRIPTION
### Description of changes
Add log lines to clustermgtd to signal that heartbeat file has been update and heartbeat metric has been published.

### Tests
Verified logs are written and wre actually helpful in root causing a problem.
```
2026-02-03 23:13:42,879 - [slurm_plugin.clustermgtd:_terminate_orphaned_instances] - INFO - Checking for orphaned instance
2026-02-03 23:13:42,879 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Writing heartbeat file
2026-02-03 23:13:42,880 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Publishing heartbeat metric
2026-02-03 23:29:43,747 - [slurm_plugin.cloudwatch_utils:put_metric] - ERROR - Failed to publish metric ClustermgtdHeartbeat: Connect timeout on endpoint URL: "https://monitoring.us-east-1.amazonaws.com/"
2026-02-03 23:29:43,747 - [slurm_plugin.clustermgtd:_get_config] - INFO - Reading /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf
2026-02-03 23:29:43,750 - [slurm_plugin.clustermgtd:manage_cluster] - INFO - Managing cluster...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
