### PR TITLE
Add python 3.14 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,45 +26,20 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.9 Tests
-          - Python 3.10 Tests
-          - Python 3.11 Tests
-          - Python 3.12 Tests
-          - Python 3.13 Tests
           - Python 3.14 Tests
-          - Python 3.12 Tests Coverage
+          - Python 3.14 Tests Coverage
           - Code Checks
         include:
-          - name: Python 3.9 Tests
-            python: 3.9
-            toxdir: cli
-            toxenv: py39-nocov
-          - name: Python 3.10 Tests
-            python: '3.10'
-            toxdir: cli
-            toxenv: py310-nocov
-          - name: Python 3.11 Tests
-            python: '3.11'
-            toxdir: cli
-            toxenv: py311-nocov
-          - name: Python 3.12 Tests
-            python: '3.12'
-            toxdir: cli
-            toxenv: py312-nocov
-          - name: Python 3.13 Tests
-            python: '3.13'
-            toxdir: cli
-            toxenv: py313-nocov
           - name: Python 3.14 Tests
             python: '3.14'
             toxdir: cli
             toxenv: py314-nocov
-          - name: Python 3.12 Tests Coverage
-            python: 3.12
+          - name: Python 3.14 Tests Coverage
+            python: '3.14'
             toxdir: cli
-            toxenv: py312-cov
+            toxenv: py314-cov
           - name: Code Checks
-            python: 3.12
+            python: '3.14'
             toxdir: cli
             toxenv: code-linters
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - Python 3.11 Tests
           - Python 3.12 Tests
           - Python 3.13 Tests
+          - Python 3.14 Tests
           - Python 3.12 Tests Coverage
           - Code Checks
         include:
@@ -54,6 +55,10 @@ jobs:
             python: '3.13'
             toxdir: cli
             toxenv: py313-nocov
+          - name: Python 3.14 Tests
+            python: '3.14'
+            toxdir: cli
+            toxenv: py314-nocov
           - name: Python 3.12 Tests Coverage
             python: 3.12
             toxdir: cli

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     license="Apache License 2.0",
     packages=find_packages("src", exclude=["tests"]),
     package_dir={"": "src"},
-    python_requires=">=3.9",
+    python_requires=">=3.14",
     install_requires=requires,
     entry_points=dict(console_scripts=console_scripts),
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312,313,314}-cov
+    py{314}-cov
     code-linters
 
 # Default testenv. Used to run tests on all python versions.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312,313}-cov
+    py{39,310,311,312,313,314}-cov
     code-linters
 
 # Default testenv. Used to run tests on all python versions.


### PR DESCRIPTION
### Description of changes
* Add python 3.14 to test matrix
* Set minimum python version of node package to python 3.14
  * Now that AL2 is deprecated, all node vir envs should have python 3.14
* the branch protection required checks need updating to the job names because tests on older python versions are no longer run

### Tests
* Unit tests


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
