### PR TITLE
[Bug Fix] Fix clustermgtd to detect bootstrap timeout so protected mode can trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+3.16.0
+------
+
+**BUG FIXES**
+- Fix clustermgtd failing to detect compute node bootstrap timeouts, which prevented the cluster from entering protected mode.
+
 3.15.0
 ------
 

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -203,7 +203,11 @@ class SlurmNode(metaclass=ABCMeta):
     SLURM_SCONTROL_POWER_UP_STATE = "POWERING_UP"
     SLURM_SCONTROL_ONLINE_STATES = {"IDLE+CLOUD", "MIXED+CLOUD", "ALLOCATED+CLOUD", "COMPLETING+CLOUD"}
     SLURM_SCONTROL_POWER_WITH_JOB_STATE = {"MIXED", "CLOUD", "POWERED_DOWN"}
-    SLURM_SCONTROL_RESUME_FAILED_STATE = {"DOWN", "CLOUD", "POWERED_DOWN", "NOT_RESPONDING"}
+    # In Slurm 25.11:
+    # When ResumeTimeout fires on a cloud node, Slurm explicitly clears NODE_STATE_NO_RESPOND (along with DRAIN,
+    # POWER_DOWN, POWERING_UP), adds POWERED_DOWN, and then set node to DOWN with reason "ResumeTimeout reached".
+    # The resulting state is therefore DOWN+CLOUD+POWERED_DOWN and does NOT include NOT_RESPONDING.
+    SLURM_SCONTROL_RESUME_FAILED_STATE = {"DOWN", "CLOUD", "POWERED_DOWN"}
     SLURM_SCONTROL_NODE_DOWN_NOT_RESPONDING_STATE = {"DOWN", "CLOUD", "NOT_RESPONDING"}
     # Due to a bug in Slurm a powered down node can enter IDLE+CLOUD+POWER_DOWN+POWERED_DOWN state
     SLURM_SCONTROL_POWER_STATES = [{"IDLE", "CLOUD", "POWERED_DOWN"}, {"IDLE", "CLOUD", "POWERED_DOWN", "POWER_DOWN"}]

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -756,7 +756,10 @@ def test_slurm_node_is_state_healthy(
             True,
         ),
         (
-            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING", "queue1"),
+            # When ResumeTimeout fires on a cloud node under power_save, Slurm clears
+            # NODE_STATE_NO_RESPOND before setting the node DOWN+CLOUD+POWERED_DOWN.
+            # See slurm/src/slurmctld/power_save.c (_do_power_work).
+            DynamicNode("queue1-dy-c5xlarge-1", "ip-1", "hostname", "DOWN+CLOUD+POWERED_DOWN", "queue1"),
             EC2Instance("id-1", "ip-1", "hostname", {"ip-1"}, "launch_time"),
             0,
             {},


### PR DESCRIPTION
### Description of changes
Compute nodes that hang during bootstrap (e.g. when a required VPC endpoint like DynamoDB is missing) loop indefinitely between ResumeTimeout and instance wake-up, because clustermgtd never counts them as bootstrap failures. Protected mode therefore never triggers and the cluster cannot stop the failing loop.

Root cause: Slurm clears `NOT_RESPOND` on `ResumeTimeout`, producing state `DOWN+CLOUD+POWERED_DOWN`. The previous expected set included `NOT_RESPONDING `and never matched.

Fix: drop `NOT_RESPONDING` from `SLURM_SCONTROL_RESUME_FAILED_STATE` so failing nodes are counted and protected mode triggers at the configured threshold.

### Tests
* Unit tests passed.
* Manually test done, now cluster can enter protected mode as expected.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
