### PR TITLE
Fix EC2 throttling during computenode launch is not retried and is reported as ICE when using multi InstanceTypes or SubnetIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ aws-parallelcluster-node CHANGELOG
 
 This file is used to list changes made in each version of the aws-parallelcluster-node package.
 
+3.17.0
+------
+
+**BUG FIXES**
+- Fix an issue where EC2 throttling during compute node launch is not retried and is reported as insufficient capacity
+  when using Multiple Instance Types or multiple subnets.
+
 3.16.0
 ------
 

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -35,8 +35,7 @@ INSTANCE_INFO_RETRIEVAL_MAX_BACKOFF = 30
 LAUNCH_THROTTLING_ERROR_CODE = "RequestLimitExceeded"
 
 # An override that CreateFleet did not fulfill because another override failed is reported with this exact
-# code and message pair, which points at the real error rather than being one. Other UnfulfillableCapacity
-# messages, such as the one about MinTargetCapacity constraints, do describe a real cause and are kept.
+# code and message pair, which points at the real error rather than being one.
 UNFULFILLED_OVERRIDE_ERROR = (
     "UnfulfillableCapacity",
     "Failed to fulfill capacity. Please review errors in the response.",
@@ -443,7 +442,7 @@ class Ec2CreateFleetManager(FleetManager):
                 logger.error("Unable to retrieve instance info for instances: %s", partial_instance_ids)
 
             if not instances:
-                # Every error is logged above, but only the ones describing a cause are worth reporting.
+                # Drop the entries that only point at the real error, unless the response carries nothing else.
                 real_errors = [
                     err
                     for err in err_list
@@ -451,8 +450,9 @@ class Ec2CreateFleetManager(FleetManager):
                 ]
                 if real_errors:
                     err_list = real_errors
-                # Throttling is reported even alongside other causes, so that the launch is retried with backoff
-                # instead of the nodes being recorded as insufficient capacity, which fails the compute resource over.
+                # A single cause is normally left. Should there be several, prefer throttling as a safety net: it is
+                # the only cause that resolves on its own, and reporting it as insufficient capacity would instead
+                # fail the compute resource over.
                 throttling = next(
                     (err for err in err_list if err.get("ErrorCode") == LAUNCH_THROTTLING_ERROR_CODE), None
                 )

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -30,6 +30,18 @@ logger = logging.getLogger(__name__)
 INSTANCE_INFO_RETRIEVAL_TIMEOUT_DEFAULT = 90
 INSTANCE_INFO_RETRIEVAL_MAX_BACKOFF = 30
 
+# The only error code EC2 returns when a launch request is throttled, see
+# https://docs.aws.amazon.com/ec2/latest/devguide/ec2-api-throttling.html
+LAUNCH_THROTTLING_ERROR_CODE = "RequestLimitExceeded"
+
+# An override that CreateFleet did not fulfill because another override failed is reported with this exact
+# code and message pair, which points at the real error rather than being one. Other UnfulfillableCapacity
+# messages, such as the one about MinTargetCapacity constraints, do describe a real cause and are kept.
+UNFULFILLED_OVERRIDE_ERROR = (
+    "UnfulfillableCapacity",
+    "Failed to fulfill capacity. Please review errors in the response.",
+)
+
 
 class EC2Instance:
     def __init__(self, id, private_ip, hostname, all_private_ips, launch_time):
@@ -430,6 +442,23 @@ class Ec2CreateFleetManager(FleetManager):
             if partial_instance_ids:
                 logger.error("Unable to retrieve instance info for instances: %s", partial_instance_ids)
 
+            if not instances:
+                # Every error is logged above, but only the ones describing a cause are worth reporting.
+                real_errors = [
+                    err
+                    for err in err_list
+                    if (err.get("ErrorCode"), err.get("ErrorMessage")) != UNFULFILLED_OVERRIDE_ERROR
+                ]
+                if real_errors:
+                    err_list = real_errors
+                # Throttling is reported even alongside other causes, so that the launch is retried with backoff
+                # instead of the nodes being recorded as insufficient capacity, which fails the compute resource over.
+                throttling = next(
+                    (err for err in err_list if err.get("ErrorCode") == LAUNCH_THROTTLING_ERROR_CODE), None
+                )
+                if throttling:
+                    raise LaunchInstancesError(throttling.get("ErrorCode"), throttling.get("ErrorMessage"))
+            # Any other cause is reported only when the response is unambiguous, unchanged from before.
             if not instances and len(err_list) == 1:
                 raise LaunchInstancesError(err_list[0].get("ErrorCode"), err_list[0].get("ErrorMessage"))
             return {"Instances": instances}

--- a/src/slurm_plugin/fleet_manager.py
+++ b/src/slurm_plugin/fleet_manager.py
@@ -458,8 +458,10 @@ class Ec2CreateFleetManager(FleetManager):
                 )
                 if throttling:
                     raise LaunchInstancesError(throttling.get("ErrorCode"), throttling.get("ErrorMessage"))
-            # Any other cause is reported only when the response is unambiguous, unchanged from before.
-            if not instances and len(err_list) == 1:
+            # Normally a single cause is left. Reporting the first one of several is a second safety net: the
+            # caller otherwise records a hardcoded InsufficientInstanceCapacity, and any code EC2 actually
+            # returned is more useful than an invented one, whichever of them the response happens to list first.
+            if not instances and err_list:
                 raise LaunchInstancesError(err_list[0].get("ErrorCode"), err_list[0].get("ErrorMessage"))
             return {"Instances": instances}
         except ClientError as e:

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -29,6 +29,23 @@ from slurm_plugin.fleet_manager import (
 from tests.common import FLEET_CONFIG, MockedBoto3Request
 
 
+UNFULFILLED_OVERRIDE = {
+    "ErrorCode": "UnfulfillableCapacity",
+    "ErrorMessage": "Failed to fulfill capacity. Please review errors in the response.",
+}
+UNSUPPORTED_ERROR = {"ErrorCode": "Unsupported", "ErrorMessage": "Not supported in this AZ."}
+MIN_TARGET_CAPACITY_ERROR = {
+    "ErrorCode": "UnfulfillableCapacity",
+    "ErrorMessage": "Unable to fulfill request due to MinTargetCapacity constraints. Please adjust your request.",
+}
+
+
+def _raises_launch_error(err_list):
+    """Mirror when _launch_instances turns a CreateFleet response with no instances into an exception."""
+    real = [err for err in err_list if err != UNFULFILLED_OVERRIDE] or err_list
+    return any(err.get("ErrorCode") == "RequestLimitExceeded" for err in real) or len(real) == 1
+
+
 def _expected_describe_attempts(timeout):
     """Compute DescribeInstances attempts for a never-converging instance, mirroring _get_instances_info."""
     attempts = 0
@@ -735,6 +752,31 @@ class TestEc2CreateFleetManager:
                 ],
                 [],
             ),
+            # create-fleet - throttling reported together with one generic error per override
+            (
+                test_on_demand_params,
+                [
+                    MockedBoto3Request(
+                        method="create_fleet",
+                        response={
+                            "Instances": [],
+                            "Errors": [
+                                {"ErrorCode": "RequestLimitExceeded", "ErrorMessage": "Request limit exceeded."},
+                            ]
+                            + [
+                                {
+                                    "ErrorCode": "UnfulfillableCapacity",
+                                    "ErrorMessage": "Failed to fulfill capacity. Please review errors in the response.",
+                                }
+                            ]
+                            * 35,
+                            "ResponseMetadata": {"RequestId": "37633199-bcc6-4a88-89e3-89d859d76096"},
+                        },
+                        expected_params=test_on_demand_params,
+                    ),
+                ],
+                [],
+            ),
         ],
         ids=[
             "fleet_spot",
@@ -743,6 +785,7 @@ class TestEc2CreateFleetManager:
             "fleet_capacity_block",
             "fleet_throttling",
             "fleet_multiple_errors",
+            "fleet_throttling_with_generic_errors",
         ],
     )
     def test_launch_instances(
@@ -765,10 +808,10 @@ class TestEc2CreateFleetManager:
             with pytest.raises(Exception) as e:
                 fleet_manager._launch_instances(launch_params)
                 assert isinstance(e, ClientError)
-        elif len(expected_assigned_nodes) == 0 and len(mocked_boto3_request[0].response.get("Errors")) == 1:
+        elif not expected_assigned_nodes and _raises_launch_error(mocked_boto3_request[0].response.get("Errors", [])):
             with pytest.raises(LaunchInstancesError) as e:
                 fleet_manager._launch_instances(launch_params)
-                assert isinstance(e, LaunchInstancesError)
+            assert_that(e.value.code).is_equal_to(mocked_boto3_request[0].response.get("Errors")[0].get("ErrorCode"))
         else:
             assigned_nodes = fleet_manager._launch_instances(launch_params)
             assert_that(assigned_nodes.get("Instances", [])).is_equal_to(expected_assigned_nodes)
@@ -1326,3 +1369,93 @@ class TestFleetManager:
 
         fleet_manager._evaluate_launch_params.assert_called_once_with(count)
         fleet_manager._launch_instances.assert_called_once()
+
+    def test_launch_ec2_instances_retries_on_throttling(self, mocker):
+        """Verify CreateFleet throttling is retried, also when the response carries one error per override."""
+        mocker.patch("time.sleep")
+        fleet_manager = FleetManagerFactory.get_manager(
+            "hit", "region", "boto3_config", FLEET_CONFIG, "queue2", "fleet-ondemand", True, {}, {}
+        )
+        mocker.patch.object(fleet_manager, "_evaluate_launch_params", return_value={})
+        launched_instance_info = {
+            "InstanceId": "i-12345",
+            "PrivateIpAddress": "ip-1",
+            "PrivateDnsName": "hostname",
+            "LaunchTime": datetime(2020, 1, 1, tzinfo=timezone.utc),
+            "NetworkInterfaces": [
+                {"Attachment": {"DeviceIndex": 0, "NetworkCardIndex": 0}, "PrivateIpAddress": "ip-1"},
+            ],
+        }
+        mocker.patch.object(
+            fleet_manager,
+            "_get_instances_info",
+            side_effect=lambda instance_ids: ([launched_instance_info] if instance_ids else [], []),
+        )
+        throttled_response = {
+            "Instances": [],
+            "Errors": [{"ErrorCode": "RequestLimitExceeded", "ErrorMessage": "Request limit exceeded."}]
+            + [
+                {
+                    "ErrorCode": "UnfulfillableCapacity",
+                    "ErrorMessage": "Failed to fulfill capacity. Please review errors in the response.",
+                }
+            ]
+            * 35,
+            "ResponseMetadata": {"RequestId": "1234-abcde"},
+        }
+        create_fleet = mocker.patch(
+            "slurm_plugin.fleet_manager.create_fleet",
+            side_effect=[throttled_response, {"Instances": [{"InstanceIds": ["i-12345"]}]}],
+        )
+
+        launched = fleet_manager.launch_ec2_instances(1)
+
+        assert_that(create_fleet.call_count).is_equal_to(2)
+        assert_that(launched).is_length(1)
+
+    @pytest.mark.parametrize(
+        ("err_list", "expected_error_code"),
+        [
+            # The real cause is reported even though every other override adds an entry pointing back at it.
+            ([UNSUPPORTED_ERROR] + [UNFULFILLED_OVERRIDE] * 35, "Unsupported"),
+            # The entries pointing at the real cause carry no order guarantee.
+            ([UNFULFILLED_OVERRIDE] * 35 + [UNSUPPORTED_ERROR], "Unsupported"),
+            # UnfulfillableCapacity messages other than that one do describe a cause and are kept.
+            ([MIN_TARGET_CAPACITY_ERROR] + [UNFULFILLED_OVERRIDE] * 35, "UnfulfillableCapacity"),
+            # A single override is unaffected, whatever the entry says.
+            ([UNFULFILLED_OVERRIDE], "UnfulfillableCapacity"),
+            ([MIN_TARGET_CAPACITY_ERROR], "UnfulfillableCapacity"),
+            # Nothing to prefer: reporting stays as it was, so no cause is claimed.
+            ([UNFULFILLED_OVERRIDE] * 36, None),
+            ([UNSUPPORTED_ERROR, {"ErrorCode": "VcpuLimitExceeded", "ErrorMessage": "vCPU limit"}], None),
+        ],
+        ids=[
+            "real_cause_first",
+            "real_cause_last",
+            "min_target_capacity_kept",
+            "single_override_unfulfilled",
+            "single_override_min_target_capacity",
+            "only_unfulfilled_overrides",
+            "two_real_causes",
+        ],
+    )
+    def test_launch_instances_reports_the_cause_among_unfulfilled_overrides(
+        self, mocker, err_list, expected_error_code
+    ):
+        """An entry is added per override that was not fulfilled; only a real cause is worth reporting."""
+        fleet_manager = FleetManagerFactory.get_manager(
+            "hit", "region", "boto3_config", FLEET_CONFIG, "queue2", "fleet-ondemand", False, {}, {}
+        )
+        mocker.patch.object(fleet_manager, "_evaluate_launch_params", return_value={})
+        mocker.patch.object(fleet_manager, "_get_instances_info", return_value=([], []))
+        mocker.patch(
+            "slurm_plugin.fleet_manager.create_fleet",
+            return_value={"Instances": [], "Errors": err_list, "ResponseMetadata": {"RequestId": "1234-abcde"}},
+        )
+
+        if expected_error_code:
+            with pytest.raises(LaunchInstancesError) as e:
+                fleet_manager._launch_instances({})
+            assert_that(e.value.code).is_equal_to(expected_error_code)
+        else:
+            assert_that(fleet_manager._launch_instances({})).is_equal_to({"Instances": []})

--- a/tests/slurm_plugin/test_fleet_manager.py
+++ b/tests/slurm_plugin/test_fleet_manager.py
@@ -28,7 +28,6 @@ from slurm_plugin.fleet_manager import (
 
 from tests.common import FLEET_CONFIG, MockedBoto3Request
 
-
 UNFULFILLED_OVERRIDE = {
     "ErrorCode": "UnfulfillableCapacity",
     "ErrorMessage": "Failed to fulfill capacity. Please review errors in the response.",
@@ -42,8 +41,7 @@ MIN_TARGET_CAPACITY_ERROR = {
 
 def _raises_launch_error(err_list):
     """Mirror when _launch_instances turns a CreateFleet response with no instances into an exception."""
-    real = [err for err in err_list if err != UNFULFILLED_OVERRIDE] or err_list
-    return any(err.get("ErrorCode") == "RequestLimitExceeded" for err in real) or len(real) == 1
+    return bool(err_list)
 
 
 def _expected_describe_attempts(timeout):
@@ -1425,9 +1423,11 @@ class TestFleetManager:
             # A single override is unaffected, whatever the entry says.
             ([UNFULFILLED_OVERRIDE], "UnfulfillableCapacity"),
             ([MIN_TARGET_CAPACITY_ERROR], "UnfulfillableCapacity"),
-            # Nothing to prefer: reporting stays as it was, so no cause is claimed.
-            ([UNFULFILLED_OVERRIDE] * 36, None),
-            ([UNSUPPORTED_ERROR, {"ErrorCode": "VcpuLimitExceeded", "ErrorMessage": "vCPU limit"}], None),
+            # Nothing to prefer: report the first entry rather than let a hardcoded code be recorded.
+            ([UNFULFILLED_OVERRIDE] * 36, "UnfulfillableCapacity"),
+            ([UNSUPPORTED_ERROR, {"ErrorCode": "VcpuLimitExceeded", "ErrorMessage": "vCPU limit"}], "Unsupported"),
+            # An empty error list is the only case left to the caller, which records insufficient capacity.
+            ([], None),
         ],
         ids=[
             "real_cause_first",
@@ -1437,6 +1437,7 @@ class TestFleetManager:
             "single_override_min_target_capacity",
             "only_unfulfilled_overrides",
             "two_real_causes",
+            "no_errors_reported",
         ],
     )
     def test_launch_instances_reports_the_cause_among_unfulfilled_overrides(

--- a/tests/slurm_plugin/test_instance_manager.py
+++ b/tests/slurm_plugin/test_instance_manager.py
@@ -4033,6 +4033,38 @@ class TestJobLevelScalingInstanceManager:
         assert_that(instances_launched).is_equal_to(expected_instances_launched)
         assert_that(instance_manager.failed_nodes).is_equal_to(expected_failed_nodes)
 
+    def test_launch_instances_reports_throttling_not_insufficient_capacity(self, mocker, instance_manager):
+        """A throttled CreateFleet must not be recorded as insufficient capacity, which would fail over.
+
+        CreateFleet reports one error per launch template override, so the throttling entry comes with a
+        generic entry for every other override.
+        """
+        mocker.patch("time.sleep")
+        mocker.patch(
+            "slurm_plugin.fleet_manager.create_fleet",
+            return_value={
+                "Instances": [],
+                "Errors": [{"ErrorCode": "RequestLimitExceeded", "ErrorMessage": "Request limit exceeded."}]
+                + [
+                    {
+                        "ErrorCode": "UnfulfillableCapacity",
+                        "ErrorMessage": "Failed to fulfill capacity. Please review errors in the response.",
+                    }
+                ]
+                * 29,
+                "ResponseMetadata": {"RequestId": "1234-abcde"},
+            },
+        )
+
+        instance_manager._launch_instances(
+            job=None,
+            nodes_to_launch={"queue2": {"fleet-ondemand": ["queue2-dy-fleet-ondemand-1"]}},
+            launch_batch_size=1,
+            scaling_strategy=ScalingStrategy.BEST_EFFORT,
+        )
+
+        assert_that(instance_manager.failed_nodes).is_equal_to({"RequestLimitExceeded": {"queue2-dy-fleet-ondemand-1"}})
+
     @pytest.mark.parametrize(
         "job_list, launch_batch_size, assign_node_batch_size, update_node_address, "
         "expected_single_nodes_no_oversubscribe, scaling_strategy",


### PR DESCRIPTION
### Description of changes

#### Customer impact

Since [#578](https://github.com/aws/aws-parallelcluster-node/pull/578), EC2 throttling during a compute node scale-up is never retried, and every launch failure is instead reported as insufficient capacity.

**Preconditions**: a compute resource with more than one instance type **or** more than one subnet, and a scale-up large enough to exhaust the `RunInstances` resource token bucket, which holds 1000 instances and refills at 2/s. See the number in ref link.

**On `best-effort` (the default)**: a single throttled call disables the **whole compute resource**, not only the batch that failed. Measured with `MaxCount 3000` and `sbatch -N 1500`: 500 nodes went DOWN and the remaining 1500 got `Temporarily disabling node due to insufficient capacity` — 2000 of 3000 nodes unusable for 600s (`insufficient_capacity_timeout`), with the job stuck `PENDING`.

**On `all-or-nothing`**: the compute resource cannot scale up reliably. Every round releases the instances already launched and starts over, so a large scale-up would fail.

#### Root cause

`CreateFleet` returns one entry in `Errors` per launch template override, so a compute resource with more than one instance type or more than one subnet gets an entry for **every** override that was not fulfilled, not only for the one that actually failed. Those extra entries all carry the same pair:

```
("UnfulfillableCapacity", "Failed to fulfill capacity. Please review errors in the response.")
```

which points at the real error rather than being one.

With 36 overrides a single failure therefore arrives as 36 entries, so the pre-existing `len(err_list) == 1` condition in `Ec2CreateFleetManager._launch_instances` never holds. No `LaunchInstancesError` is raised, and `InstanceManager._launch_ec2_instances` falls back to a hardcoded `InsufficientInstanceCapacity`. Three things follow:

* **Throttling is never retried.** `launch_ec2_instances` already implements the exponential backoff [the EC2 documentation recommends](https://docs.aws.amazon.com/ec2/latest/devguide/ec2-api-throttling.html#api-backoff), sized to wait for the bucket to refill a full `launch_max_batch_size` batch, but no exception ever reaches it. The batch is abandoned after a single attempt even though retrying is all it needed.
* **The compute resource is failed over for nothing.** `InsufficientInstanceCapacity` is in `SlurmNode.EC2_ICE_ERROR_CODES`, so `clustermgtd` treats the failure as a capacity shortage and disables the whole compute resource, not just the batch that failed.
* **The real cause is lost.** A `VcpuLimitExceeded`, an `Unsupported` instance type or an `UnauthorizedOperation` is all flattened into insufficient capacity.

#### The fix

1. **Drop the entries that only point at the real error** before deciding what to report, so the existing `len(err_list) == 1` condition works again for multi-override compute resources. The response is left untouched when those entries are all it carries, so the worst case is today's behaviour.
2. **Prefer throttling over any other remaining cause**, as a safety net for a response carrying more than one real error. Throttling is the only cause that resolves on its own, and reporting it as insufficient capacity costs a fail-over of the whole compute resource.

### Tests

* End-to-end test on real clusters of both best-effort and all-or-nothing chain, both worked as expected.

### References

* https://docs.aws.amazon.com/ec2/latest/devguide/ec2-api-throttling.html
* https://docs.aws.amazon.com/ec2/latest/devguide/ec2-api-throttling.html#throttling-limits-cost-based

### Checklist

- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

