### PR TITLE
Refer SLURM_SCONTROL_RESUME_FAILED_STATE in is_bootstrap_failure comment

### DIFF
--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -734,7 +734,7 @@ class DynamicNode(SlurmNode):
                 self.state_string,
             )
             return True
-        # Dynamic node in DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING state
+        # Dynamic node in SLURM_SCONTROL_RESUME_FAILED_STATE.
         elif self.is_bootstrap_timeout():
             # We need to check if nodeaddr is set to avoid counting powering up nodes as bootstrap failure nodes during
             # cluster start/stop.


### PR DESCRIPTION
## Summary

Follow-up cleanup to #702. The inline comment above the `is_bootstrap_timeout()` branch in `DynamicNode.is_bootstrap_failure()` was hard-coding the expected flags (`DOWN+CLOUD+POWERED_DOWN+NOT_RESPONDING`). After #702 changed the constant to `DOWN+CLOUD+POWERED_DOWN`, the comment drifted from the code.

Replace the hard-coded flags with a reference to the `SLURM_SCONTROL_RESUME_FAILED_STATE` constant so future changes to the state set don't require touching this comment.

## Test plan

- [x] No functional change; existing unit tests pass locally.