### PR TITLE
[Node] Log that an unhealthy static node is not protected from replacement

### DIFF
--- a/src/slurm_plugin/clustermgtd.py
+++ b/src/slurm_plugin/clustermgtd.py
@@ -961,7 +961,11 @@ class ClusterManager:
             log.info("Found the following unhealthy dynamic nodes: %s", print_with_count(unhealthy_dynamic_nodes))
             self._handle_unhealthy_dynamic_nodes(unhealthy_dynamic_nodes)
         if unhealthy_static_nodes:
-            log.info("Found the following unhealthy static nodes: %s", print_with_count(unhealthy_static_nodes))
+            # Include the node states, which carry the reason the nodes are considered unhealthy.
+            log.info(
+                "Found the following unhealthy static nodes: %s",
+                print_with_count([f"{node} in state {node.state_string}" for node in unhealthy_static_nodes]),
+            )
             self._handle_unhealthy_static_nodes(unhealthy_static_nodes)
 
         # evaluate partitions to put in protected mode and ICEs nodes to terminate

--- a/src/slurm_plugin/slurm_resources.py
+++ b/src/slurm_plugin/slurm_resources.py
@@ -589,20 +589,30 @@ class StaticNode(SlurmNode):
                 return True
             else:
                 if log_warn_if_unhealthy:
-                    logger.warning("Node state check: node %s in DRAINED, node state: %s", self, self.state_string)
+                    logger.warning(
+                        "Node state check: node %s in DRAINED and not within the replacement protection window, "
+                        "it is considered unhealthy and will be replaced, node state: %s",
+                        self,
+                        self.state_string,
+                    )
                 return False
         # Check to see if node is in DOWN, ignoring any node currently being replaced
         elif self.is_down() and consider_down_as_unhealthy:
             if self.is_being_replaced:
                 logger.debug(
-                    "Node state check: node %s in DOWN but is currently being replaced, ignoring. Node state: ",
+                    "Node state check: node %s in DOWN but is currently being replaced, ignoring, node state: %s",
                     self,
                     self.state_string,
                 )
                 return True
             else:
                 if log_warn_if_unhealthy:
-                    logger.warning("Node state check: node %s in DOWN, node state: %s", self, self.state_string)
+                    logger.warning(
+                        "Node state check: node %s in DOWN and not within the replacement protection window, "
+                        "it is considered unhealthy and will be replaced, node state: %s",
+                        self,
+                        self.state_string,
+                    )
                 return False
         return True
 

--- a/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
+++ b/tests/slurm_plugin/slurm_resources/test_slurm_resources.py
@@ -719,6 +719,40 @@ def test_slurm_node_is_state_healthy(
 
 
 @pytest.mark.parametrize(
+    "node, is_being_replaced, expected_warning",
+    [
+        pytest.param(
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+CLOUD+MAINTENANCE+RESERVED", "queue"),
+            False,
+            "node queue-st-c5xlarge-1(some_ip) in DOWN and not within the replacement protection window",
+            id="down_without_protection_window",
+        ),
+        pytest.param(
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "IDLE+CLOUD+DRAIN", "queue"),
+            False,
+            "node queue-st-c5xlarge-1(some_ip) in DRAINED and not within the replacement protection window",
+            id="drained_without_protection_window",
+        ),
+        pytest.param(
+            StaticNode("queue-st-c5xlarge-1", "some_ip", "hostname", "DOWN+CLOUD+MAINTENANCE+RESERVED", "queue"),
+            True,
+            None,
+            id="down_within_protection_window_not_warned",
+        ),
+    ],
+)
+def test_slurm_node_state_unhealthy_reason_is_logged(node, is_being_replaced, expected_warning, caplog):
+    """An unhealthy state is reported together with the fact that the node is not protected from replacement."""
+    caplog.set_level(logging.WARNING)
+    node.is_being_replaced = is_being_replaced
+    node.is_state_healthy(consider_drain_as_unhealthy=True, consider_down_as_unhealthy=True)
+    if expected_warning:
+        assert_that(caplog.text).contains(expected_warning, node.state_string)
+    else:
+        assert_that(caplog.text).is_empty()
+
+
+@pytest.mark.parametrize(
     "node, instance, max_count, count_map, is_static_nodes_in_replacement, is_replacement_timeout, "
     "bootstrap_failure_messages, is_failing_health_check, is_node_bootstrap_failure",
     [


### PR DESCRIPTION
### Description of changes
A static node that clustermgtd is replacing is shielded from being replaced again while it bootstraps (the replacement protection window). When that protection did not apply, the logs never said so: they showed the node being terminated and relaunched with no indication that it had lost, or never had, the grace period. This is what made the maintenance reservation issue hard to diagnose, and the same gap affects every other reason a node can end up unprotected.

- When a DOWN or DRAINED static node is found unhealthy, the existing warning now also reports that the node is not within the replacement protection window and that it will be replaced. This is the point where the decision is made, and it holds for every reason the window may not apply.
- The log listing the unhealthy static nodes now includes the node states, so the state that led to the replacement is visible without correlating against `scontrol` output.

The node state carries the reason, so the logging does not assume a specific cause and stays accurate if the conditions change.

This also fixes the format string of the debug log covering the opposite case (node still protected), which was missing a placeholder and raised `TypeError: not all arguments converted during string formatting` whenever it was emitted.

#### Example

A node being replaced fails its EC2 health check while bootstrapping, so it is removed from the replacement set and replaced again immediately:

```
Detected failed health check for static node in replacement. No longer considering nodes ['queue1-st-cr1-1'] as in replacement process. Will attempt to replace node again immediately.
Node state check: node queue1-st-cr1-1(192.168.104.165) in DOWN and not within the replacement protection window, it is considered unhealthy and will be replaced, node state: DOWN+CLOUD   <-- reason and consequence added
Found the following unhealthy static nodes: (x1) ['queue1-st-cr1-1(192.168.104.165) in state DOWN+CLOUD']   <-- node states added
Setting unhealthy static nodes to DOWN
Terminating instances backing unhealthy static nodes
Terminating instances (x1) ['i-021cb4b7fa1050c13']
Launching new instances for unhealthy static nodes
```

A DRAINED node reads the same way:

```
Node state check: node queue1-st-cr1-1(192.168.104.165) in DRAINED and not within the replacement protection window, it is considered unhealthy and will be replaced, node state: IDLE+CLOUD+DRAIN
```

While a node is inside the protection window it is reported as healthy and only a debug line is emitted, so the warning above only shows up for nodes that are not shielded.

### Tests
* Unit tests passed, including new cases asserting the unhealthy-state warning reports the missing protection window for DOWN and DRAINED nodes, and that no warning is emitted while the node is still protected.
* Verified on a real cluster with this branch installed via `DevSettings/NodePackage`.

### References
* Follow-up to the COE action item for clearer termination logging.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
